### PR TITLE
fix: Fixed "Anti Ice" typos on Flight Deck and API Docs

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/a32nx_api.md
+++ b/docs/pilots-corner/a32nx-briefing/a32nx_api.md
@@ -335,7 +335,7 @@ Flight Deck: [AC Panel](flight-deck/ovhd/ac.md)
 | RAM AIR        | A32NX_AIRCOND_RAMAIR_TOGGLE_LOCK                          | 0 \| 1 | R          | Custom LVAR | Switch Guard |
 |                | A32NX_AIRCOND_RAMAIR_TOGGLE                               | 0 \| 1 | R/W        | Custom LVAR |              |
 
-### Anit Ice Panel
+### Anti Ice Panel
 
 Flight Deck: [Anti Ice Panel](flight-deck/ovhd/anti-ice.md)
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/anti-ice.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/anti-ice.md
@@ -8,7 +8,7 @@
 
 ![Anti Ice Panel](../../../assets/a32nx-briefing/overhead-panel/Anti-Ice-Panel.jpg "Anti Ice Panel")
 
-!!! note "API Documentation: [Anit Ice Panel API](../../a32nx_api.md#anit-ice-panel)"
+!!! note "API Documentation: [Anti Ice Panel API](../../a32nx_api.md#anti-ice-panel)"
 
 ---
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
Fixed Anti Ice misspelling on 2 documents.

1. The first document is the overhead panel overview for the Anti Ice Panel, on this page the API documentation link is misspelled as `API Documentation: Anit Ice Panel API` which is then linked to the API Documentation on the Anti Ice Panel.

2. The second document is the API Documentation, where the header for the Anti Ice Panel is also misspelled as `Anit Ice Panel`
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/flight-deck/ovhd/anti-ice/
https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/a32nx_api/#anit-ice-panel

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Rare Potato#9693
