### PR TITLE
reported-issues: rename FCU section and move selected heading issue to fixed

### DIFF
--- a/docs/start/reported-issues.md
+++ b/docs/start/reported-issues.md
@@ -290,14 +290,14 @@ Crash to desktop (CTD) can either be a sim issue or a conflict with the A32NX. T
 
 ## Fixed Issues
 
-- Selected Heading may not work after using DIR feature or inputting a STAR. *Fixed [PR #5593](https://github.com/flybywiresim/a32nx/pull/5593)*
+- Selected Heading may not work after using DIR feature or inputting a STAR. *[Fixed PR #5593](https://github.com/flybywiresim/a32nx/pull/5593)*
     - Closed Issue: [#5479](https://github.com/flybywiresim/a32nx/issues/5479)
 
 * ND Terrain does not appear. *[Fixed #5470](https://github.com/flybywiresim/a32nx/pull/5470)*
   
 * Turning off right PFD also disables left one. *Fixed*
 
-* Vertical speed indicator not working. *Fixed [PR #5398](https://github.com/flybywiresim/a32nx/pull/5398)*
+* Vertical speed indicator not working. *[Fixed PR #5398](https://github.com/flybywiresim/a32nx/pull/5398)*
 
 * In development/experimental versions, the engine startup sound is bugged due to a fuel flow issue. This will be fixed when engine startup procedures will be implemented. *(fixed)*
 

--- a/docs/start/reported-issues.md
+++ b/docs/start/reported-issues.md
@@ -107,14 +107,6 @@ Using the "lbs" weight setting on the EFB may cause the following issues.
 
     This information is stated on [Installation Guide](installation.md).
 
-- Selected Heading may not work after using DIR feature or inputting a STAR. *Under Investigation.*
-    - Workaround: After performing an update of our addon through installer do the following steps:
-        - Load into your flight once. *Press Fly*
-        - Reload / restart the flight after you are in the flight deck.
-        - This usually helps restore functionality. 
-    - Open Issue: [#5479](https://github.com/flybywiresim/a32nx/issues/5479)
-    - Read Discussion: [Developer Comment](https://github.com/flybywiresim/a32nx/issues/5479#issuecomment-891032069)
-
 - Navigraph FMS Beta Users - If you are missing SID/STARs please delete and reinstall your navdata via the Navigraph Center and **restart** your simulator.
 
 - **Intermittent / Single time event only** - Printing METAR reports may cause a CTD. Please report this to us on our Discord.  
@@ -297,6 +289,9 @@ Crash to desktop (CTD) can either be a sim issue or a conflict with the A32NX. T
 ---
 
 ## Fixed Issues
+
+- Selected Heading may not work after using DIR feature or inputting a STAR. *Fixed [PR #5593](https://github.com/flybywiresim/a32nx/pull/5593)*
+    - Closed Issue: [#5479](https://github.com/flybywiresim/a32nx/issues/5479)
 
 * ND Terrain does not appear. *[Fixed #5470](https://github.com/flybywiresim/a32nx/pull/5470)*
   

--- a/docs/start/reported-issues.md
+++ b/docs/start/reported-issues.md
@@ -151,12 +151,7 @@ The effects of non-standard day pressure and temperature on altitude in MSFS is 
 - The built-in MSFS ATC will experience the same altitude issues - you may see FL390 on your altimeter, but the ATC will see you at a different altitude.
 
 
-#### FCU Heading Knob
-
-On the first load of the A32NX the heading knob push/pull may not work.
-
-- Solution:
-    - Restart once as for unknown reasons this event doesn't work the first time.
+#### Cockpit Interaction System
 
 !!! info "**Legacy** Cockpit Interaction System"
     If you want to use the old method of interacting with the cockpit before Sim Update 5:


### PR DESCRIPTION
- Changed #fcu-heading-knob section -> #cockpit-interaction-system.
- Reference PR fix to selected heading + moved text to fixed section.