### PR TITLE
build: bump mkdocs-material -> 8.1.1

### DIFF
--- a/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
+++ b/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
@@ -1,22 +1,6 @@
 # Fuel and Weight
 
-<style>
-.md-typeset .admonition.info {
-    display: flow-root;
-    overflow: visible;
-    padding-top: 0;
-    font-size: 0.75rem;
-}
-.md-typeset .admonition-title, .md-typeset summary {
-    background-color: rgba(68,138,255,.1);
-    border-left: .2rem solid #448aff;
-    font-weight: 700;
-    font-size: 0.7rem;
-    margin: 0 -.6rem 0 -.8rem;
-    padding: .4rem .6rem .4rem 2rem;
-    position: relative;
-}
-</style>
+<link rel="stylesheet" href="/../../stylesheets/fuel-weight.css">
 
 This section provides information on the A32NX weights configuration and insight on how to utilize and reference onboard/sim features to configure the aircraft appropriately for departure.
 

--- a/docs/stylesheets/admonitions.css
+++ b/docs/stylesheets/admonitions.css
@@ -1,9 +1,4 @@
-/*Additional Modifications*/
-.md-typeset .admonition {
-  border-left: .2rem solid #00C2CB;
-  border-color: #00C2CB;
-}
-/*Admonition Question Variant*/
+/*Admonition Modifications*/
 /*Upper Section*/
 .md-typeset .question>.admonition-title, .md-typeset .question>summary,
 .md-typeset .faq>.admonition-title, .md-typeset .faq>summary,

--- a/docs/stylesheets/fuel-weight.css
+++ b/docs/stylesheets/fuel-weight.css
@@ -1,0 +1,13 @@
+.md-typeset .admonition.info {
+    display: flow-root;
+    overflow: visible;
+    padding-top: 0;
+    font-size: 0.75rem;
+}
+.md-typeset .admonition-title, .md-typeset summary {
+    font-weight: 700;
+    font-size: 0.7rem;
+    margin: 0 -.6rem 0 -.8rem;
+    padding: .4rem .6rem .4rem 2rem;
+    position: relative;
+}

--- a/docs/stylesheets/navigation.css
+++ b/docs/stylesheets/navigation.css
@@ -27,8 +27,9 @@
     overflow: auto;
     text-align: center;
 }
-.md-typeset img, .md-typeset svg {
-    height: auto;
-    max-width: 100%;
-    vertical-align: text-bottom;
-}
+/*8.1.1 compatibility*/
+/*.md-typeset img, .md-typeset svg {*/
+/*    height: auto;*/
+/*    max-width: 100%;*/
+/*    vertical-align: text-bottom;*/
+/*}*/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==8.0.5
+mkdocs-material==8.1.1
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
Most notable fix for our website is the broken footer (left-aligned on production) which I was hoping an update would solve due to changes in previous versions.

See [Material Changelog](https://squidfunk.github.io/mkdocs-material/changelog/).

**Note:** Admonition styles were broken with this version. I've resolved them with this PR but would be prudent to check sitewide if everything is as it should. 

Any admonition styles we have passed inline within a certain page we should move to a dedicated stylesheet for easier tracking to breaking styles.
### Location
<!-- Please provide the original URL of the page modified or directory location here -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
