### PR TITLE
fix: Various fixes from issue #397

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/fcu.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/fcu.md
@@ -119,7 +119,7 @@ When pushed an immediate level off is commanded (V/S of 0). The flight mode annu
 
 ### APPR
 
-Approach modes are activated ot deactivated (armed, disarmed, engaged, disengaged):
+Approach modes are activated or deactivated (armed, disarmed, engaged, disengaged):
 
 - If an ILS approach is selected in the flight plan it activates LOC and G/S modes
 - If a non precision approach is selected in the flight plan, it activates APP NAV-FINAL modes.

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/ecam-control.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/ecam-control.md
@@ -14,6 +14,10 @@
 
 The ECAM Control Panel is used to change what is displayed on the Warning Display and System Display (Lower ECAM) and also has knobs to regulate brightness of the both ECAM displays.
 
+See detailed ECAM briefing:
+
+[ECAM SD](../../ecam/sd/index.md){ .md-button }
+
 ## Usage
 
 ###  OFF / BRT knobs
@@ -25,9 +29,6 @@ These knobs control the brightness of the ECAM displays and also allow to turn t
 Displays the respective page on the SD.
 
 Available pages are: ENG, BLEED, PRESS, ELEC, HYD, FUEL, APU, COND, DOOR, WHEEL, F CTL, STS, CRUISE.
-
-!!! info "Future Update"
-    A more in depth description of the ECAM Pages is currently being developed and will be available in the near future.
 
 ### CLR and RCL
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/flaps.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/flaps.md
@@ -31,7 +31,7 @@ Before selecting any position, the pilot must pull the lever out of the detent. 
 
 Takeoff in CONFIG 1:
 
-- 1 + F (18°/10°) is selected. If the pilot does not select configuration 0 after takeoff, the flaps retract automatically at 210 knots.
+- 1 + F (18° Slats /  10° **F**laps) is selected. If the pilot does not select configuration 0 after takeoff, the flaps retract automatically at 210 knots.
 
 Takeoff or go-around in CONFIG 2 or 3:
 
@@ -40,7 +40,7 @@ Takeoff or go-around in CONFIG 2 or 3:
 
 CONFIG O to CONFIG 1 in flight:
 
-- CONFIG 1 ( 18°/0°) is selected.
+- CONFIG 1 ( 18° Slats / 0° Flaps) is selected.
 
 !!! info ""
     Note: After flap retraction, CONFIG 1 + F is no longer available until the airspeed is 100 knots or less, unless CONFIG 2, 3, or FULL has been selected previously.

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/mcdu.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/mcdu.md
@@ -18,9 +18,12 @@ Typical usage is the definition and selection of a flight plan for lateral and v
 
 After entry or selection of the flight plan and other required performance data into the MCDU, the FMGS generates the climb and descent profiles for departure and arrival, provides automatic airplane guidance, and computes current and predicted progress along the flight plan.
 
+Learn how to setup the MCDU for flight here: [Preparing MCDU](../../../beginner-guide/preparing-mcdu.md)
+
 <!-- TODO: UPDATE -->
 !!! info "Future Update"
     A more in depth briefing section of the MCDU is currently being developed and will be available in the near future.
+
 
 ---
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
@@ -106,7 +106,7 @@ Power supply to the RMP.
     - Green lines come on.
     - Deselecting by pressing the pushbutton again, through selecting another channel.
 - CALL:
