### PR TITLE
feat: create dedicated audio page

### DIFF
--- a/docs/fbw-a32nx/feature-guides/audio.md
+++ b/docs/fbw-a32nx/feature-guides/audio.md
@@ -26,7 +26,7 @@ If this setting is enabled the following crew announcements are played.
 | Trigger                                    | Audio Played                                    |     Speaker      |
 |:-------------------------------------------|:------------------------------------------------|:----------------:|
 | Boarding Completed                         | "Boarding Completed" announcement               | Flight Attendant |
-| Boarding Completed + 30s                   | Captain makes a "welcome on board" announcement |     Captain      |
+| Boarding Completed + 30s                   | Captain makes a "Welcome on Board" announcement |     Captain      |
 | Beacon Light set to `ON`                   | "Arm Doors" Announcement                        | Flight Attendant |
 | "Arm Doors" Announcement + 30s             | Safety Demo                                     | On-Board System  |
 | Landing Lights set to `ON`                 | "Prepare for Takeoff" Announcement              |     Captain      |

--- a/docs/fbw-a32nx/feature-guides/audio.md
+++ b/docs/fbw-a32nx/feature-guides/audio.md
@@ -26,6 +26,9 @@ If this setting is enabled the following ambience sounds are played:
 
 ### Announcements
 
+!!! important "Customizations"
+    Due to limitations with MSFS audio configurations adding user customizable announcements/sounds is not easily possible at this time.
+
 If this setting is enabled the following crew announcements are played.
 
 | Trigger                                    | Audio Played                                    |     Speaker      |

--- a/docs/fbw-a32nx/feature-guides/audio.md
+++ b/docs/fbw-a32nx/feature-guides/audio.md
@@ -27,7 +27,7 @@ If this setting is enabled the following ambience sounds are played:
 ### Announcements
 
 !!! important "Customizations"
-    Due to limitations with MSFS audio configurations adding user customizable announcements/sounds is not easily possible at this time.
+    Due to limitations with MSFS audio configurations adding user customizable announcements/sounds is not easily possible.
 
 If this setting is enabled the following crew announcements are played.
 

--- a/docs/fbw-a32nx/feature-guides/audio.md
+++ b/docs/fbw-a32nx/feature-guides/audio.md
@@ -32,8 +32,8 @@ If this setting is enabled the following crew announcements are played.
 | Landing Lights set to `ON`                 | "Prepare for Takeoff" Announcement              |     Captain      |
 | Enter **Cruise Phase** + 30s               | "Cruise" Announcement                           |     Captain      |
 | Enter **Descent Phase** + 30s              | "Descent" Announcement                          |     Captain      |
-| Gear Down + **Approach Phase** Active      | "Prepare for Landing" Announcement              |       ???        |
-| **Done Phase** + Beacon Light set to `OFF` | "Disarm Doors" Announcement                     |       ???        |
+| Gear Down + **Approach Phase** Active      | "Prepare for Landing" Announcement              |     Captain      |
+| **Done Phase** + Beacon Light set to `OFF` | "Disarm Doors" Announcement                     | Flight Attendant |
 
 ### Boarding Music
 If enabled music will be played during boarding.

