### PR TITLE
fix: correct support guide navigation title

### DIFF
--- a/docs/fbw-a32nx/support/.pages
+++ b/docs/fbw-a32nx/support/.pages
@@ -5,7 +5,7 @@
 
 title: Support
 nav:
-    - index.md
+    - Support Guide: index.md
     - reported-issues.md
     - performance-tips.md
     - ...


### PR DESCRIPTION
fixes: #487 

## Summary
- Uses `Support Guide: index.md` so the navigation has the correct title instead of issue shown in #487

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
