### PR TITLE
docs(beg-guide): include pitch trim advice

### DIFF
--- a/docs/pilots-corner/beginner-guide/engine-start-taxi.md
+++ b/docs/pilots-corner/beginner-guide/engine-start-taxi.md
@@ -206,7 +206,7 @@ Complete the after start flow:
 Perform the AFTER START checklist.
 
 !!! info "Setting Pitch Trim Advice"
-    While setting the pitch trim is standard operating procedure, a precisely set trim value on the trim wheel is not critical. As long as your Center of Gravity (CG) is within CG limits, any trim setting within the green band will provide for a safe takeoff. Appropriate trim settings can be found at the bottom of our [checklist](../../assets/FBW_A32NX_CHECKLIST.pdf).
+    While setting the pitch trim is standard operating procedure, a precisely set trim value on the trim wheel is not critical. As long as your center of gravity (CG) is within CG limits, any trim setting within the green band will provide for a safe takeoff. Appropriate trim settings can be found at the bottom of our [checklist](../../assets/FBW_A32NX_CHECKLIST.pdf).
 
     There is a rotation law in the NEO that gives you a consistent rotation rate for any given stick input regardless of other conditions. Upon liftoff, the autotrim becomes active.
 

--- a/docs/pilots-corner/beginner-guide/engine-start-taxi.md
+++ b/docs/pilots-corner/beginner-guide/engine-start-taxi.md
@@ -201,9 +201,14 @@ Complete the after start flow:
 - PITCH TRIM - `Check`
 - RUDDER TRIM - `Zero`
 
+![after start checklist](../assets/beginner-guide/taxi/afterstart.png){loading=lazy}
+
 Perform the AFTER START checklist.
 
-![after start checklist](../assets/beginner-guide/taxi/afterstart.png){loading=lazy}
+!!! info "Pitch Trim Advice"
+    While setting the pitch trim is standard operating procedure, a precisely set trim value on the trim wheel is not critical. As long as your Center of Gravity (CG) is within CG limits, any trim setting within the green band will provide for a safe takeoff. Appropriate trim settings can be found at the bottom of our [checklist](../../assets/FBW_A32NX_CHECKLIST.pdf).
+
+    There is a rotation law in the NEO that gives you a consistent rotation rate for any given stick input regardless of other conditions. Upon liftoff, the autotrim becomes active.
 
 ---
 

--- a/docs/pilots-corner/beginner-guide/engine-start-taxi.md
+++ b/docs/pilots-corner/beginner-guide/engine-start-taxi.md
@@ -211,10 +211,17 @@ Perform the AFTER START checklist.
     There is a rotation law in the NEO that gives you a consistent rotation rate for any given stick input regardless of other conditions. Upon liftoff, the autotrim becomes active.
 
     ---
+    
+    !!! block ""
+        ![Throttle quad](../assets/beginner-guide/mcdu/Thrust-lever-elev-trim.png){loading=lazy width=50% align=left}
 
-    For this flight take a look at your throttle quadrant and look for the CG markings on next to the trim wheel. We need to set a nose down trim of about 0.8.
+        For this flight take a look at your throttle quadrant and look for the trim markings closest to the throttle levers. Based on the [Preparing the MCDU](preparing-mcdu.md) section we have a general estimate of 30.5 for our CG. 
 
-    ![Throttle quad](../assets/beginner-guide/mcdu/Thrust-lever-elev-trim.png){loading=lazy}
+        The FlyByWire checklist's trim section at the bottom indicates we would need to set a nose up trim of about 0.2.
+
+    !!! warning "The CG scale available in the Asobo's model of the flight deck not entirely accurate for the A320neo."
+
+    
 
 ---
 

--- a/docs/pilots-corner/beginner-guide/engine-start-taxi.md
+++ b/docs/pilots-corner/beginner-guide/engine-start-taxi.md
@@ -206,7 +206,7 @@ Complete the after start flow:
 Perform the AFTER START checklist.
 
 !!! info "Setting Pitch Trim Advice"
