### PR TITLE
docs(briefing): corrective text to nomenclature and descriptions

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/pfd/.pages
+++ b/docs/pilots-corner/a32nx-briefing/pfd/.pages
@@ -1,7 +1,7 @@
 title: PFD
 nav:
  - Overview: index.md
- - Flight Mode Annunciations: fma.md
+ - Flight Mode Annunciator: fma.md
  - Airspeed: speedtape.md
  - Attitude and Guidance: artificial-horizon.md
  - ILS Indications: ils-indicator.md

--- a/docs/pilots-corner/a32nx-briefing/pfd/fifth-column.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/fifth-column.md
@@ -1,7 +1,6 @@
 <link rel="stylesheet" href="../../../../stylesheets/pfd-interactive.css">
 
-# Autopilot Status Annunciators
-
+# Autopilot Status Annunciations
 <div style="position: relative; width: 413px; height: auto; margin-left: auto;  margin-right: auto;">
     <img src="/pilots-corner/assets/a32nx-briefing/pfd/pfd-small.png" style="width: 413px; height: auto;">
     <a href="/pilots-corner/a32nx-briefing/pfd/fma/">               <div class="imagemap highlighted" style="position: absolute; left:     0%; top:     0%; width:   100%; height: 15.00%;"><span class="imagemapname">Flight Mode Annunciators</span></div></a>

--- a/docs/pilots-corner/a32nx-briefing/pfd/fifth-column.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/fifth-column.md
@@ -29,7 +29,7 @@
 
 ## Description
 
-This column tells the pilot which autopilot and which flight director is activated. It will also display the engagement status of the autothrust.
+This column displays the autotthrust modes that are armed or active, as well as any requested pilot actions.
 
 ---
 

--- a/docs/pilots-corner/a32nx-briefing/pfd/first-column.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/first-column.md
@@ -1,6 +1,6 @@
 <link rel="stylesheet" href="../../../../stylesheets/pfd-interactive.css">
 
-# Autothrust Mode Annunciators
+# Autothrust Mode Annunciations
 
 <div style="position: relative; width: 413px; height: auto; margin-left: auto;  margin-right: auto;">
     <img src="/pilots-corner/assets/a32nx-briefing/pfd/pfd-small.png" style="width: 413px; height: auto;">

--- a/docs/pilots-corner/a32nx-briefing/pfd/first-column.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/first-column.md
@@ -40,7 +40,7 @@ Displayed with white text surrounded by a white box. This is displayed when Auto
 
 ### MAN FLX XX
 
-Displayed with white text surrounded by a white box. The numbers are blue. Displayed when Autothrust is armed and at least one thrust lever is in the MCT/FLX detent. The FLX TO temp will be displayed as XX in blue.
+Displayed with white text surrounded by a white box. The numbers are blue. Displayed when Autothrust is armed and at least one thrust lever is in the MCT/FLX detent and the other is at or below this detent. The FLX TO temp will be displayed as XX in blue.
 
 ### MAN MCT
 

--- a/docs/pilots-corner/a32nx-briefing/pfd/fma.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/fma.md
@@ -1,6 +1,6 @@
 <link rel="stylesheet" href="../../../../stylesheets/pfd-interactive.css">
 
-# Flight Mode Annunciators
+# Flight Mode Annunciator
 ---
 
 <div style="position: relative; width: 413px; height: auto; margin-left: auto;  margin-right: auto;">
@@ -41,20 +41,20 @@ The FMA has various ways to signify different states:
 - Armed flight modes are displayed in cyan text.
 - Changed modes have a white box around the new annunciation for 10 seconds.
 
-Each of the 5 columns at the top of the PFD will display different types of Flight Mode Annunciators. You can learn more about each annunciator by clicking on each column on the PFD below.
+Each of the 5 columns at the top of the PFD will display different types of Flight Mode Annunciations. You can learn more about each annunciation by clicking on each column on the PFD below.
 
-There are also some annunciators that take up two columns. These can either be Special Message Annunciators or Common Mode Annunciators.
+There are also some annunciations that take up two columns. These can either be Special Message Annunciations or Common Mode Annunciations.
 
 ---
 
 ## Chapters
 
-- [First Column (Autothrust Mode Annunciators)](first-column.md)
-- [Second Column (Vertical Mode Annunciators)](second-column.md)
-- [Third Column (Lateral Mode Annunciators)](third-column.md)
-- [Fourth Column (Approach Annunciators)](fourth-column.md)
-- [Fifth Column (Autopilot Status Annunciators)](fifth-column.md)
-- [Special Message and Common Mode Annunciators](special-message-annunciators.md)
+- [First Column (Autothrust Mode Annunciations)](first-column.md)
+- [Second Column (Vertical Mode Annunciations)](second-column.md)
+- [Third Column (Lateral Mode Annunciations)](third-column.md)
+- [Fourth Column (Approach Annunciations)](fourth-column.md)
+- [Fifth Column (Autopilot Status Annunciations)](fifth-column.md)
+- [Special Message and Common Mode Annunciations](special-message-annunciators.md)
 
 ---
 

