### PR TITLE
refactor: references to #support channel to #a32nx-support

### DIFF
--- a/docs/fbw-a32nx/faq.md
+++ b/docs/fbw-a32nx/faq.md
@@ -32,7 +32,7 @@
     No, it is a completely free aircraft, open-source.
 
 ??? info "Q: How do we report bugs?"
-    Report bugs to us in the [Discord server](https://discord.gg/flybywire){target=new}, under the `#support` channel, or by creating a [GitHub issue](https://github.com/flybywiresim/a32nx/issues/new/choose){target=new}.
+    Report bugs to us in the [Discord server](https://discord.gg/flybywire){target=new}, under the `#a32nx-support` channel, or by creating a [GitHub issue](https://github.com/flybywiresim/a32nx/issues/new/choose){target=new}.
 
     Just make sure to search for existing issues first before creating a new one.
 

--- a/docs/fbw-a32nx/feature-guides/index.md
+++ b/docs/fbw-a32nx/feature-guides/index.md
@@ -4,7 +4,7 @@
 
 This section is dedicated to guides for specific features and functionalities of the FlyByWire A32NX.
 
-It is not a complete collection of all features but a growing list which is extended when we feel the need to explain a feature in more detail due to complexity or due to frequent inquiries on our Discord #support channel.
+It is not a complete collection of all features but a growing list which is extended when we feel the need to explain a feature in more detail due to complexity or due to frequent inquiries on our Discord #a32nx-support channel.
 
 | Quick Links                                            |
 | : ----------------                                     |

--- a/docs/fbw-a32nx/support/index.md
+++ b/docs/fbw-a32nx/support/index.md
@@ -54,7 +54,7 @@ Read the [Reported Issues](reported-issues.md) section - most issues users encou
 
 If you have a github account please also see [Issues](https://github.com/flybywiresim/a32nx/issues){target=new} there. Please also use the search for your particular issue.
 
-Join our Discord server [:fontawesome-brands-discord:{: .discord } - **Discord Link**](https://discord.gg/flybywire){target=new} in channel #support and do the following:
+Join our Discord server [:fontawesome-brands-discord:{: .discord } - **Discord Link**](https://discord.gg/flybywire){target=new} in channel #a32nx-support and do the following:
 
 - Read the Pinned Messages for commonly reported issues
 
@@ -64,7 +64,7 @@ Join our Discord server [:fontawesome-brands-discord:{: .discord } - **Discord L
 
     ![Sticky-Message](../assets/support-guide/Sticky-Message.png "Sticky-Message")
 
-- Search in the #support channel for similar issues other users have reported.
+- Search in the #a32nx-support channel for similar issues other users have reported.
 
     ![Search-support](../assets/support-guide/Search-support.png "Search-support")
 
@@ -72,7 +72,7 @@ Join our Discord server [:fontawesome-brands-discord:{: .discord } - **Discord L
 
 ## 4. Report Issue on Discord
 
-If you can't solve or find your issue with the above steps, you can use our [:fontawesome-brands-discord:{: .discord } - **Discord**](https://discord.gg/flybywire){target=new} **#support** channel to get further help.
+If you can't solve or find your issue with the above steps, you can use our [:fontawesome-brands-discord:{: .discord } - **Discord**](https://discord.gg/flybywire){target=new} **#a32nx-support** channel to get further help.
 
 Please prepare the following before reporting any issues:
 
@@ -81,7 +81,7 @@ Please prepare the following before reporting any issues:
 - [Community Folder Content](#community-folder-content)
 - [Screenshot of Cockpit](#screenshot-of-cockpit)
 
-With this information at hand go to our Discord  [:fontawesome-brands-discord:{: .discord } - **Discord**](https://discord.gg/flybywire){target=new} **#support** channel and
+With this information at hand go to our Discord  [:fontawesome-brands-discord:{: .discord } - **Discord**](https://discord.gg/flybywire){target=new} **#a32nx-support** channel and
 describe your issue and respond to the questions our support team might have.
 
 !!! warning "Please do some research (see [above](#3-research-known-issues) ) before you post any questions or report any issues."

--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -84,7 +84,7 @@ TEMPLATE
     
     ^^Additional Information / Workaround^^
     
-    Please complete the steps below to perform a workaround and/or send us screenshot in our #support channel.
+    Please complete the steps below to perform a workaround and/or send us screenshot in our #a32nx-support channel.
     
     ```title="Support Screenshot of PFD_TEMPLATE"
     1. Pause your sim using ESC
@@ -92,7 +92,7 @@ TEMPLATE
     3. Go to `http://localhost:19999/` OR `http://127.0.0.1:19999/`
     4. Click on the first link that says "PFD_TEMPLATE"
     5. On the page that appears, click on the "Console" tab
-    6. Send a screenshot to our #support channel on Discord
+    6. Send a screenshot to our #a32nx-support channel on Discord
     ```
 
     **Workaround:** Once you've completed the steps above before sending a screenshot of the issue you can try refreshing the system by clicking on the reload button near the top of the page displayed. After clicking the refresh button return to your simulator. 

--- a/docs/pilots-corner/a32nx-briefing/a32nx_api.md
+++ b/docs/pilots-corner/a32nx-briefing/a32nx_api.md
@@ -16,7 +16,7 @@ hide:
 
     You can help us keep this up to date and improve this by reporting any errors
     or omissions on our [:fontawesome-brands-discord:{: .discord } - **Discord**](https://discord.gg/flybywire){target=new}
-    in the **#support** channel or by creating an issue report here: [Docs Issues](https://github.com/flybywiresim/docs/issues){target=new}.
+    in the **#a32nx-support** channel or by creating an issue report here: [Docs Issues](https://github.com/flybywiresim/docs/issues){target=new}.
 
 Find the complete list of Custom Event and Custom LVARS of the A32NX:
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
As discussed by support-ops this PR fixes all #support channel references to support the new channel name #a32nx-support.

### Location
Site wide

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
