### PR TITLE
docs(PFD Briefing): corrections and updates

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
@@ -112,10 +112,17 @@ This is a blue dot on the right side of the speedtape. It displays the speed at 
 
 This is a magenta triangle on the right side of the speedtape. It displays the V~2~ speed which has been set in the TAKE OFF PERF page of the MCDU. V~2~ is the minimum speed that needs to be maintained in the event of an engine failure after V~1~ up to acceleration altitude.
 
-V~2~+10 provides the best climb performance (before acceleration altitude + during NAPs).
+V~2~+10 provides better climb performance (before acceleration altitude and during noise abatement program departures).
 
 !!! info "Engine Loss V~2~ Speeds"
-    After takeoff **V~2~+10** is the targeted speed you should reach and maintain by the time you attain a height of 35 FT after takeoff with an engine failure until reaching the acceleration altitude. Pilots should not degrade to V~2~ after an engine failure but rather maintain the speed at point of engine loss where V~2~ is the minimum allowable speed.
+    After takeoff **V~2~+10** is the targeted speed you should reach and maintain by the time you attain a height of 35 FT after takeoff until reaching the acceleration altitude. 
+
+    When an engine failure occurs (shortly before or after takeoff), V~2~ is the minimum allowable speed. 
+
+    - In a situation where engine is lost before reaching V~2~ the targeted speed is V~2~. 
+    - If after takeoff the aircraft speed is higher than V~2~ then pilots should maintain the higher speed but not exceed V~2~+15.
+
+    Essentially pilots should not decelerate to V~2~ after an engine failure but rather maintain the speed at point of engine loss. 
 
 
 

--- a/docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
@@ -49,13 +49,13 @@ This is displayed in green and is shown if the Mach number reaches above 0.5. It
 
 This is displayed in green and shows the speed at which overspeed protections become active.
 
-This speed is V~MO~ (maximum operating speed) + 6 knots or MMO (maximum Mach speed) + 0.01
+This speed is V~MO~ (maximum operating speed) + 6 knots or ~MMO~ (maximum Mach speed) + 0.01
 
 ### ECON Speed Range
 
 This appears in descent mode with ECON/AUTO SPD mode active. Two half triangles will represent the upper and lower limits calculated by the FMGC. This replaces the target speed symbol.
 
-The upper speed is equal to the target speed + 20 knots, limited to V~MAX~, V~MO~ - 3 knots or MMO - 0.006, whichever is the lowest.
+The upper speed is equal to the target speed + 20 knots, limited to V~MAX~, V~MO~ - 3 knots or ~MMO~ - 0.006, whichever is the lowest.
 
 If a speed constraint or limit applies then the upper margin is limited to ECON SPD + 5kts.
 
@@ -80,7 +80,7 @@ The top of a red strip along the speed scale indicates this speed. It represents
 
 The lower end of a red and black strip along the speed scale represents this speed. It is the lowest of:
 
-- V~MO~ or the corresponding to MMO
+- V~MO~ or the corresponding to ~MMO~
 - V~LE~
 - V~FE~
 

--- a/docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
@@ -115,14 +115,12 @@ This is a magenta triangle on the right side of the speedtape. It displays the V
 V~2~+10 provides better climb performance (before acceleration altitude and during noise abatement program departures).
 
 !!! info "Engine Loss V~2~ Speeds"
-    After takeoff **V~2~+10** is the targeted speed you should reach and maintain by the time you attain a height of 35 FT after takeoff until reaching the acceleration altitude. 
+    After takeoff **V~2~+10** is the targeted speed you should reach and maintain by the time you attain a height of 35 FT after takeoff until reaching the acceleration altitude.  
 
-    When an engine failure occurs (shortly before or after takeoff), V~2~ is the minimum allowable speed. 
+    When an engine failure occurs (shortly before or after takeoff), V~2~ is the minimum allowable speed. Pilots should aim to meet the criteria below at point of engine loss:
 
-    - In a situation where engine is lost before reaching V~2~ the targeted speed is V~2~. 
-    - If after takeoff the aircraft speed is higher than V~2~ then pilots should maintain the higher speed but not exceed V~2~+15.
-
-    Essentially pilots should not decelerate to V~2~ after an engine failure but rather maintain the speed at point of engine loss. 
+    - In a situation where engine is lost before reaching V~2~ the targeted speed is V~2~.
+    - If the aircraft speed is higher than V~2~ then pilots should maintain the higher speed but not exceed V~2~+15.
 
 
 

--- a/docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
@@ -110,7 +110,7 @@ This is a blue dot on the right side of the speedtape. It displays the speed at 
 
 ### V~2~
 
-This is a magenta triangle on the right side of the speedtape. It displays the V~2~ speed which has been set in the TAKE OFF PERF page of the MCDU. V~2~ is the minimum speed that needs to be maintained in the even to of an engine failure after V~1~ up to acceleration altitude.
+This is a magenta triangle on the right side of the speedtape. It displays the V~2~ speed which has been set in the TAKE OFF PERF page of the MCDU. V~2~ is the minimum speed that needs to be maintained in the event of an engine failure after V~1~ up to acceleration altitude.
 
 V~2~+10 provides the best climb performance (before acceleration altitude + during NAPs).
 

