### PR TITLE
refactor:Change to checkbox checkmark color in CSS

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -157,3 +157,8 @@ h4 {
 .md-typeset .block > summary::before {
     height: 0rem;
 }
+
+/* Tasklist */
+ .md-typeset [type=checkbox]:checked+.task-list-indicator:before {
+    background-color: #00C2CC;
+}

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -160,5 +160,5 @@ h4 {
 
 /* Tasklist */
  .md-typeset [type=checkbox]:checked+.task-list-indicator:before {
-    background-color: #00C2CC;
+    background-color: #00A2AB;
 }


### PR DESCRIPTION
## Summary
Changes the mkdocs-material checkbox checkmark color to the fbw color. 

### Location
extra.css

OLD:
![image](https://user-images.githubusercontent.com/16833201/132858679-7506dd92-bdbf-42e8-b40a-4e8151c10885.png)

NEW:
![unknown](https://user-images.githubusercontent.com/16833201/132859799-4c449b6d-1b63-4bdf-8929-bfa61e139414.png)
