### PR TITLE
docs: discourage painters from using panel.cfg

### DIFF
--- a/docs/dev-corner/texture-changes.md
+++ b/docs/dev-corner/texture-changes.md
@@ -15,3 +15,7 @@ If you are the author of an affected livery please reference the following:
 
 !!! warning ""
     For further context you can review [pull request #5490](https://github.com/flybywiresim/a32nx/pull/5490){target=new} on our GitHub if necessary.
+
+## Registration Decal
+
+The A32NX has a toggle option in the EFB to disable the dynamic registration number decal normally located near the rear of the aircraft. The intention of this option is to remove the need for livery designers to include a `panel.cfg` file in their livery packages. Overriding `panel.cfg` creates future conflicts with A32NX development. Please avoid using `panel.cfg` to disable this decal, and instead advise users to disable the dynamic decal in the EFB settings.

--- a/docs/dev-corner/texture-changes.md
+++ b/docs/dev-corner/texture-changes.md
@@ -18,4 +18,9 @@ If you are the author of an affected livery please reference the following:
 
 ## Registration Decal
 
-The A32NX has a toggle option in the EFB to disable the dynamic registration number decal normally located near the rear of the aircraft. The intention of this option is to remove the need for livery designers to include a `panel.cfg` file in their livery packages. Overriding `panel.cfg` creates future conflicts with A32NX development. Please avoid using `panel.cfg` to disable this decal, and instead advise users to disable the dynamic decal in the EFB settings.
+The A32NX has a [toggle option in the EFB to disable the dynamic registration number decal](../../fbw-a32nx/feature-guides/flyPad/settings/#sim-options) normally located near the rear of the aircraft. The intention of this option is to remove the need for livery designers to include a `panel.cfg` file in their livery packages.
+
+!!! warning "Avoid Using panel.cfg"
+    Overriding `panel.cfg` creates future conflicts with A32NX development.
+
+    Please avoid using `panel.cfg` to disable the registration number decal, and instead advise users to [disable the dynamic decal in the EFB settings](../../fbw-a32nx/feature-guides/flyPad/settings/#sim-options).


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
https://github.com/flybywiresim/a32nx/pull/6099 introduced an option to disable the dynamic registration decal number, in the hopes that livery designers will stop trying to override `panel.cfg`, which causes the aircraft to break each time we make necessary changes to this file.

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
N/A

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