-    -  When the SELCAL system detects a call the legend flashes amber (and buzzer sounds).
+    -  When the [SELCAL](https://skybrary.aero/articles/selective-calling-system-selcal){target=new} system detects a call the legend flashes amber (and buzzer sounds).
 - MECH:
     - When called from the nose gear bay the legend flashes amber (and buzzer sounds). If it is not reset, the MECH light goes off after 60 seconds.
 - ATT:

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/thrust-elev-trim.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/thrust-elev-trim.md
@@ -57,6 +57,8 @@ This system is always active, even when the Autopilot is off (in Normal Law whic
 
 Nevertheless, the pitch trim wheels in the cockpit provide mechanical control of the Trimmable Horizontal Stabilizer (THS) and have priority over electrical control. The Autopilot is disconnected when a pilot uses the trim wheel during flight.
 
+See our [Preparing MCDU: PERF](../../../beginner-guide/preparing-mcdu.md#perf) guide for additional info about trimming.
+
 !!! info ""
     Note: Pilot's use of the pitch trim wheel does not disconnect the ELACs to make sure that the computers remain synchronized with the manually-selected position.
 

--- a/docs/pilots-corner/a32nx-briefing/pfd/second-column.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/second-column.md
@@ -46,6 +46,14 @@ Displayed in green when climb mode is engaged and the FMGS Target altitude is hi
 
 Displayed in green when open climb mode is engaged and the FCU selected altitude is higher that the actual altitude. Altitude constraints are disregarded.
 
+### EXP CLB
+
+Displayed when the aircraft is in EXP CLB mode.
+
+The target speed is Green Dot, which is maintained with pitch control. Autothrust, if active, sets the thrust at CLB THRUST automatically.
+
+When EXPEDITE is engaged, the system disregards SPD CSTR, ALT CSTR, and SPD LIM.
+
 ### ALT\* or ALT CST\*
 
 Altitude Capture is engaged
@@ -71,6 +79,15 @@ Displayed in green when descent mode (managed) is engaged and the FMGS target al
 ### OP DES
 
 Displayed in green when open descent (selected) mode is engaged and the FCU selected altitude is lower than the current altitude. Altitude Constraints are not taken into account.
+
+### EXP DES
+
+Displayed when the aircraft is in EXP DES mode.
+
+When the aircraft is in EXP DES, the target speed is 340 kt or M 0.8 which is maintained with pitch
+control. Autothrust, if active, sets the thrust at IDLE automatically.
+
+When EXPEDITE is engaged, the system disregards SPD CSTR, ALT CSTR, and SPD LIM.
 
 ### G/S\*
 


### PR DESCRIPTION
Fixes #397

## Summary
Various fixes

- [x] 1. [FCU - APPR](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/flight-deck/glareshield/fcu/#appr): Typo: _Approach modes are activated **ot** deactivated_
- [x] 2. [FCU - EXPED](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/flight-deck/glareshield/fcu/?h=exped#exped):  The EXP DES mode is well described here, but not part of the [PFD in-depth guide](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/pfd/second-column/)
- [x] 3. [ECAM Control Panel](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/flight-deck/pedestal/ecam-control/#system-page-buttons): The info box mentions a future update in terms of detail description. But isn't that [this guide](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/ecam/sd/#ecam-system-display-pages) that you can link here?
- [x] 4. [Flaps](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/flight-deck/pedestal/flaps/): Not sure who the target audience is, but if it's for dummies (me), the difference between CONF 1 and CONF 1 + F is not clear. For what does F stand for? I assume it stands for flaps. So CONF 1 gives slats 18 but flaps 0, while + F gives flaps 10
  - F = Flaps - page describes quite well that they are automatically retracted at a certain speed and not available once flaps are retracted. Added terms to clarify. 
- [x] 5. [MCDU](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/flight-deck/pedestal/mcdu/#description): The info box mentions a future update in terms of detailed guide. I think [this guide here](https://docs.flybywiresim.com/pilots-corner/beginner-guide/preparing-mcdu/) is already good enough to be linked here
- [x] ~~6. [Radio - Transmission Keys #1](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp/#tansmission-keys): The box under the screenshot (_Currently only the VHF1-3 (...)_) feels misplaced, maybe it can be removed since it's covered in the the chapter "Reception Knobs"?~~
- [x] 7. [Radio - Transmission Keys #2](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp/#tansmission-keys):"SELCAL" is mentioned in the chapter, while not explaining what it is. Sure I [googled](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp/#tansmission-keys) it, but would be handy to have it on one place. 
- [x] 7. [Thrust Lever](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/flight-deck/pedestal/thrust-elev-trim/): In terms of THS and pitch trim, you might want to link to [this guide](https://docs.flybywiresim.com/pilots-corner/beginner-guide/preparing-mcdu/?h=ths#perf) to give more context

### Location
Flight Deck guide

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Cdr_Maverick#6475
