### PR TITLE
refactor: design of various quick link sections + code blocks

### DIFF
--- a/docs/dev-corner/dev-guide/index.md
+++ b/docs/dev-corner/dev-guide/index.md
@@ -1,3 +1,5 @@
+<link rel="stylesheet" href="../../../stylesheets/toc-tables.css">
+
 # FlyByWire Development Guide
 
 ## Introduction
@@ -14,14 +16,12 @@ This documentation describes the FlyByWire Development Process and tools in deta
 
 It is structured in a series of sections which are based on each other starting with the necessary software and tools, downloading and compiling the A32NX successfully to guidelines how to contribute within the project.
 
-##  Topics / Notes:
+##  Topics
 
-- [Resources](resources.md)
-    - General information and documentation resources
-- [Setting up Development Environment](setup-environment.md)
-    - From software to troubleshooting everything you need to successfully change and compile the code.
-- [Contribution Guidelines](contribute.md)
-    - From General Development Process and Practices to Pull Requests - everything you need to know to collaborate and contribute to the project.
-- [Specific Development Areas](specific/)
-    - Information for specific parts of the project like the flyPad or avionics.
+| Quick Links                                                | Description                                                                                                                                 |
+| :----                                                      | :----                                                                                                                                       |
+| [Resources](resources.md)                                  | General information and documentation resources                                                                                             |
+| [Setting up Development Environment](setup-environment.md) | From software to troubleshooting everything you need to successfully change and compile the code.                                           |
+| [Contribution Guidelines](contribute.md)                   | From General Development Process and Practices to Pull Requests - everything you need to know to collaborate and contribute to the project. |
+| [Specific Development Areas](specific/)                    | Information for specific parts of the project like the flyPad or avionics.                                                                  |
 

--- a/docs/dev-corner/development-projects/index.md
+++ b/docs/dev-corner/development-projects/index.md
@@ -1,30 +1,14 @@
+<link rel="stylesheet" href="../../../stylesheets/toc-tables.css">
+
 # Overview
 
 FlyByWire Simulations consists of several projects to allow efficient and quick development of various aspects of each project.
 
