### PR TITLE
docs(reported-issues): update with installer error and package separation information

### DIFF
--- a/docs/start/convert-liveries.md
+++ b/docs/start/convert-liveries.md
@@ -15,7 +15,7 @@ If your community directory has incompatible liveries you will be greeted by the
 
 ![installer conversion one](../assets/images/installer1.png)
 
-### ^^Step 2^^"
+### ^^Step 2^^
 
 Click `Convert` and the prompt will expand offering you the choice to select specific liveries or `Select All`. The image shows the difference between a non-selected and selected livery.
 
@@ -25,7 +25,7 @@ Click `Convert` and the prompt will expand offering you the choice to select spe
 
 Select all liveries or as many as you'd like and press `Confirm`. Your liveries will now be converted. The progress bar will display 100% when all selected liveries have been successfully converted.  
 
-![installer conversion two](../assets/images/installer4.png)
+![installer conversion four](../assets/images/installer4.png)
 
 You can confirm conversion by checking your community directory and checking that the new folder name is `livery_folder_name_a32nx`. You can now safely remove the older folders if you wish.
 

--- a/docs/start/reported-issues.md
+++ b/docs/start/reported-issues.md
@@ -38,6 +38,13 @@ FBW Installer - [Download Here](https://api.flybywiresim.com/installer) / *Sim V
         - Solution: Select the *FlyByWire Simulations A320neo (LEAP)* in the aircraft selector instead of the Asobo one. 
     - Invisible plane / Sounds not working / Installation issues
         - Workaround: Reinstall A32NX, delete any old version from your Community Folder. Ensure you are on Installer v1.1.4.
+    
+#### Installer Issues
+
+* Installer displays the following error: ![installer issue](https://media.discordapp.net/attachments/831654046405230652/832741603940237362/unknown.png)
+    - This is an issue with your community directory. Our installer detects a certain directory as your community directory even though it does not exist. 
+        - Workaround: You can create the specified directory, restart the installer and change the community directory in the installer settings
+
 * Installer Memory Leak
     - Commonly happens when our installer updates. Currently being investigated.
         - Workaround: Exit out of the FlyByWire Installer. Open `Task Manager` and find FlyByWire Installer. End Task.

--- a/docs/start/reported-issues.md
+++ b/docs/start/reported-issues.md
@@ -90,7 +90,7 @@ FBW Installer - [Download Here](https://api.flybywiresim.com/installer) / *Sim V
     * You have to set your keybinding to rudder axis right and left
 
 * Wing dips on landing (due to bad transition to direct law in flare, same with the default A320)
-    * Workaround use minimal aileron input on landing
+    * Workaround: use minimal aileron input on landing
 
 * Black screens / unable to start
     * Conflict with another mod/livery or incorrect installation of the A32NX mod

--- a/docs/start/reported-issues.md
+++ b/docs/start/reported-issues.md
@@ -10,8 +10,8 @@
 
     Make sure you do a full reinstall A32NX. Delete either of the folders below from your community folder: 
 
-    * A32NX
-    * flybywire-aircraft-a320-neo 
+    * A32NX (old folder name)
+    * flybywire-aircraft-a320-neo (new folder name) 
     
     Do this before reporting bugs. 
 
@@ -23,21 +23,24 @@ FBW Installer - [Download Here](https://api.flybywiresim.com/installer) / *Sim V
 
 ### ^^Latest Issues^^
 
-!!! warning "Liveries incompatible due to Hard Fork"
+!!! warning "Liveries incompatible due to package separation"
 
-    **Will only affect new versions of the development and experimental branches for now (a 0.6.0 stable release with the fork will come within the week).**
+    **Affects all versions of the A32NX (Stable, Development, and Experimental**
 
     Liveries made for the default A320neo will no longer function in the new FlyByWire package. Liveries will need to be converted by their respective authors. 
 
-    While this might represent an inconvenience for a short amount of time, we are sure that 3rd party content authors will be quick to provide you with updated liveries and programs. *If you wish to avoid this, we advise that you remain on your currently installed development/experimental versions for now.*
+    While this might represent an inconvenience for a short amount of time, we are sure that 3rd party content authors will be quick to provide you with updated liveries and programs.
 
-    **Workaround:** See our guide to [convert liveries](convert-liveries.md) 
+    **Convert Your Liveries:** 
+    
+    - See our guide to [convert liveries](convert-liveries.md)
+    - Visit Flightsim.to with updated liveries [here](https://flightsim.to/c/liveries/flybywire-a32nx/)  
 
-* Package separation or "fork" issues (*Development or Experimental*):
+* Package separation or "fork" issues (*All Versions*):
     -  Default aircraft showing
         - Solution: Select the *FlyByWire Simulations A320neo (LEAP)* in the aircraft selector instead of the Asobo one. 
     - Invisible plane / Sounds not working / Installation issues
-        - Workaround: Reinstall A32NX, delete any old version from your Community Folder. Ensure you are on Installer v1.1.4.
+        - Workaround: Reinstall A32NX, delete any old version from your Community Folder. Ensure you are on Installer v1.2.0 or above. 
     
 #### Installer Issues
 

--- a/docs/start/reported-issues.md
+++ b/docs/start/reported-issues.md
@@ -50,7 +50,7 @@ FBW Installer - [Download Here](https://api.flybywiresim.com/installer) / *Sim V
 
 ![installer issue](https://media.discordapp.net/attachments/831654046405230652/832741603940237362/unknown.png)
 
-* If there is an issue with your community directory our installer will display the error above. This means the installer detects a certain directory as your community directory even though it does not exist.
+* If there is an issue with your community directory our installer will display the error above. This means the installer detects a certain directory as your community directory even though it does not exist anymore.
     - Workaround: You can create the specified directory, restart the installer and change the community directory in the installer settings
     
 * Installer Memory Leak

--- a/docs/start/reported-issues.md
+++ b/docs/start/reported-issues.md
@@ -51,7 +51,7 @@ FBW Installer - [Download Here](https://api.flybywiresim.com/installer) / *Sim V
 ![installer issue](https://media.discordapp.net/attachments/831654046405230652/832741603940237362/unknown.png)
 
 * If there is an issue with your community directory our installer will display the error above. This means the installer detects a certain directory as your community directory even though it does not exist anymore.
-    - Workaround: You can create the specified directory, restart the installer and change the community directory in the installer settings
+    - Solution: You can create the specified directory, restart the installer and change the community directory in the installer settings
     
 * Installer Memory Leak
     - Commonly happens when our installer updates. Currently being investigated.

--- a/docs/start/reported-issues.md
+++ b/docs/start/reported-issues.md
@@ -42,16 +42,24 @@ FBW Installer - [Download Here](https://api.flybywiresim.com/installer) / *Sim V
     - Invisible plane / Sounds not working / Installation issues
         - Workaround: Reinstall A32NX, delete any old version from your Community Folder. Ensure you are on Installer v1.2.0 or above. 
     
+* Wipers don't function correctly on FSX Liveries
+
+***
+    
 #### Installer Issues
 
-* Installer displays the following error: ![installer issue](https://media.discordapp.net/attachments/831654046405230652/832741603940237362/unknown.png)
-    - This is an issue with your community directory. Our installer detects a certain directory as your community directory even though it does not exist. 
-        - Workaround: You can create the specified directory, restart the installer and change the community directory in the installer settings
+![installer issue](https://media.discordapp.net/attachments/831654046405230652/832741603940237362/unknown.png)
 
+* If there is an issue with your community directory our installer will display the error above. This means the installer detects a certain directory as your community directory even though it does not exist.
+    - Workaround: You can create the specified directory, restart the installer and change the community directory in the installer settings
+    
 * Installer Memory Leak
     - Commonly happens when our installer updates. Currently being investigated.
         - Workaround: Exit out of the FlyByWire Installer. Open `Task Manager` and find FlyByWire Installer. End Task.
-* Wipers don't function correctly on FSX Liveries
+    
+* Instructions to send us installer logs can be found [here](installation.md#flybywire-installer)
+
+***
 
 #### MSFS WU4 Known Issues
 


### PR DESCRIPTION
Changelog

- All references to only development / experimental are separated removed. 
- Added descriptors to old and new folder names in warning message
- Update liveries warning message with our guide and link to flightsim.to
- Sectioned #latest issues for cleaner format
- Added installer issue
- Referential anchor link to how to debug installer on installation.md
- Fix small typos discovered on converting liveries.md