### PR TITLE
docs: Change to CSS - color of H3 

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -28,13 +28,13 @@
 h1 {
   text-transform: uppercase;
 }
-h3 {
-  color: #00C2CB;
-}
 h2 {
   color: #00C2CB;
   text-transform: uppercase;
   padding-bottom: 0.5em;
+}
+h3 {
+  color: #00C2CB;
 }
 h4 {
   padding-top: 1em;

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -28,6 +28,9 @@
 h1 {
   text-transform: uppercase;
 }
+h3 {
+  color: #00C2CB;
+}
 h2 {
   color: #00C2CB;
   text-transform: uppercase;

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -34,7 +34,7 @@ h2 {
   padding-bottom: 0.5em;
 }
 h3 {
-  color: #00C2CB;
+  color: #A9CEEF;
 }
 h4 {
   padding-top: 1em;


### PR DESCRIPTION
Change to CSS - 3rd level headlines now also in "fbw green"  but not in capital letters like level 2 - improves readability