### PR TITLE
reported-issues: updated fixed and latest issues

### DIFF
--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -38,20 +38,6 @@ FBW Installer - [Download Here](https://api.flybywiresim.com/installer){target=n
     - [**Typical Issues + Solutions**](../feature-guides/autopilot-fbw.md#typical-issues-and-how-to-solve-them)
     - [**Known Issues**](../feature-guides/autopilot-fbw.md#known-issues)
 
-#### Using the *"Pounds (lbs)"* on the EFB
-
-!!! tip ""
-    *Affected versions: Stable, Development*
-
-The lbs weight setting on the EFB may cause the following issues.
-
-- Simbrief integration - fuel and payload showing 0 after OFP request in AOC.
-- EFB unit conversions cause weights on ECAM and MCDU to show 0 when **lbs** is selected by the efb.
-- FOB displays 0 on ECAM.
-
-- **Workaround:** Set lbs through the MCDU only and reload the aircraft.
-- **Fix in Progress [PR #5344](https://github.com/flybywiresim/a32nx/pull/5344){target=new}**
-
 #### Fuel Consumption
 
 !!! tip ""
@@ -395,6 +381,9 @@ Crash to desktop (CTD) can either be a sim issue or a conflict with the A32NX. T
 ---
 
 ## Fixed Issues
+
+- Using the *"Pounds (lbs)"* on the EFB. *[Fixed PR #5344](https://github.com/flybywiresim/a32nx/pull/5344){target=new}*
+    - Closed Issues: [#5316](https://github.com/flybywiresim/a32nx/issues/5316), [#5321](https://github.com/flybywiresim/a32nx/issues/5321)
 
 - Installer v1.2.0 issues resolved in v2.0.
 

--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -392,7 +392,7 @@ Crash to desktop (CTD) can either be a sim issue or a conflict with the A32NX. T
 ## Fixed Issues
 
 !!! tip ""
-    Unless stated otherwise all fixed issues are first released on our development version.
+    Unless stated otherwise, all fixed issues are first released on our development version.
 
 - Using the *"Pounds (lbs)"* on the EFB. *[Fixed PR #5344](https://github.com/flybywiresim/a32nx/pull/5344){target=new}*
     - Closed Issues: [#5316](https://github.com/flybywiresim/a32nx/issues/5316), [#5321](https://github.com/flybywiresim/a32nx/issues/5321)

--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -121,6 +121,15 @@ Sometimes the sim will "*miss*" the trigger point being reached for outer tank f
 
     This information is stated on [Installation Guide](../installation.md).
 
+#### EFB Issues in External View
+
+!!! tip ""
+    *Affected versions: Stable, Development*
+
+When attempting to pop out the EFB (++"ralt"+"Left Click"++) and switching to external view the EFB may seem unresponsive.
+
+- Workaround: Make sure to click on the actual EFB screen (not the popped out window) before switching to external camera.  
+
 #### Printing METAR Reports May Cause a CTD
 
 !!! tip ""

--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -126,7 +126,7 @@ Sometimes the sim will "*miss*" the trigger point being reached for outer tank f
 !!! tip ""
     *Affected versions: Stable, Development*
 
-When attempting to pop out the EFB (++"ralt"+"Left Click"++) and switching to external view the EFB may seem unresponsive.
+Can't interact with EFB when to popped-out (++"ralt"+"Left Click"++) and switching to external view the EFB.
 
 - Workaround: Make sure to click on the actual EFB screen (not the popped out window) before switching to external camera.  
 

--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -391,6 +391,9 @@ Crash to desktop (CTD) can either be a sim issue or a conflict with the A32NX. T
 
 ## Fixed Issues
 
+!!! tip ""
+    Unless stated otherwise all fixed issues are first released on our development version.
+
 - Using the *"Pounds (lbs)"* on the EFB. *[Fixed PR #5344](https://github.com/flybywiresim/a32nx/pull/5344){target=new}*
     - Closed Issues: [#5316](https://github.com/flybywiresim/a32nx/issues/5316), [#5321](https://github.com/flybywiresim/a32nx/issues/5321)
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
- Moved EFB pounds issues to fixed as noted by https://github.com/flybywiresim/a32nx/pull/5344.
- Added the EFB issue when window is popped out and trying to interact in with it in external view. Added to SU5 issues.
### Location
<!-- Please provide the original URL of the page modified or directory location here -->
 `docs/fbw-a32nx/support/reported-issues.md`
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
