### PR TITLE
style: customize info and note in admonitions.css

### DIFF
--- a/docs/stylesheets/admonitions.css
+++ b/docs/stylesheets/admonitions.css
@@ -48,3 +48,38 @@
 .md-typeset .block > summary::before {
   height: 0rem;
 }
+/*Established Admonitions Changes*/
+/*Info*/
+.md-typeset :is(.admonition,details):is(.info) {
+    border-color: #00E0FE;
+}
+.md-typeset :is(.info)>:is(.admonition-title,summary) {
+    border-color: #00E0FE;
+    background-color: rgba(0,224,254,.1);
+}
+.md-typeset :is(.info,.todo)>:is(.admonition-title,summary):before {
+    background-color: #00E0FE;
+    -webkit-mask-image: var(--md-admonition-icon--info);
+    mask-image: var(--md-admonition-icon--info);
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+}
+/*Note*/
+.md-typeset :is(.admonition,details):is(.note) {
+    border-color: #00E0FE;
+}
+.md-typeset :is(.note)>:is(.admonition-title,summary) {
+    border-color: #00E0FE;
+    background-color: rgba(0,224,254,.1);
+}
+.md-typeset :is(.note)>:is(.admonition-title,summary):before {
+    background-color: #00E0FE;
+    -webkit-mask-image: var(--md-admonition-icon--note);
+    mask-image: var(--md-admonition-icon--note);
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+}


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
Correctly style the adomnitions for `note` and `info` to match new branding.
```css
    border-color: #00E0FE;
    background-color: rgba(0,224,254,.1);
```
![image](https://user-images.githubusercontent.com/1619968/157509113-bfca9384-4072-4bb8-8efc-0de01a8a51de.png)

### Location
- docs/stylesheets/admonitions.css

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
