### PR TITLE
docs(mcdu-guide): created MCDU keyboard guide

### DIFF
--- a/docs/start/mcdu-keyboard.md
+++ b/docs/start/mcdu-keyboard.md
@@ -1,0 +1,74 @@
+---
+
+## Overview
+
+The A32NX is now capable of accepting native keyboard inputs when utilizing the MCDU. Your inputs will be seen in the `scratchpad` area. 
+
+What this feature allows:
+
+- [x] Able to input text and numbers into the MCDU with keyboard
+- [x] Cockpit buttons are pressed with keyboard input
+- [x] Visual indicator that input is being accepted by MCDU
+- [x] Options for MCDU keyboard entry
+- [x] A timer can be set to automatically lose focus from the MCDU after a set period
+- [x] Normal Sim Keyboard Events (i.e. Camera) will be disabled while MCDU is in focus.
+
+---
+
+## Usage Guide
+
+!!! warning "Important"
+    Focusing the MCDU for keyboard input will stop all sim keybinds from working. Most notably, you will not be able to move the camera. Unfocusing should return control (i.e. camera)
+
+### Enable MCDU keyboard
+
+To begin using your keyboard with the MCDU you must first enable the function within `MCDU Options`. Follow the guide below:
+
+- Select `MCDU Options`
+- Select `Options`
+- Select `Realism`
+- Select `Keyboard Input`
+- Select `ALLOW INPUT`
+
+You will have to reload the flight for this change to take effect. (Similar to switching units from kg/lbs)
+
+Once you have completed the above steps simply click on the MCDU screen to put it into focus. The MCDU will display a visual indicator when input is ready to be accepted. The scratchpad should be highlighted, and the title will be highlighted in cyan as well.
+
+**[Insert Sample Image Here]**
+
+### Accepted Keys
+
+You may now use any combination of the following on your keyboard to use for entry:
+
+- Letters
+- Numbers
+- Dots
+- Slashes
+- ++backspace++ - should perform the same usage as `CLR` on the MCDU
+- ++shift+backspace++ - should function as holding down the `CLR` key on the MCDU for 2 seconds
+
+To use the `Line Select Keys` ++"-"++ (LSK) with your keyboard use the following keys:
+
+- `LSK1L - LSK6L` uses ++f1++ through ++f6++
+- `LSK1R - LSK6R` uses ++f7++ through ++f12++
+
+### How to set a timeout
+
+-- No details yet --
+
+---
+
+## Known Issues
+
+- ++esc++ and arrow keys are not captured
+- CLR held (>2s) 
+    * Use ++shift+backspace++ together instead of ++backspace++ 
+- Clicking on screen + using camera keybind keys will cause MCDU to move out of the view. Since the camera is locked it is not possible to click on the screen to unfocus the MCDU
+    * Use keyboard shortcutsb below to unfocus:
+        * ++ctrl+z++
+        * ++alt++
+- Keybindings are currently optimized for `ANSI/ISO-UK` keyboard layouts. `ISO-DE/ISO-NORD` users will notice that slash keys on their keyboards may not function as expected. This is an unfortunate limitation of the Coherent Webkit based JS Engine. 
+    * The following keys can be used as substitutes instead: 
+        * ++slash++ (Int backslash) 
+        * ++"#"++ (or ++"'/*"++)
+    * **Note:** that the numpad will work as expected regardless of keyboard layout.

--- a/docs/start/mcdu-keyboard.md
+++ b/docs/start/mcdu-keyboard.md
@@ -86,6 +86,6 @@ Sample Image:
         * ++alt++
 - Keybindings are currently optimized for `ANSI/ISO-UK` keyboard layouts. `ISO-DE/ISO-NORD` users will notice that slash keys on their keyboards may not function as expected. This is an unfortunate limitation of the Coherent Webkit based JS Engine. 
     * The following keys can be used as substitutes instead: 
-        * ++greater++ or ++less++ (Int backslash) 
-        * ++"#"++ (or ++"'/*"++)
+        * ++greater++ 
+        * ++"#"++ (or ++single-quote++)
     * **Note:** that the numpad will work as expected regardless of keyboard layout.

--- a/docs/start/mcdu-keyboard.md
+++ b/docs/start/mcdu-keyboard.md
@@ -86,6 +86,6 @@ Sample Image:
         * ++alt++
 - Keybindings are currently optimized for `ANSI/ISO-UK` keyboard layouts. `ISO-DE/ISO-NORD` users will notice that slash keys on their keyboards may not function as expected. This is an unfortunate limitation of the Coherent Webkit based JS Engine. 
     * The following keys can be used as substitutes instead: 
-        * ++slash++ (Int backslash) 
+        * ++greater++ or ++less++ (Int backslash) 
         * ++"#"++ (or ++"'/*"++)
     * **Note:** that the numpad will work as expected regardless of keyboard layout.

--- a/docs/start/mcdu-keyboard.md
+++ b/docs/start/mcdu-keyboard.md
@@ -64,7 +64,7 @@ To use the `Line Select Keys` ++"-"++ (LSK) with your keyboard use the following
 - CLR held (>2s) 
     * Use ++shift+backspace++ together instead of ++backspace++ 
 - Clicking on screen + using camera keybind keys will cause MCDU to move out of the view. Since the camera is locked it is not possible to click on the screen to unfocus the MCDU
