### PR TITLE
feat: configure search-exclusions + associated cleanup

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/.pages
+++ b/docs/pilots-corner/a32nx-briefing/.pages
@@ -1,7 +1,7 @@
 title: A320neo Pilot Briefing
 nav:
   - Overview: index.md
-  - flight-deck
+  - Flight Deck: flight-deck
   - a32nx_api.md
   - ecam
   - pfd

--- a/docs/pilots-corner/a32nx-briefing/tbd.md
+++ b/docs/pilots-corner/a32nx-briefing/tbd.md
@@ -1,4 +1,0 @@
-# This chapter is currently in development
-
-!!! info "Coming soon"
-    This chapter is currently in development.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ plugins:
         - pilots-corner/advanced-guides/flight-planning/holds.md
         - pilots-corner/advanced-guides/flight-planning/fplan.md
         - pilots-corner/advanced-guides/flight-planning/offset.md
+        - pilots-corner/advanced-guides/flight-planning/overview.md
         - pilots-corner/advanced-guides/flight-guidance/approaches.md
         - pilots-corner/advanced-guides/flight-guidance/autopilot.md
         - pilots-corner/advanced-guides/flight-guidance/lnav.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,15 @@ theme:
 plugins:
   - search:
       lang: en
+  - exclude-search:
+      exclude:
+        - pilots-corner/advanced-guides/flight-planning/holds.md
+        - pilots-corner/advanced-guides/flight-planning/fplan.md
+        - pilots-corner/advanced-guides/flight-planning/offset.md
+        - pilots-corner/advanced-guides/flight-guidance/approaches.md
+        - pilots-corner/advanced-guides/flight-guidance/autopilot.md
+        - pilots-corner/advanced-guides/flight-guidance/lnav.md
+        - pilots-corner/advanced-guides/flight-guidance/vnav.md
   - awesome-pages
   - git-revision-date-localized:
       type: date

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ mkdocs-material==8.2.1
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects
+mkdocs-exclude-search


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
**Adds new plugin mkdocs-exclude-search**. Please locally update `requirements.txt` for future builds or locally checking out this PR.

Without access to mkdocs-material insiders branch this is an alternative method to delist empty pages from showing up in the search bar. Reported in #chat certain empty pages like "Holds" would be discoverable from the search bar. 

The config is located in mkdocs.yml and currently contained to only advanced-guides placeholder *.md files. This should help keep the repo indicative of pages already in place but also prevent them from showing up in the search bar. 

The awesome-pages `.pages` is unaffected and navigation exclusion should remain constant. 

---

PR also removed an empty tbd.md and cleans up one of the `.pages` files in pilots briefing. 

**Note:** Requires any updated pages to be removed from the search exclusion when they are ready in the future.

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
- pilots-corner/advanced-guides/flight-planning/
- pilots-corner/advanced-guides/flight-guidance/
- mkdocs.yml
- docs/pilots-corner/a32nx-briefing/.pages
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
