### PR TITLE
fix: update installation.md with new simbrief airframe

### DIFF
--- a/docs/fbw-a32nx/installation.md
+++ b/docs/fbw-a32nx/installation.md
@@ -216,7 +216,7 @@ More info [A32NX Development Overview](../dev-corner/development-guide.md)
 
 ## SimBrief Airframe
 
-The FlyByWire Simulations SimBrief airframe with correct weights is available below. This is a new airframe based on our updated flight model, and will always be kept up-to-date thanks to Navigraph's new features.
+The FlyByWire Simulations simBrief airframe with correct weights is available below. This is a new airframe based on our updated flight model, and will always be kept up-to-date thanks to Navigraph's new features. 
 
 ✈ [SimBrief Airframe Link](https://www.simbrief.com/system/dispatch.php?sharefleet=337364_1631550522735){target=new} Credits: [@sidnov](https://github.com/sidnov){target=new}
 

--- a/docs/fbw-a32nx/installation.md
+++ b/docs/fbw-a32nx/installation.md
@@ -216,13 +216,9 @@ More info [A32NX Development Overview](../dev-corner/development-guide.md)
 
 ## SimBrief Airframe
 
-SimBrief now has a dedicated airframe for the A320neo.
+The FlyByWire Simulations SimBrief airframe with correct weights is available below. This is a new airframe based on our updated flight model, and will always be kept up-to-date thanks to Navigraph's new features.
 
-- Select `A20N - A320-251N` for your aircraft type.
-
-You may also select the FlyByWire Simulations SimBrief airframe with correct weights which is available below.
-
-✈ [SimBrief Airframe Link](https://www.simbrief.com/system/dispatch.php?sharefleet=eyJ0cyI6IjE2MjAyMTYxMzY2MjciLCJiYXNldHlwZSI6IkEyME4iLCJjb21tZW50cyI6IkZCVyBBMzJOWCIsImljYW8iOiJBMjBOIiwibmFtZSI6IkEzMjBORU8gRkJXIiwiZW5naW5lcyI6IkxFQVAtMUEyNiIsInJlZyI6IkQtQUZCVyIsImZpbiI6IiIsInNlbGNhbCI6IiIsImhleGNvZGUiOiIiLCJjYXQiOiJNIiwicGVyIjoiQyIsImVxdWlwIjoiU0RFMkUzRkdISUoxUldYWSIsInRyYW5zcG9uZGVyIjoiTEIxIiwicGJuIjoiQTFCMUMxRDFPMVMyIiwiZXh0cmFybWsiOiIiLCJtYXhwYXgiOiIxODAiLCJ3Z3R1bml0cyI6IktHUyIsIm9ldyI6IjQxMDA1IiwibXpmdyI6IjY0MzAwIiwibXRvdyI6Ijc5MDAwIiwibWx3IjoiNjc0MDAiLCJtYXhmdWVsIjoiMTkwNDUiLCJwYXh3Z3QiOiIxMDQiLCJkZWZhdWx0Y2kiOiIiLCJmdWVsZmFjdG9yIjoiUDAwIiwiY3J1aXNlb2Zmc2V0IjoiUDAwMDAifQ--){target=new} Credits: [@viniciusfont](https://github.com/viniciusfont){target=new}
+✈ [SimBrief Airframe Link](https://www.simbrief.com/system/dispatch.php?sharefleet=337364_1631550522735){target=new} Credits: [@sidnov](https://github.com/sidnov){target=new}
 
 Pilot ID can be found in the Optional Entries section of the Dispatch Options page.
 


### PR DESCRIPTION
Summary

Updates due to: https://github.com/flybywiresim/a32nx/pull/5547

Updates installation.md with the new simbrief airframe link and slight reword on the airframe section. 

Location
https://docs.flybywiresim.com/fbw-a32nx/installation/#simbrief-airframe

Updated page: 
![image](https://user-images.githubusercontent.com/87286435/133800868-d0162346-be38-405e-a1ea-fc4d771f7568.png)


Discord username (if different from GitHub): █▀█ █▄█ ▀█▀#2123