--- a/docs/fbw-a32nx/feature-guides/audio.md
+++ b/docs/fbw-a32nx/feature-guides/audio.md
@@ -1,0 +1,36 @@
+# Audio Configuration
+
+This page provides an overview of the various audio settings available in the A32NX and their respective functions.
+
+- PTU Audible in Cockpit (unrealistic):
+    - Allows the PTU to be heard in the cockpit which in real life is not the case. But many people are used to this sound as it is very audible in the passenger cabin.
+
+- Exterior Master Volume:
+    - Volume for sounds audible when in external views.
+
+- Engine Interiors Sounds:
+    - Volume for engine sounds when in interior views.
+
+- Wind Interior Volume:
+    - Volume for wind sounds when in interior views.
+
+- Passenger Ambience
+    - If this setting is enabled the following ambience sounds are played:
+        - Boarding sound begins when the W/B in `MCDU-ATSU-AOC-W&B` boarding is started.
+        - Once passengers are on the plane, a constant passenger ambience sound plays.
+        - Deboarding through the the W/B section in `MCDU-ATSU-AO-W&B` triggers the deboarding sound.
+
+- Announcements
+    - If this setting is enabled the following crew announcements are played:
+        - When boarding is finished, the flight attendant says "boarding completed."
+        - 30 seconds after "boarding completed", the captain makes a "welcome on board" announcement.
+        - Beacon light triggers the FA "arm doors" announcement
+        - 30 seconds after the "arm doors" announcement a safety demo is played.
+        - Turning on the Landing Lights before take off triggers the "prepare for takeoff" announcement.
+        - 30 seconds after entering **Cruise Phase** the captain makes a cruise announcement.
+        - 30 seconds after entering **Descent Phase** the captain makes a descent announcement.
+        - Gear down and being in **Approach Phase** phase triggers the "prepare for landing" announcement.
+        - Being in the **Done Phase** (after landing) and deactivating the Beacon light triggers the "disarm doors" announcement.
+
+- Boarding Music
+    - If enabled music will be playing during boarding.

--- a/docs/fbw-a32nx/feature-guides/audio.md
+++ b/docs/fbw-a32nx/feature-guides/audio.md
@@ -4,9 +4,9 @@ This page provides an overview of the various audio settings available in the A3
 
 These settings can be found on the EFB:
 
