### PR TITLE
style: move code highlight style to extra.css

### DIFF
--- a/docs/stylesheets/admonitions.css
+++ b/docs/stylesheets/admonitions.css
@@ -3,15 +3,6 @@
   border-left: .2rem solid #00C2CB;
   border-color: #00C2CB;
 }
-.md-typeset code {
-    background-color: hsl(232,7%,28%);
-    border-radius: .1rem;
-    -webkit-box-decoration-break: clone;
-    box-decoration-break: clone;
-    font-size: .95em;
-    padding: 0 .2941176471em;
-    word-break: break-word;
-}
 /*Admonition Question Variant*/
 /*Upper Section*/
 .md-typeset .question>.admonition-title, .md-typeset .question>summary,

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -53,6 +53,15 @@ h4 {
     color: white;
     text-decoration: none;
 }
+.md-typeset code {
+    background-color: hsl(232,7%,28%);
+    border-radius: .1rem;
+    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
+    font-size: .95em;
+    padding: 0 .2941176471em;
+    word-break: break-word;
+}
 /*Standardize Font Awesome CSS Styling*/
 .discord {
   font-size: 20px;


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
The styling for code highlights was set in the wrong CSS file. 
### Location
<!-- Please provide the original URL of the page modified or directory location here -->
- stylesheets
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