-    * Use keyboard shortcutsb below to unfocus:
+    * Use keyboard shortcuts below to unfocus:
         * ++ctrl+z++
         * ++alt++
 - Keybindings are currently optimized for `ANSI/ISO-UK` keyboard layouts. `ISO-DE/ISO-NORD` users will notice that slash keys on their keyboards may not function as expected. This is an unfortunate limitation of the Coherent Webkit based JS Engine. 

--- a/docs/start/mcdu-keyboard.md
+++ b/docs/start/mcdu-keyboard.md
@@ -18,7 +18,7 @@ What this feature allows:
 ## Usage Guide
 
 !!! warning "Important"
-    Focusing the MCDU for keyboard input will stop all sim keybinds from working. Most notably, you will not be able to move the camera. Unfocusing should return control (i.e. camera)
+    Focusing the MCDU for keyboard input will stop all sim keybinds from working. Most notably, you will not be able to move the camera. Unfocusing should return control (i.e. camera).
 
 ### Enable MCDU keyboard
 
@@ -34,7 +34,9 @@ You will have to reload the flight for this change to take effect. (Similar to s
 
 Once you have completed the above steps simply click on the MCDU screen to put it into focus. The MCDU will display a visual indicator when input is ready to be accepted. The scratchpad should be highlighted, and the title will be highlighted in cyan as well.
 
-**[Insert Sample Image Here]**
+Visual indicator sample:
+
+![visual sample](https://media.discordapp.net/attachments/756972656422813807/856489441245397013/unknown.png?width=476&height=352)
 
 ### Accepted Keys
 
@@ -45,12 +47,18 @@ You may now use any combination of the following on your keyboard to use for ent
 - Dots
 - Slashes
 - ++backspace++ - should perform the same usage as `CLR` on the MCDU
-- ++shift+backspace++ - should function as holding down the `CLR` key on the MCDU for 2 seconds
+- ++shift+backspace++ - should function as `CLR HELD` keybind on the MCDU (clears the scratchpad)
 
 To use the `Line Select Keys` ++"-"++ (LSK) with your keyboard use the following keys:
 
 - `LSK1L - LSK6L` uses ++f1++ through ++f6++
 - `LSK1R - LSK6R` uses ++f7++ through ++f12++
+
+To unfocus the MCDU use one of the keys below:
+
+- ++ctrl+z++
+- ++alt++
+
 
 ### How to set a timeout
 

--- a/docs/start/mcdu-keyboard.md
+++ b/docs/start/mcdu-keyboard.md
@@ -36,7 +36,7 @@ Once you have completed the above steps simply click on the MCDU screen to put i
 
 Visual indicator sample:
 
-![visual sample](https://media.discordapp.net/attachments/756972656422813807/856489441245397013/unknown.png?width=476&height=352)
+![visual sample](https://media.discordapp.net/attachments/717548046522777604/857051288003674142/unknown.png)
 
 ### Accepted Keys
 
@@ -54,15 +54,24 @@ To use the `Line Select Keys` ++"-"++ (LSK) with your keyboard use the following
 - `LSK1L - LSK6L` uses ++f1++ through ++f6++
 - `LSK1R - LSK6R` uses ++f7++ through ++f12++
 
-To unfocus the MCDU use one of the keys below:
+To unfocus the MCDU use any of actions below:
 
-- ++ctrl+z++
-- ++alt++
+- Click on the MCDU Screen
+- Press ++ctrl+z++
+- Press ++alt++
 
 
 ### How to set a timeout
 
--- No details yet --
+The timeout feature will "automatically unfocus" the MCDU screen should you be unable to use any of the actions above to manually unfocus. 
+
+Return to the realism settings in `MCDU Options`. You should see `INPUT TIMEOUT`. You can specify how long the the timeout feature will wait before unfocusing the MCDU. 
+
+- Valid range is `5 - 120 seconds`
+
+Sample Image:
+
+![timeout screen](https://cdn.discordapp.com/attachments/717548046522777604/857051435471732736/unknown.png)
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ nav:
       - Porting Custom Camera Views: start/porting-custom-cameras.md
       - Reported Issues: start/reported-issues.md
       - Common Questions: start/faq.md
+      - MCDU Keyboard Input: start/mcdu-keyboard.md
       - Autopilot / Fly-By-Wire: start/autopilot-fbw.md
   - Airliner Flying Guide:
       - Overview: airliner-flying-guide/overview.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,8 @@ markdown_extensions:
   - pymdownx.mark # Formatting Extension
   - pymdownx.tilde # Formatting Extension
   - pymdownx.keys # Visual keyboard keys extension
+  - pymdownx.tasklist:
+      custom_checkbox: true
   - pymdownx.emoji: # Allows emoji style inline embeds for icons
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg


### PR DESCRIPTION
Documentation based on https://github.com/flybywiresim/a32nx/pull/4902

- included feat: tasklist pyndownx CSS

I had to add this inline with PR so I can get the styling otherwise it doesn't work (small change to mkdocs.yml).

### TODO
- [x] add a relevant sample image
- [x] add instructions on how to set a timeout
- [x] need a review after final implementation of the PR 


[Direct Link](https://docs-git-fork-valastiri-mcdukeyboard-flybywire.vercel.app/start/mcdu-keyboard/)