### PR TITLE
fix: remove leading whitespace for the admonition in efis_control.md

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/efis_control.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/efis_control.md
@@ -8,7 +8,7 @@
 
 ![EFIS Control](../../../assets/a32nx-briefing/glareshield/EFIS-Control.jpg "EFIS Control")
 
- !!! note "API Documentation: [EFIS Control Panel](../../a32nx_api.md#efis-control-panel)"
+!!! note "API Documentation: [EFIS Control Panel](../../a32nx_api.md#efis-control-panel)"
 
 ## Description
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->
fixes #297

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
Quick fix
### Location
<!-- Please provide the original URL of the page modified or directory location here -->
- docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/efis_control.md
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
