### PR TITLE
feat: add back to top button 

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -17,6 +17,9 @@
 .md-tabs {
   background: #3D6575
 }
+.md-top {
+  color: #ffffff;
+}
 
 /*Header Modifications*/
 .md-typeset h1 {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,7 @@ theme:
   features:
     - navigation.tabs
     - navigation.instant
+    - navigation.top
   favicon: assets/images/FBW-Tail.png
 
 # Plugins


### PR DESCRIPTION
Add a small QoL to return to top of page. Button only appears when scrolling up in a document and vanishes when scrolling down. 

- Made the default text (non-hover state) white so it's slightly easier to see. 

Default button: 
![image](https://user-images.githubusercontent.com/1619968/126018541-716787e1-57ba-408f-9628-d3da7df1859e.png)

Button with white text:
![image](https://user-images.githubusercontent.com/1619968/126018553-468138b3-f13c-48eb-9fca-d7e4cc46a339.png)

