### PR TITLE
feat: add a32nx briefing to home page

### DIFF
--- a/overrides/assets/stylesheets/home.css
+++ b/overrides/assets/stylesheets/home.css
@@ -154,7 +154,7 @@
     .feature-margin {
         width: 100%;
         display: flex;
-        max-width: 70rem;
+        max-width: 80rem;
         margin-right: auto;
         margin-left: auto;
         padding: 0 .5rem;

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -50,6 +50,15 @@
         </a>
     </div>
     <div class="f-box">
+        <a href="pilots-corner/a32nx-briefing/">
+            <h2>
+                Pilot's Briefing
+            </h2>
+            <hr>
+            <p>Interactive A320neo systems overview for use with Microsoft Flight Simulator and the FlyByWire A32NX aircraft add-on.</p>
+        </a>
+    </div>
+    <div class="f-box">
         <a href="dev-corner/development-guide/">
         <h2>
             Contributing


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
Include feature box for the new A320neo briefing section. Adjusted style to ensure max-width doesn't squish the content. 
### Location
<!-- Please provide the original URL of the page modified or directory location here -->
- overrides/home.html
- overrides/assets/stylesheets/home.css
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri
