### PR TITLE
fix(airliner flying guide): UTC not GMT

### DIFF
--- a/docs/pilots-corner/airliner-flying-guide/weather.md
+++ b/docs/pilots-corner/airliner-flying-guide/weather.md
@@ -18,7 +18,7 @@ These are weather reports created by an on-airport weather station and tend to b
 
     === "DATE/TIME"
 
-        Then follows the Date and Time in the format of DDTTTTZ. So, the date in two digits, followed by the Zulu (GMT) time in four digits. The time is always referenced in Zulu no matter what time zone you are in. For example: 032050Z = The 3rd day of that month, 20:50Z or 8:50PM GMT time. If this is followed with AUTO, it means that the weather station is publishing the METARs without any intervention or checks by a human controller.
+        Then follows the Date and Time in the format of DDTTTTZ. So, the date in two digits, followed by the Zulu (UTC) time in four digits. The time is always referenced in Zulu no matter what time zone you are in. For example: 032050Z = The 3rd day of that month, 20:50Z or 8:50PM UTC time. If this is followed with AUTO, it means that the weather station is publishing the METARs without any intervention or checks by a human controller.
 
     === "WIND"
 


### PR DESCRIPTION

English speakers often use GMT as a synonym for Coordinated Universal Time (UTC): in modern usage, this is incorrect – GMT is now a time zone, not a time reference. For navigation, it is considered equivalent to UT1 (the modern form of mean solar time at 0° longitude); but this meaning can differ from UTC by up to 0.9 s. The term GMT should not thus be used for purposes that require precision.
-- https://en.wikipedia.org/wiki/Greenwich_Mean_Time