### PR TITLE
docs: Fixed typo for "ENG 1+2 MASTER" api usage

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/a32nx_api.md
+++ b/docs/pilots-corner/a32nx-briefing/a32nx_api.md
@@ -953,8 +953,8 @@ Flight Deck: [ENG Panel](flight-deck/pedestal/engine.md)
 
 | Function       | API Usage                    | Values | Read/Write | Type       | Remark                 |
 |:---------------|:-----------------------------|:-------|:-----------|:-----------|:-----------------------|
-| ENG 1+2 MASTER | FUELSYSTEN_VALVE_OPEN        | 1 \| 2 | -          | MSFS EVENT | Activates the switch   |
-|                | FUELSYSTEN_VALVE_CLOSE       | 1 \| 2 | -          | MSFS EVENT | Deactivates the switch |
+| ENG 1+2 MASTER | FUELSYSTEM_VALVE_OPEN        | 1 \| 2 | -          | MSFS EVENT | Activates the switch   |
+|                | FUELSYSTEM_VALVE_CLOSE       | 1 \| 2 | -          | MSFS EVENT | Deactivates the switch |
 |                | FUELSYSTEM VALVE SWITCH:1    | 0 \| 1 | R          | MSFS VAR   |                        |
 |                | FUELSYSTEM VALVE SWITCH:2    | 0 \| 1 | R          | MSFS VAR   |                        |
 |                |                              |        |            |            |                        |


### PR DESCRIPTION
## Summary
There is a typo in the api usage of "ENG 1+2 MASTER". The MSFS event is not `FUELSYSTE_N_` but `FUELSYSTE_M_`.

### Location
https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/a32nx_api/#eng-panel
