### PR TITLE
fix: disable navigation.instant 

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,7 +59,8 @@ theme:
     scheme: slate
   features:
     - navigation.tabs
-    - navigation.instant
+    # Temporarily deactivated to provide support for Discord browser + anchor links
+    # - navigation.instant
     - navigation.top
   favicon: assets/images/FBW-Tail.png
 


### PR DESCRIPTION
fixes #160

Discord's native browser doesn't seem to support XHR requests designed by mkdocs-material. This fix temporarily removes instant loading configuration to allow mobile users on Discord to have working anchor links. 