--- a/docs/pilots-corner/a32nx-briefing/pfd/fma.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/fma.md
@@ -5,7 +5,7 @@
 
 <div style="position: relative; width: 413px; height: auto; margin-left: auto;  margin-right: auto;">
     <img src="/pilots-corner/assets/a32nx-briefing/pfd/pfd-small.png" style="width: 413px; height: auto;">
-    <a href="/pilots-corner/a32nx-briefing/pfd/fma/">               <div class="imagemap highlighted" style="position: absolute; left:     0%; top:     0%; width:   100%; height: 15.00%;"><span class="imagemapname">Flight Mode Annunciators</span></div></a>
+    <a href="/pilots-corner/a32nx-briefing/pfd/fma/">               <div class="imagemap highlighted" style="position: absolute; left:     0%; top:     0%; width:   100%; height: 15.00%;"><span class="imagemapname">Flight Mode Annunciator</span></div></a>
     <a href="/pilots-corner/a32nx-briefing/pfd/altitude-indicator/"><div class="imagemap"             style="position: absolute; left: 72.60%; top: 20.00%; width: 16.00%; height: 58.00%;"><span class="imagemapname">Altitude Indicator</span></div></a>
     <a href="/pilots-corner/a32nx-briefing/pfd/vertical-speed/">    <div class="imagemap"             style="position: absolute; left: 89.00%; top: 18.15%; width: 11.00%; height: 64.20%;"><span class="imagemapname">Vertical Speed Indicator</span></div></a>
     <a href="/pilots-corner/a32nx-briefing/pfd/baro-ref/">          <div class="imagemap"             style="position: absolute; left: 74.04%; top: 81.00%; width: 19.44%; height:   5.8%;"><span class="imagemapname">Barometric Reference</span></div></a>

--- a/docs/pilots-corner/a32nx-briefing/pfd/fourth-column.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/fourth-column.md
@@ -1,6 +1,6 @@
 <link rel="stylesheet" href="../../../../stylesheets/pfd-interactive.css">
 
-# Approach Annunciators
+# Approach Annunciations
 
 <div style="position: relative; width: 413px; height: auto; margin-left: auto;  margin-right: auto;">
     <img src="/pilots-corner/assets/a32nx-briefing/pfd/pfd-small.png" style="width: 413px; height: auto;">
@@ -30,10 +30,10 @@
 
 ## Description
 
-These annunciators are related to the approach flight phase. They show the category of approach that the aircraft is capable of as well as the DH or MDA (if selected).
+These annunciations are related to the approach flight phase. They show the category of approach that the aircraft is capable of as well as the DH or MDA (if selected).
 
 !!! note ""
-    These annunciators are showing the aircraft's capabilities and are independent from the actual airport and runway capabilities.
+    These annunciations are showing the aircraft's capabilities and are independent from the actual airport and runway capabilities.
 
 ---
 

--- a/docs/pilots-corner/a32nx-briefing/pfd/second-column.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/second-column.md
@@ -1,6 +1,6 @@
 <link rel="stylesheet" href="../../../../stylesheets/pfd-interactive.css">
 
-# Vertical Mode Annunciators
+# Vertical Mode Annunciations
 
 <div style="position: relative; width: 413px; height: auto; margin-left: auto;  margin-right: auto;">
     <img src="/pilots-corner/assets/a32nx-briefing/pfd/pfd-small.png" style="width: 413px; height: auto;">
@@ -30,7 +30,7 @@
 
 ## Description
 
-These annunciators tell the pilots which vertical mode the autopilot and flight director are engaged in and which mode is armed.
+These annunciations tell the pilots which vertical mode the autopilot and flight director are engaged in and which mode is armed.
 
 ### SRS
 

--- a/docs/pilots-corner/a32nx-briefing/pfd/third-column.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/third-column.md
@@ -1,6 +1,6 @@
 <link rel="stylesheet" href="../../../../stylesheets/pfd-interactive.css">
 
-# Lateral Mode Annunciators
+# Lateral Mode Annunciations
 
 <div style="position: relative; width: 413px; height: auto; margin-left: auto;  margin-right: auto;">
     <img src="/pilots-corner/assets/a32nx-briefing/pfd/pfd-small.png" style="width: 413px; height: auto;">
@@ -30,7 +30,7 @@
 
 ## Description
 
-These annunciators tell the pilots which lateral mode the autopilot and the flight director are engaged in and which modes are armed.
+These annunciations tell the pilots which lateral mode the autopilot and the flight director are engaged in and which modes are armed.
 
 ---
 


### PR DESCRIPTION
fixes #346 

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
Note: Currently unsure if we should include the 4th point in the issue on the FMA pages or somewhere else. 

For organization purposes @frankkopp some insight on what you think.

Copy from Issue:

> Since the MCT description refers to this being the maximum thrust that the engine can be set to for an extended period of time, do you want to say that TOGA and FLX can only be used for no more than 5 minutes at a time with both engines operating, or 10 minutes with one-engine-inoperative? (Just a suggestion - no need if this would be too complicated or too much information).

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
Touches all pages related to FMA based on:
- docs/pilots-corner/a32nx-briefing/pfd/index.md
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
