### PR TITLE
docs(throttle-cal): update keyboard/controller section

### DIFF
--- a/docs/fbw-a32nx/feature-guides/flyPad/throttle-calibration.md
+++ b/docs/fbw-a32nx/feature-guides/flyPad/throttle-calibration.md
@@ -312,11 +312,16 @@ To deactivate the reverse thrust the reverse levers must be released and the thr
 
 ![Keyboard F1-F4](../../assets/flypad/throttle-calibration/keyboard-f1-f4.png){loading=lazy}
 
-==Calibration not strictly required for keyboard - read below!==
+==No calibration required for keyboard - read below!==
 
 The keyboard does not have any axis which could be used for controlling the throttles. It uses various keys to increase and decrease the throttles or to set the throttles to predetermined positions.
 
-!!! warning "Check you have set a large enough range/deadband on the EFB to ensure compatibility. For a basic description - [Read Here](#step-2-flypad-throttle-calibration-page)"
+!!! warning "Please Note the Following"
+    If you have trouble hitting the detents with the keyboard you might have an old configuration which has detents defined that are smaller than the 0.05 button stroke step size. To fix this you either: 
+
+    - Manually remove the old ThrottleConfiguration.ini in our work folder. 
+        - See [Work Folder Section](#work-folder) for details.
+    - Fix the problematic detent's deadband size to be large than 0.05.
 
 The default Microsoft Flight Simulator mappings is:
 
@@ -352,13 +357,11 @@ With the default throttle configuration built into the A32NX this results in the
 
 ![Xbox-Controller](../../assets/flypad/throttle-calibration/xbox-controller.png "Xbox-Controller"){loading=lazy}
 
-==Calibration not strictly required for the Xbox-Controller - read below!==
+==No calibration required for the Xbox controller - read below!==
 
 The Xbox-Controller (or any other game controller) is very similar to controlling the throttle with the keyboard. It uses buttons to increase and decrease the throttles.
 
 Therefore read the [Keyboard](#keyboard) section section but instead of ++f2++ or ++f3++ use the buttons mapped to throttle increase and decrease on your controller.
-
-!!! warning "Check you have set a large enough range/deadband on the EFB to ensure compatibility. For a basic description - [Read Here](#step-2-flypad-throttle-calibration-page)"
 
 For the Xbox-Controller the default buttons are:
 

--- a/docs/fbw-a32nx/feature-guides/flyPad/throttle-calibration.md
+++ b/docs/fbw-a32nx/feature-guides/flyPad/throttle-calibration.md
@@ -37,12 +37,12 @@ This quickstart lists all necessary steps for calibrating your throttle. Please 
 
 ### Step 2: flyPad Throttle Calibration Page
 
-- Set `Reverse On Axis` and `Independent Axis` as required for your controller (for the TCA both are ON)
-- Move your controller all the way back (with reverser to `Reverse Full`, without reverser to `Idle`)
-- Click in the middle on the detent's name to select the detent you want to calibrate
+- Set `Reverse On Axis` and `Independent Axis` as required for your controller (for the TCA both are ON).
+- Move your controller all the way back (with reverser to `Reverse Full`, without reverser to `Idle`).
+- Click in the middle on the detent's name to select the detent you want to calibrate.
 - Move your controller's throttle to the corresponding detent and click on `Set From Throttle` to set the current throttle position as the value for this detent.
 - Repeat this for all positions/detents.
-- Click `Save & Apply`
+- Click `Save & Apply`.
 - Test your settings.
 
 [Detailed step-by-step Guide](#step-2-calibrating-the-tca-throttle-detents-in-the-flybywire-flypad-efb)
@@ -312,9 +312,11 @@ To deactivate the reverse thrust the reverse levers must be released and the thr
 
 ![Keyboard F1-F4](../../assets/flypad/throttle-calibration/keyboard-f1-f4.png){loading=lazy}
 
-==No calibration required for keyboard - read below!==
+==Calibration not strictly required for keyboard - read below!==
 
 The keyboard does not have any axis which could be used for controlling the throttles. It uses various keys to increase and decrease the throttles or to set the throttles to predetermined positions.
+
+!!! warning "Check you have set a large enough range/deadband on the EFB to ensure compatibility. For a basic description - [Read Here](#step-2-flypad-throttle-calibration-page)"
 
 The default Microsoft Flight Simulator mappings is:
 
@@ -342,7 +344,7 @@ With the default throttle configuration built into the A32NX this results in the
 - 10 times ++ctrl+f3++ (increase) for `MCT/FLX` detent (0.5)
 - 10 times ++ctrl+f3++ (increase) for `TO/GA` detent (1.0)
 
-**Congratulations! No need to calibrate your keyboard throttle!**
+**Congratulations! You can use the keyboard for throttle control!**
 
 ---
 
@@ -350,11 +352,13 @@ With the default throttle configuration built into the A32NX this results in the
 
 ![Xbox-Controller](../../assets/flypad/throttle-calibration/xbox-controller.png "Xbox-Controller"){loading=lazy}
 
-==No calibration required for the Xbox-Controller - read below!==
+==Calibration not strictly required for the Xbox-Controller - read below!==
 
 The Xbox-Controller (or any other game controller) is very similar to controlling the throttle with the keyboard. It uses buttons to increase and decrease the throttles.
 
 Therefore read the [Keyboard](#keyboard) section section but instead of ++f2++ or ++f3++ use the buttons mapped to throttle increase and decrease on your controller.
+
+!!! warning "Check you have set a large enough range/deadband on the EFB to ensure compatibility. For a basic description - [Read Here](#step-2-flypad-throttle-calibration-page)"
 
 For the Xbox-Controller the default buttons are:
 
@@ -368,7 +372,7 @@ Of course you can map different buttons in MSFS. Also other controllers might ha
 
     We recommend to also map a button to set the throttles to `IDLE` during landing. This can be done by mapping the `THROTTLE CUT` function to a controller button.
 
-**Congratulations! No need to calibrate your Xbox controller!**
+**Congratulations! You can use your Xbox controller for throttle control!**
 
 ---
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
Due to possible confusion removed copy that states calibration isn't required for keyboard and controller. Added a warning about ranges to help with compatibility
### Location
<!-- Please provide the original URL of the page modified or directory location here -->
- docs/fbw-a32nx/feature-guides/flyPad/throttle-calibration.md
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