-Current Projects:
-
-- [A32NX](https://github.com/flybywiresim/a32nx){target=new}
-
-    Main project where the actual FlyByWire A32NX is developed
-
-- [Installer](https://github.com/flybywiresim/installer){target=new}
-
-    Project for developing and improving the FlyByWire Installer.
-
-- [Docs](documentation.md)
-
-    Documentation project to manage and improve documentation for our users. This includes documentation about the A32NX, general sim-pilot documentation, and documentation about development for the A32NX.
-
-- [Discord Bot](discord-bot.md)
-
-    FlyByWire Simulations custom bot commands list and changelog. Provides a quick overview of available support commands and changes to bot development.
-
-- [Website](website.md)
-
-    Marketing website for FlyByWire Simulations
-
-- [msfs-rs](https://github.com/flybywiresim/msfs-rs){target=new}
-
-     A Rusty way to interact with Microsoft Flight Simulator 2020
-
+| Projects                                                           | Description                                                                                                                                                                                               |
+| :----                                                              | :----                                                                                                                                                                                                     |
+| [A32NX](https://github.com/flybywiresim/a32nx){target=new}         | Main project where the actual FlyByWire A32NX is developed                                                                                                                                                |
+| [Installer](https://github.com/flybywiresim/installer){target=new} | Project for developing and improving the FlyByWire Installer.                                                                                                                                             |
+| [Docs](documentation.md)                                           | Documentation project to manage and improve documentation for our users. This includes documentation about the A32NX, general sim-pilot documentation, and documentation about development for the A32NX. |
+| [Discord Bot](discord-bot.md)                                      | FlyByWire Simulations custom bot commands list and changelog. Provides a quick overview of available support commands and changes to bot development.                                                     |
+| [Website](website.md)                                              | Marketing website for FlyByWire Simulations                                                                                                                                                               |
+| [msfs-rs](https://github.com/flybywiresim/msfs-rs){target=new}     | A Rusty way to interact with Microsoft Flight Simulator 2020                                                                                                                                              |

--- a/docs/dev-corner/index.md
+++ b/docs/dev-corner/index.md
@@ -1,17 +1,16 @@
+<link rel="stylesheet" href="../../../stylesheets/toc-tables.css">
+
 # Development Corner Overview
 
 This section of the FlyByWire Documentation is dedicated to the development aspects of the A32NX add-on. It is aimed at developers, contributors or anyone who would like to start contributing to the project.
 
-## Quick Links
-
-
 [:fontawesome-brands-github:{: .github } **GitHub Contributing.md**](https://github.com/flybywiresim/a32nx/blob/master/.github/Contributing.md){ .md-button target=new}
 
-[Development Guide](dev-guide/index.md){ .md-button }
+## Quick Links
 
-##  Topics
-
-- [Development Guide](dev-guide/index.md)
-- [Texture Changes](texture-changes.md)
-- [FlyByWire Projects](development-projects/)
+| Topics                                      |
+| :----                                       |
+| [Development Guide](dev-guide/index.md)     |
+| [Texture Changes](texture-changes.md)       |
+| [FlyByWire Projects](development-projects/) |
 

--- a/docs/fbw-a32nx/a32nx-api/index.md
+++ b/docs/fbw-a32nx/a32nx-api/index.md
@@ -34,7 +34,7 @@ So, for example the standard software command for the landing lights is the Simc
 
 But the Aerosoft CRJ aircraft requires these variables:
 
-```
+```title="Sample Variables"
     - set ASCRJ_OVHD_LDG_LEFT -> 1  
     - set ASCRJ_OVHD_LDG_NOSE -> 1  
     - set ASCRJ_OVHD_LDG_RIGHT -> 1

--- a/docs/fbw-a32nx/feature-guides/autopilot-fbw.md
+++ b/docs/fbw-a32nx/feature-guides/autopilot-fbw.md
@@ -158,7 +158,7 @@ The work folder can be found here:
     In order to enable the use with normal axes, the following needs to be done.
 
     Put a file named `ModelConfiguration.ini` into the work folder (see "Work folder location" on this page) that has the following option set to true:
-    ```
+    ```ini title="ModelConfiguration.ini"
     [flight_controls]
     disable_xbox_compatibility_rudder_axis_plus_minus = true
     ```

--- a/docs/fbw-a32nx/feature-guides/flyPad/throttle-calibration.md
+++ b/docs/fbw-a32nx/feature-guides/flyPad/throttle-calibration.md
@@ -451,7 +451,7 @@ Click on "Save & Apply".
 
         You still should verify the configurations as described below as all hardware units are slightly different.
 
-        ```
+        ```ini title="ThrottleConfiguration.ini"
         [throttle_common]
         reverse_on_axis = false
 
@@ -696,7 +696,7 @@ To restore the default values you can just delete this file. It will be regenera
 
 Example "**ThrottleConfiguration.ini**" file based on the default values:
 
-```
+```ini title="ThrottleConfiguration.ini"
 [throttle_common]
 reverse_on_axis = true
 

--- a/docs/fbw-a32nx/feature-guides/index.md
+++ b/docs/fbw-a32nx/feature-guides/index.md
@@ -1,15 +1,20 @@
+<link rel="stylesheet" href="../../stylesheets/toc-tables.css">
+
 # A32NX Feature Guides
 
 This section is dedicated to guides for specific features and functionalities of the FlyByWire A32NX.
 
 It is not a complete collection of all features but a growing list which is extended when we feel the need to explain a feature in more detail due to complexity or due to frequent inquiries on our Discord #support channel.
 
-Topics:
-
-- [Autopilot and fly-by-wire](autopilot-fbw.md)
-- [Flight Management System](cFMS.md)
-- [Fuel and Weight](loading-fuel-weight.md)
-- [MCDU Keyboard Support](mcdu-keyboard.md)
-- [SimBrief Integration](simbrief.md)
-- [Throttle Calibration](flyPad/throttle-calibration.md)
-- [flyPad EFB](flyPad/index.md)
+| Quick Links                                            |
+| : ----------------                                     |
+| [Autopilot and Fly-By-Wire](autopilot-fbw.md)          |
+| [Flight Management System](cFMS.md)                    |
+| [Free Text](freetext.md)                               |
+| [Fuel and Weight](loading-fuel-weight.md)              |
+| [Hoppie ACARS](hoppie.md)                              |
+| [MCDU Keyboard Support](mcdu-keyboard.md)              |
+| [MCDU Web Interface](web-mcdu.md)                      |
+| [Nose Wheel and Tiller Operation](nw-tiller.md)        |
+| [SimBrief Integration](simbrief.md)                    |
+| [Throttle Calibration](flyPad/throttle-calibration.md) |

--- a/docs/fbw-a32nx/index.md
+++ b/docs/fbw-a32nx/index.md
@@ -10,11 +10,17 @@ The A32NX Project is a community-driven open source project to create a free Air
 
 The following aircraft configurations are currently simulated:
 
-```
-Model      A320-251N
-Engine     LEAP 1A-26
-FMGS       Honeywell Pegasus II
-FWC Std.   H2F9C
+```title="Simulated Hardware"
+Model       A320-251N
+Engine      CFM LEAP 1A-26
+APU         APS3200
+FMS         Honeywell Release H3
+FWC Std.    H2F9C
+TAWS        Honeywell EGPWS
+ACAS        Honeywell TPA-100B
+ATC         Honeywell TRA-100B
+MMR         Honeywell iMMR
+WXR         Honeywell RDR-4000
 ```
 
 ## Quick Links

--- a/docs/fbw-a32nx/index.md
+++ b/docs/fbw-a32nx/index.md
@@ -1,3 +1,5 @@
+<link rel="stylesheet" href="../../stylesheets/toc-tables.css">
+
 # FlyByWire A32NX Overview
 
 This section of the FlyByWire Documentation is dedicated to the A32NX add-on itself. It covers the software and more technical aspects of the FlyByWire add-on.
@@ -25,12 +27,13 @@ FWC Std.   H2F9C
 
 ##  Topics
 
-- [Version and Feature Guide](fbw-versions.md)
-- [Installation Guide](installation.md)
-- [Livery Guide](liveries.md)
-- [Support](support/index.md)
-- [Feature Guides](feature-guides/)
-- [API and Hardware](a32nx-api)
+| Featured List                                |
+| :----                                        |
+| [Installation Guide](installation.md)        |
+| [Version and Feature Guide](fbw-versions.md) |
+| [Livery Guide](liveries.md)                  |
+| [Support](support/index.md)                  |
+| [API and Hardware](a32nx-api)                |
 
 
 

--- a/docs/fbw-a32nx/support/index.md
+++ b/docs/fbw-a32nx/support/index.md
@@ -1,3 +1,5 @@
+<link rel="stylesheet" href="../../stylesheets/toc-tables.css">
+
 # Support Guide
 
 Microsoft Flight Simulator 2020 is still a rather young flight simulator and many issues still need to be addressed.
@@ -8,12 +10,14 @@ This guide shall help you how to identify and solve these issues by guiding you 
 
 ##  Index
 
-1. [Learn how to fly the A32NX](#1-learn-how-to-fly-the-a32nx)
-- [How to Troubleshoot](#2-how-to-troubleshoot)
-- [Research Known Issues](#3-research-known-issues)
-- [Report Issue on Discord](#4-report-issue-on-discord)
-- [Report Issue on the A32NX Github](#5-report-issue-on-the-a32nx-github)
-- [Collecting Support Information](#collecting-support-information)
+| Quick Links                                                                |
+| :----                                                                      |
+| 1. [Learn how to fly the A32NX](#1-learn-how-to-fly-the-a32nx)             |
+| 2. [How to Troubleshoot](#2-how-to-troubleshoot)                           |
+| 3. [Research Known Issues](#3-research-known-issues)                       |
+| 4. [Report Issue on Discord](#4-report-issue-on-discord)                   |
+| 5. [Report Issue on the A32NX Github](#5-report-issue-on-the-a32nx-github) |
+| 6. [Collecting Support Information](#collecting-support-information)       |
 
 ## 1. Learn How to Fly the A32NX
 

--- a/docs/fbw-a32nx/support/index.md
+++ b/docs/fbw-a32nx/support/index.md
@@ -140,7 +140,7 @@ To get the actual build number of your installed A32NX go into your Community fo
 <your-Community-Folder>\flybywire-aircraft-a320-neo\build_info.json
 
 This should contain something like this:
-```
+```json title="build_info.json"
 {
   "built": "2021-08-11T07:29:20+00:00",
   "ref": "master",

--- a/docs/pilots-corner/a32nx-briefing/ecam/index.md
+++ b/docs/pilots-corner/a32nx-briefing/ecam/index.md
@@ -1,3 +1,5 @@
+<link rel="stylesheet" href="../../../stylesheets/toc-tables.css">
+
 # ECAM Overview
 
 ## Description
@@ -14,5 +16,7 @@ The Electronic Centralized Aircraft Monitoring (ECAM) consists of two displays:
 
 ##  Topics
 
-- [ECAM Engine and Warning Display](ecam-e-wd.md)
-- [ECAM Systems Display](sd/index.md)
+| Quick Links                                     |
+| :----                                           |
+| [ECAM Engine and Warning Display](ecam-e-wd.md) |
+| [ECAM Systems Display](sd/index.md)             |

--- a/docs/pilots-corner/a32nx-briefing/index.md
+++ b/docs/pilots-corner/a32nx-briefing/index.md
@@ -1,3 +1,5 @@
+<link rel="stylesheet" href="../../../stylesheets/toc-tables.css">
+
 # A320neo Pilot Briefing
 
 **For Simulation Use Only**
@@ -17,10 +19,12 @@ but are omitted in this briefing.
 
 ##  Topics
 
-- [Flight-Deck](flight-deck/index.md)
-- [Flight-Deck A32NX API](a32nx_api.md)
-- [ECAM](ecam/index.md)
-- [PFD](pfd/index.md)
+| Quick Links                           |
+| :-----                                |
+| [Flight-Deck](flight-deck/index.md)   |
+| [Flight-Deck A32NX API](a32nx_api.md) |
+| [ECAM](ecam/index.md)                 |
+| [PFD](pfd/index.md)                   |
 <!--- [ND](nd/index.md)-->
 <!--- [MCDU](mcdu/index.md)-->
 

--- a/docs/pilots-corner/a32nx-briefing/pfd/index.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/index.md
@@ -1,4 +1,5 @@
 <link rel="stylesheet" href="../../../../stylesheets/pfd-interactive.css">
+<link rel="stylesheet" href="../../../stylesheets/toc-tables.css">
 
 # Primary Flight Display (PFD)
 
@@ -45,11 +46,13 @@ The Primary Flight Display (PFD) is the main aviation instrument for the pilots.
 
 ## Chapters
 
-- [Flight Mode Annunciators](fma.md)
-- [Actual Airspeed Reference Line and Scale](speedtape.md)
-- [Attitude and Guidance](artificial-horizon.md)
-- [Altitude Indicator](altitude-indicator.md)
-- [Barometric Reference](baro-ref.md)
-- [Heading Reference Line and Scale](heading-ref.md)
-- [Vertical Speed indicator](vertical-speed.md)
-- [Flags and Messages](flags-messages.md)
+|Quick Links|
+|:----|
+| [Flight Mode Annunciators](fma.md)|
+|[Actual Airspeed Reference Line and Scale](speedtape.md)|
+|[Attitude and Guidance](artificial-horizon.md)|
+|[Altitude Indicator](altitude-indicator.md)|
+|[Barometric Reference](baro-ref.md)|
+|[Heading Reference Line and Scale](heading-ref.md)|
+|[Vertical Speed indicator](vertical-speed.md)|
+|[Flags and Messages](flags-messages.md)|

--- a/docs/pilots-corner/advanced-guides/overview.md
+++ b/docs/pilots-corner/advanced-guides/overview.md
@@ -1,3 +1,5 @@
+<link rel="stylesheet" href="../../../stylesheets/toc-tables.css">
+
 # Overview
 
 Welcome to the A32NX Advanced Guides.
@@ -21,10 +23,12 @@ Each page was reviewed by an A320 type rated pilot and provides accurate informa
 
 ## Topics:
 
-- [Flight Phases](flight-phases.md)
-- [Flight Planning](flight-planning/fixinfo.md)
-- [Flight Guidance](flight-guidance/overview.md)
-- [Protections](protections/overview.md)
+| Quick Links                                    |
+| :-----                                         |
+| [Flight Phases](flight-phases.md)              |
+| [Flight Planning](flight-planning/fixinfo.md)  |
+| [Flight Guidance](flight-guidance/overview.md) |
+| [Protections](protections/overview.md)         |
 <!--- [Data Management](data-management.md)-->
 
 ---

--- a/docs/pilots-corner/airliner-flying-guide/overview.md
+++ b/docs/pilots-corner/airliner-flying-guide/overview.md
@@ -1,3 +1,5 @@
+<link rel="stylesheet" href="../../../stylesheets/toc-tables.css">
+
 # Overview
 
 This is a rough basic guide to general airliner terminology and flying techniques that can be generally applied to most aircraft in the simulator, with a focus towards the Airbus A320 Family and the FBW A32NX add-on.
@@ -8,12 +10,9 @@ Author Credit: *Shomas on Discord (A320 Pilot)*
 
 ---
 
-Topics:
-
-[Types of Approaches](approaches.md)
-
-[Navigation](navigation.md)
-
-[Understanding Altitude References](altitude-refs.md)
-
-[METARs/TAFs/ATIS](weather.md)
+| Topics                                                |
+| :-----                                                |
+| [Types of Approaches](approaches.md)                  |
+| [Navigation](navigation.md)                           |
+| [Understanding Altitude References](altitude-refs.md) |
+| [METARs/TAFs/ATIS](weather.md)                        |

--- a/docs/pilots-corner/beginner-guide/overview.md
+++ b/docs/pilots-corner/beginner-guide/overview.md
@@ -1,3 +1,5 @@
+<link rel="stylesheet" href="../../../stylesheets/toc-tables.css">
+
 # Overview
 
 Welcome to the A32NX Beginner's Guide. Although this guide is tailored towards beginners, each topic below may even serve as reminders of proper procedure at different stages of flight for veteran sim pilots.
@@ -17,27 +19,18 @@ The [Preflight](preflight.md) page contains guides on how to set up relevant dat
 
 ---
 
-Topics:
-
-[Preflight](preflight.md)
-
-[Starting the Aircraft](starting-the-aircraft.md)
-
-[Preparing the MCDU](preparing-mcdu.md)
-
-[Engine Start and Taxi](engine-start-taxi.md)
-
-[Takeoff, Climb and Cruise](takeoff-climb-cruise.md)
-
-[Descent Planning and Descent](descent.md)
-
-[Approach and ILS Landing](landing.md)
-
-[After Landing and Taxi to Gate](after-landing.md)
-
-[Powering Down](powering-down.md)
-
-[Abbreviations](abbreviations.md)
+| Topics                                               |
+| :-----                                               |
+| [Preflight](preflight.md)                            |
+| [Starting the Aircraft](starting-the-aircraft.md)    |
+| [Preparing the MCDU](preparing-mcdu.md)              |
+| [Engine Start and Taxi](engine-start-taxi.md)        |
+| [Takeoff, Climb and Cruise](takeoff-climb-cruise.md) |
+| [Descent Planning and Descent](descent.md)           |
+| [Approach and ILS Landing](landing.md)               |
+| [After Landing and Taxi to Gate](after-landing.md)   |
+| [Powering Down](powering-down.md)                    |
+| [Abbreviations](abbreviations.md)                    |
 
 ---
 

--- a/docs/pilots-corner/index.md
+++ b/docs/pilots-corner/index.md
@@ -1,3 +1,5 @@
+<link rel="stylesheet" href="../../stylesheets/toc-tables.css">
+
 # Pilot's Corner Overview
 
 Welcome to the Pilot's Corner of the FlyByWire Documentation site.
@@ -12,8 +14,10 @@ This section is aimed at sim pilots of all levels and covers topics regarding fl
 
 ##  Topics
 
-- [Beginner Guide](beginner-guide/overview.md)
-- [Advanced Guides](advanced-guides/overview.md)
-- [Airliner Flying Guide](airliner-flying-guide/overview.md)
-- [A320neo Pilot Briefing](a32nx-briefing/index.md)
-- [Standard Operating Procedures](SOP.md)
+| Featured List                                              |
+| :---                                                       |
+| [Beginner Guide](beginner-guide/overview.md)               |
+| [Advanced Guides](advanced-guides/overview.md)             |
+| [Airliner Flying Guide](airliner-flying-guide/overview.md) |
+| [A320neo Pilot Briefing](a32nx-briefing/index.md)          |
+| [Standard Operating Procedures](SOP.md)                    |

--- a/docs/stylesheets/toc-tables.css
+++ b/docs/stylesheets/toc-tables.css
@@ -1,0 +1,16 @@
+/*Table Styling*/
+.md-typeset table:not([class]) th {
+  font-weight: bold;
+  background-color: #00C2CB;
+  color: var(--md-default-bg-color);
+  font-size: larger;
+  padding: .75em;
+  text-align: center;
+}
+/* reduced table row height */
+.md-typeset table:not([class]) td {
+  border-top: .05rem solid var(--md-default-fg-color--lightest);
+  padding: .75em 1.25em;
+  vertical-align: top;
+  font-size: initial;
+}


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
- Changes the style of how we do "quick links" or on-page table of contents. Helps with mobile users and also a cleaner look over using `.md-button` or a Markdown list for the topics included in a section.
- Updated code blocks to have an associated title (to set a standard) and define what type of file if required.
- Includes a new stylesheet `toc-tables.css` to override the main table styling site-wide.
- **Additional out-of-scope change**: updated the simulated list on the FBW Overview Page

### Notes / TODO
- Decided not to use the new format for the beginner guide.
- [x] Finish other pages that require style changes
- [x] Double-check untitled code blocks

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
This PR touches every **overview** page with a topics list and any subsection that has a topics list.

### Sample Images
![pr sample 2](https://user-images.githubusercontent.com/1619968/154141422-5d1b9735-1cc2-408f-97a8-74cbf23a9765.png)
![PR sample 1](https://user-images.githubusercontent.com/1619968/154141563-f38caaed-f9d2-4e7a-91b4-0211f0fefa44.png)

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
