### PR TITLE
fix: missing generator notice in footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,7 +69,6 @@ extra_css:
 
 # Extra Functions / Customizations
 extra:
-  generator: false
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/flybywiresim


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->
fixes #236
## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
For some reason the generator notice was flagged as `false` since January. Removed in config to continue supporting mkdocs-material
### Location
<!-- Please provide the original URL of the page modified or directory location here -->
- config
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