-![EFB Audio Settings](#)
+![EFB Audio Settings](../assets/flypad/flypad-settings-audio.png)
 
-For information on the other settings available on the EFB visit our [flyPad Settings](#) page.
+For information on the other settings available on the EFB visit our [flyPad Settings](flyPad/settings.md) page.
 
 ## Passenger Simulation
 
@@ -38,8 +38,15 @@ If this setting is enabled the following crew announcements are played.
 ### Boarding Music
 If enabled music will be played during boarding.
 
-- PTU Audible in Cockpit (unrealistic):
-    - Allows the PTU to be heard in the cockpit which in real life is not the case. But many people are used to this sound as it is very audible in the passenger cabin.
+## Realism
+
+### PTU
+
+The PTU is generally not heard in the cockpit. As a passenger we understand people may be used to this sound as it is very audible in the passenger cabin.
+
+We have added a toggle to allow the PTU to be heard in the cockpit which in real life is not the case. 
+
+## Engine and Wind
 
 - Exterior Master Volume:
     - Volume for sounds audible when in external views.

--- a/docs/fbw-a32nx/feature-guides/audio.md
+++ b/docs/fbw-a32nx/feature-guides/audio.md
@@ -2,6 +2,42 @@
 
 This page provides an overview of the various audio settings available in the A32NX and their respective functions.
 
+These settings can be found on the EFB:
+
+![EFB Audio Settings](#)
+
+For information on the other settings available on the EFB visit our [flyPad Settings](#) page.
+
+## Passenger Simulation
+
+We have included various settings that provide flight crew simulation with passengers on board.
+
+### Passenger Ambience
+If this setting is enabled the following ambience sounds are played:
+
+- Boarding sound begins when the W/B in `MCDU-ATSU-AOC-W&B` boarding is started.
+- Once passengers are on the plane, a constant passenger ambience background sound plays.
+- Deboarding through the the W/B section in `MCDU-ATSU-AO-W&B` triggers the deboarding sound.
+
+### Announcements
+
+If this setting is enabled the following crew announcements are played.
+
+| Trigger                                    | Audio Played                                    |     Speaker      |
+|:-------------------------------------------|:------------------------------------------------|:----------------:|
+| Boarding Completed                         | "Boarding Completed" announcement               | Flight Attendant |
+| Boarding Completed + 30s                   | Captain makes a "welcome on board" announcement |     Captain      |
+| Beacon Light set to `ON`                   | "Arm Doors" Announcement                        | Flight Attendant |
+| "Arm Doors" Announcement + 30s             | Safety Demo                                     | On-Board System  |
+| Landing Lights set to `ON`                 | "Prepare for Takeoff" Announcement              |     Captain      |
+| Enter **Cruise Phase** + 30s               | "Cruise" Announcement                           |     Captain      |
+| Enter **Descent Phase** + 30s              | "Descent" Announcement                          |     Captain      |
+| Gear Down + **Approach Phase** Active      | "Prepare for Landing" Announcement              |       ???        |
+| **Done Phase** + Beacon Light set to `OFF` | "Disarm Doors" Announcement                     |       ???        |
+
+### Boarding Music
+If enabled music will be played during boarding.
+
 - PTU Audible in Cockpit (unrealistic):
     - Allows the PTU to be heard in the cockpit which in real life is not the case. But many people are used to this sound as it is very audible in the passenger cabin.
 
@@ -13,24 +49,3 @@ This page provides an overview of the various audio settings available in the A3
 
 - Wind Interior Volume:
     - Volume for wind sounds when in interior views.
-
-- Passenger Ambience
-    - If this setting is enabled the following ambience sounds are played:
-        - Boarding sound begins when the W/B in `MCDU-ATSU-AOC-W&B` boarding is started.
-        - Once passengers are on the plane, a constant passenger ambience sound plays.
-        - Deboarding through the the W/B section in `MCDU-ATSU-AO-W&B` triggers the deboarding sound.
-
-- Announcements
-    - If this setting is enabled the following crew announcements are played:
-        - When boarding is finished, the flight attendant says "boarding completed."
-        - 30 seconds after "boarding completed", the captain makes a "welcome on board" announcement.
-        - Beacon light triggers the FA "arm doors" announcement
-        - 30 seconds after the "arm doors" announcement a safety demo is played.
-        - Turning on the Landing Lights before take off triggers the "prepare for takeoff" announcement.
-        - 30 seconds after entering **Cruise Phase** the captain makes a cruise announcement.
-        - 30 seconds after entering **Descent Phase** the captain makes a descent announcement.
-        - Gear down and being in **Approach Phase** phase triggers the "prepare for landing" announcement.
-        - Being in the **Done Phase** (after landing) and deactivating the Beacon light triggers the "disarm doors" announcement.
-
-- Boarding Music
-    - If enabled music will be playing during boarding.

--- a/docs/fbw-a32nx/feature-guides/audio.md
+++ b/docs/fbw-a32nx/feature-guides/audio.md
@@ -10,6 +10,11 @@ For information on the other settings available on the EFB visit our [flyPad Set
 
 ## Passenger Simulation
 
+!!! important "Cockpit Door"
+    The cockpit door in the A32NX is simulating a real A320 cockpit door which in consequence dampens most of the sounds from the passenger cabin. 
+
+    If you want to enjoy the Passenger Ambience sounds make sure it is open. 
+
 We have included various settings that simulate flight crew interactions with passengers on board.
 
 ### Passenger Ambience
@@ -17,7 +22,7 @@ If this setting is enabled the following ambience sounds are played:
 
 - Boarding sound begins when the W/B in `MCDU-ATSU-AOC-W&B` boarding is started.
 - Once passengers are on the plane, a constant passenger ambience background sound plays.
-- Deboarding through the the W/B section in `MCDU-ATSU-AO-W&B` triggers the deboarding sound.
+- Deboarding through the W/B section in `MCDU-ATSU-AO-W&B` triggers the deboarding sound.
 
 ### Announcements
 

--- a/docs/fbw-a32nx/feature-guides/audio.md
+++ b/docs/fbw-a32nx/feature-guides/audio.md
@@ -10,7 +10,7 @@ For information on the other settings available on the EFB visit our [flyPad Set
 
 ## Passenger Simulation
 
-We have included various settings that provide flight crew simulation with passengers on board.
+We have included various settings that simulate flight crew interactions with passengers on board.
 
 ### Passenger Ambience
 If this setting is enabled the following ambience sounds are played:
@@ -38,7 +38,7 @@ If this setting is enabled the following crew announcements are played.
 ### Boarding Music
 If enabled music will be played during boarding.
 
-## Realism
+## Realism Settings
 
 ### PTU
 

--- a/docs/fbw-a32nx/feature-guides/flyPad/settings.md
+++ b/docs/fbw-a32nx/feature-guides/flyPad/settings.md
@@ -240,38 +240,7 @@ Settings for various audio sources and sounds.
     <span class="imagesub">Click on the menu icons in this image to see other flyPad pages.</span>
 </div>
 
-- PTU Audible in Cockpit (unrealistic):
-    - Allows the PTU to be heard in the cockpit which in real life is not the case. But many people are used to this sound as it is very audible in the passenger cabin.
-
-- Exterior Master Volume:
-    - Volume for sounds audible when in external views.
-
-- Engine Interiors Sounds:
-    - Volume for engine sounds when in interior views.
-
-- Wind Interior Volume:
-    - Volume for wind sounds when in interior views.
-
-- Passenger Ambience
-    - If this setting is enabled the following ambience sounds are played:
-        - Boarding sound begins when the W/B in `MCDU-ATSU-AOC-W&B` boarding is started.
-        - Once passengers are on the plane, a constant passenger ambience sound plays.
-        - Deboarding through the the W/B section in `MCDU-ATSU-AO-W&B` triggers the deboarding sound.
-
-- Announcements
-    - If this setting is enabled the following crew announcements are played:
-        - When boarding is finished, the flight attendant says "boarding completed."
-        - 30 seconds after "boarding completed", the captain makes a "welcome on board" announcement.
-        - Beacon light triggers the FA "arm doors" announcement
-        - 30 seconds after the "arm doors" announcement a safety demo is played.
-        - Turning on the Landing Lights before take off triggers the "prepare for takeoff" announcement.
-        - 30 seconds after entering **Cruise Phase** the captain makes a cruise announcement.
-        - 30 seconds after entering **Descent Phase** the captain makes a descent announcement.
-        - Gear down and being in **Approach Phase** phase triggers the "prepare for landing" announcement.
-        - Being in the **Done Phase** (after landing) and deactivating the Beacon light triggers the "disarm doors" announcement.
-
-- Boarding Music
-    - If enabled music will be playing during boarding.
+For detailed information on these settings please visit the [Audio Configuration](../audio.md) page.
 
 ## flyPad Settings
 

--- a/docs/fbw-a32nx/feature-guides/flyPad/settings.md
+++ b/docs/fbw-a32nx/feature-guides/flyPad/settings.md
@@ -240,7 +240,20 @@ Settings for various audio sources and sounds.
     <span class="imagesub">Click on the menu icons in this image to see other flyPad pages.</span>
 </div>
 
-For detailed information on these settings please visit the [Audio Configuration](../audio.md) page.
+For detailed information on these settings please visit: 
+
+[Audio Configuration Page](../audio.md){.md-button target=new}
+
+- Toggle ON/OFF - PTU Audible in Cockpit (unrealistic)
+
+- Volume Sliders
+    - Dynamically adjust various audio elements while in the virtual cockpit  
+
+- Toggle ON/OFF - Various Passenger Ambience Sounds
+
+- Toggle ON/OFF - Announcements in Flight
+
+- Toggle ON/OFF - Boarding Music
 
 ## flyPad Settings
 

--- a/docs/fbw-a32nx/feature-guides/flyPad/settings.md
+++ b/docs/fbw-a32nx/feature-guides/flyPad/settings.md
@@ -240,10 +240,6 @@ Settings for various audio sources and sounds.
     <span class="imagesub">Click on the menu icons in this image to see other flyPad pages.</span>
 </div>
 
-For detailed information on these settings please visit: 
-
-[Audio Configuration Page](../audio.md){.md-button target=new}
-
 - Toggle ON/OFF - PTU Audible in Cockpit (unrealistic)
 
 - Volume Sliders
@@ -254,6 +250,10 @@ For detailed information on these settings please visit:
 - Toggle ON/OFF - Announcements in Flight
 
 - Toggle ON/OFF - Boarding Music
+
+For detailed information on these settings please visit:
+
+[Audio Configuration Page](../audio.md){.md-button}
 
 ## flyPad Settings
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
As discussed in the docs channel separate audio from the flypad settings guide and create a dedicated page. 

Should allow for easier expansion and users can find / read information in a more targeted format.

### Location
- feature-guides/audiomd

![image](https://user-images.githubusercontent.com/1619968/157364971-30f7baa0-554e-419c-b816-74df8969b2e5.png)

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
