### PR TITLE
Adds CNAME to docs_dir

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+docs.flybywiresim.com


### PR DESCRIPTION
Simple addition of CNAME to proper directory. Should keep workflow from deleting CNAME in gh-pages branch on builds.