### PR TITLE
docs(mcdu-keyboard): add development only warning

### DIFF
--- a/docs/start/mcdu-keyboard.md
+++ b/docs/start/mcdu-keyboard.md
@@ -2,6 +2,9 @@
 
 ## Overview
 
+!!! warning "Please Note"
+    Available only on Development Version
+
 The A32NX is now capable of accepting native keyboard inputs when utilizing the MCDU. Your inputs will be seen in the `scratchpad` area.
 
 What this feature allows:

--- a/docs/start/mcdu-keyboard.md
+++ b/docs/start/mcdu-keyboard.md
@@ -15,7 +15,7 @@ What this feature allows:
 - [x] Options for MCDU keyboard entry
 - [x] A timer can be set to automatically lose focus from the MCDU after a set period
 - [x] Normal Sim Keyboard Events (i.e. Camera) will be disabled while MCDU is in focus
-- [x] Keyboard combo's to delete text in MCDU scratchpad
+- [x] Keyboard shortcuts to delete text in MCDU scratchpad
 
 ---
 


### PR DESCRIPTION
Resolves comment brought up by https://github.com/flybywiresim/a32nx/issues/5528#issuecomment-892616418

corrected a typo

