### PR TITLE
feat: sticky navigaton

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ theme:
     scheme: slate
   features:
     - navigation.tabs
+    - navigation.tabs.sticky
     # Temporarily deactivated to provide support for Discord browser + anchor links
     # - navigation.instant
     - navigation.top


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary

Leaves main navigation at the top of the page as a QoL for the user. (User does not have to scroll to the top of the page to reach the main navigation.

Note: Back to Top button remains as another function to return to the top of page (useful for beginner guide and other sections of the website.

Before:
![no nav sample](https://user-images.githubusercontent.com/1619968/134784152-e693dc42-b89a-4409-81c0-bd5345cb0489.png)
After:
![sticky nav sample](https://user-images.githubusercontent.com/1619968/134784154-c23163ff-1337-4915-b563-643289cfc658.png)
### Location
<!-- Please provide the original URL of the page modified or directory location here -->
- config
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