-    While setting the pitch trim is standard operating procedure, a precisely set trim value on the trim wheel is not critical. As long as your center of gravity (CG) is within CG limits, any trim setting within the green band will provide for a safe takeoff. Appropriate trim settings can be found at the bottom of our [checklist](../../assets/FBW_A32NX_CHECKLIST.pdf).
+    While setting the pitch trim is standard operating procedure, a precisely set trim value on the trim wheel is not critical. As long as your center of gravity (CG) is within CG limits, any trim setting within the green band will provide for a safe takeoff in the A320neo. Appropriate trim settings can be found at the bottom of our [checklist](../../assets/FBW_A32NX_CHECKLIST.pdf).
 
     There is a rotation law in the NEO that gives you a consistent rotation rate for any given stick input regardless of other conditions. Upon liftoff, the autotrim becomes active.
 

--- a/docs/pilots-corner/beginner-guide/engine-start-taxi.md
+++ b/docs/pilots-corner/beginner-guide/engine-start-taxi.md
@@ -205,10 +205,16 @@ Complete the after start flow:
 
 Perform the AFTER START checklist.
 
-!!! info "Pitch Trim Advice"
+!!! info "Setting Pitch Trim Advice"
     While setting the pitch trim is standard operating procedure, a precisely set trim value on the trim wheel is not critical. As long as your Center of Gravity (CG) is within CG limits, any trim setting within the green band will provide for a safe takeoff. Appropriate trim settings can be found at the bottom of our [checklist](../../assets/FBW_A32NX_CHECKLIST.pdf).
 
     There is a rotation law in the NEO that gives you a consistent rotation rate for any given stick input regardless of other conditions. Upon liftoff, the autotrim becomes active.
+
+    ---
+
+    For this flight take a look at your throttle quadrant and look for the CG markings on next to the trim wheel. We need to set a nose down trim of about 0.8.
+
+    ![Throttle quad](../assets/beginner-guide/mcdu/Thrust-lever-elev-trim.png){loading=lazy}
 
 ---
 

--- a/docs/pilots-corner/beginner-guide/preparing-mcdu.md
+++ b/docs/pilots-corner/beginner-guide/preparing-mcdu.md
@@ -357,14 +357,31 @@ For this flight we will be taking off with a `1+F` flaps configuration.
 
 * Using the keypad type in `1` and press LSK3R
 
-!!! info ""
+!!! info "THS Field MCDU"
     **Entry of the THS field is subject to airline SOP and may not be required.**
 
-The THS field is where we enter the stabilizer trim for takeoff based on the aircraft's CG. The FUEL PRED page provides an auto-calculated CG of 30.5.
+    ---
 
-Take a look at your throttle quadrant and look for the CG markings on next to the trim wheel. We need to set a nose down trim of about 0.8.
+    The THS field is where we enter the stabilizer trim for takeoff based on the aircraft's takeoff CG (TOCG). Entiering this value in the MCDU will trigger the ^^F/CTL PITCH TRIM/MCDU/CG DISAGREE^^ ECAM caution, if appropriate.
 
-![Throttle quad](../assets/beginner-guide/mcdu/Thrust-lever-elev-trim.png){ loading=lazy  }
+    If you have already entered your flaps configuration in the step above, applicable entires are formatted `/X.XDN` or `/X.XUP` representing a trim value and nose down or up respectively.
+
+    Examples:
+
+    - Nose down trim of 0.4 can be inputted as `/0.4DN`
+    - Nose up trim of 1.5 can be inputted as `/1.5UP`
+
+    For our flight today we need to set a nose down trim of 0.8, input `/0.8DN` into the scratchpad and press LSK3R.
+
+    See the [After Engine Start](engine-start-taxi.md#after-engine-start) section to physically set your trim.
+
+    {--
+
+    **For the purposes of simulation** we can use the auto-calculated GWCG on the FUEL PRED page to input a value into the THS field. Since this is not accurate for real world use, you can infer the TOCG and pitch trim by referring to this value right before takeoff to confirm the pitch trim configuration for your flight. 
+
+    We plan on adding a better visual representation of the TOCG at later time.
+
+    --}
 
 * Using the keypad type in `/DN0.8` and press LSK3R
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
Based on a request to provide additional information when setting pitch trim in the A32NX. See the discord #docs channel.

Will possibly consolidate this and add it to #217 when the relevant A32NX PR is ready. Would provide a general overview in #217 in case people want to only review the relevant information when setting up w&b.

### Location
- docs/pilots-corner/beginner-guide/engine-start-taxi.md
- docs/pilots-corner/beginner-guide/preparing-mcdu.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
 Valastiri#8902
