### PR TITLE
style: fix custom admonition `.block` breaking other admonitions

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -134,26 +134,26 @@ h4 {
 }
 
 /* for aligning image left or right with control over which text flows around */
- .md-typeset .admonition.block,
- .md-typeset details.block {
-     border-color: var(--md-default-bg-color);
-     background-color: var(--md-default-bg-color);
-     box-shadow: none;
-     font-size: .8rem;
-     margin: 0.5em 0;
-     padding: 0 .3rem;
- }
+.md-typeset .admonition.block,
+.md-typeset details.block {
+   border-color: var(--md-default-bg-color);
+   background-color: var(--md-default-bg-color);
+   box-shadow: none;
+   font-size: .8rem;
+   margin: 0.5em 0;
+   padding: 0 .3rem;
+}
 .md-typeset .block > .admonition-title,
-.md-typeset .admonition-title .block, .md-typeset summary {
-    background-color: var(--md-default-bg-color);
-    border-color: var(--md-default-bg-color);
-    border-left: .2rem solid #448aff;
-    font-weight: 700;
-    margin: 0 -.6rem 0 -.8rem;
-    padding: 0 0 0 0.4rem;
-    position: relative;
+.md-typeset .block > summary {
+  background-color: var(--md-default-bg-color);
+  border-color: var(--md-default-bg-color);
+  border-left: .2rem solid #448aff;
+  font-weight: 700;
+  margin: 0 -.6rem 0 -.8rem;
+  padding: 0 0 0 0.4rem;
+  position: relative;
 }
 .md-typeset .block > .admonition-title::before,
 .md-typeset .block > summary::before {
-    height: 0rem;
+  height: 0rem;
 }


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
Removed `.admonition-title` called twice. Seemed to be breaking the collapsible block admonitions and overriding their style. 
![broken sample](https://cdn.discordapp.com/attachments/847054770291736627/885854098950340608/unknown.png)
### Location
<!-- Please provide the original URL of the page modified or directory location here -->
- docs/stylesheets/extra.css
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