--- a/docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
@@ -49,7 +49,7 @@ This is displayed in green and is shown if the Mach number reaches above 0.5. It
 
 This is displayed in green and shows the speed at which overspeed protections become active.
 
-This speed is V~MO~~ (maximum operating speed) + 6 knots or MMO (maximum Mach speed) + 0.01
+This speed is V~MO~ (maximum operating speed) + 6 knots or MMO (maximum Mach speed) + 0.01
 
 ### ECON Speed Range
 

--- a/docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
@@ -49,13 +49,13 @@ This is displayed in green and is shown if the Mach number reaches above 0.5. It
 
 This is displayed in green and shows the speed at which overspeed protections become active.
 
-This speed is V~MO~ (maximum operating speed) + 6 knots or ~MMO~ (maximum Mach speed) + 0.01
+This speed is V~MO~ (maximum operating speed) + 6 knots or M~MO~ (maximum Mach speed) + 0.01
 
 ### ECON Speed Range
 
 This appears in descent mode with ECON/AUTO SPD mode active. Two half triangles will represent the upper and lower limits calculated by the FMGC. This replaces the target speed symbol.
 
-The upper speed is equal to the target speed + 20 knots, limited to V~MAX~, V~MO~ - 3 knots or ~MMO~ - 0.006, whichever is the lowest.
+The upper speed is equal to the target speed + 20 knots, limited to V~MAX~, V~MO~ - 3 knots or M~MO~ - 0.006, whichever is the lowest.
 
 If a speed constraint or limit applies then the upper margin is limited to ECON SPD + 5kts.
 
@@ -80,7 +80,7 @@ The top of a red strip along the speed scale indicates this speed. It represents
 
 The lower end of a red and black strip along the speed scale represents this speed. It is the lowest of:
 
-- V~MO~ or the corresponding to ~MMO~
+- V~MO~ or the corresponding to M~MO~
 - V~LE~
 - V~FE~
 

--- a/docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
@@ -90,7 +90,7 @@ The top of the red and black strip along the speed scale represents this speed. 
 
 ### Decision Speed (V~1~)
 
-It is sown as blue numeral one (1) at a speed that the pilot inserted manually in the takeoff performance page in the MCDU. When it is off the scale, the upper part of the scale shows the speed in numbers. It disappears after liftoff.
+It is shown as blue numeral one (1) at a speed that the pilot inserted manually in the takeoff performance page in the MCDU. When it is off the scale, the upper part of the scale shows the speed in numbers. It disappears after liftoff.
 
 ### Minimum Flap Retraction Speed (F)
 

--- a/docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
@@ -122,8 +122,6 @@ V~2~+10 provides better climb performance (before acceleration altitude and duri
     - In a situation where engine is lost before reaching V~2~ the targeted speed is V~2~.
     - If the aircraft speed is higher than V~2~ then pilots should maintain the higher speed but not exceed V~2~+15.
 
-
-
 ---
 
 [Back to Interactive PFD](index.md){ .md-button }

--- a/docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
@@ -110,7 +110,14 @@ This is a blue dot on the right side of the speedtape. It displays the speed at 
 
 ### V~2~
 
-This is a magenta triangle on the right side of the speedtape. It displays the V~2~ speed which has been set in the TAKE OFF PERF page of the MCDU. This is the speed the aircraft needs to maintain at a minimum up to the acceleration altitude.
+This is a magenta triangle on the right side of the speedtape. It displays the V~2~ speed which has been set in the TAKE OFF PERF page of the MCDU. V~2~ is the minimum speed that needs to be maintained in the even to of an engine failure after V~1~ up to acceleration altitude.
+
+V~2~+10 provides the best climb performance (before acceleration altitude + during NAPs).
+
+!!! info "Engine Loss V~2~ Speeds"
+    After takeoff **V~2~+10** is the targeted speed you should reach and maintain by the time you attain a height of 35 FT after takeoff with an engine failure until reaching the acceleration altitude. Pilots should not degrade to V~2~ after an engine failure but rather maintain the speed at point of engine loss where V~2~ is the minimum allowable speed.
+
+
 
 ---
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

fixes #251

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->

Currently only targeting review comments made in https://github.com/flybywiresim/docs/pull/177 past the merge date. 

A rather large change to the V2 speed description to provide more clarity and detail to engine out ops and general definition of V2.

![image](https://user-images.githubusercontent.com/1619968/136711459-5d0cdb00-af29-41d7-b8e1-7b4b990ec10d.png)

### Location
<!-- Please provide the original URL of the page modified or directory location here -->

 docs/pilots-corner/a32nx-briefing/pfd/speedtape.md
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
 Valstiri#8902
