### PR TITLE
style(fix): font import for firefox compatibility

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,4 +1,4 @@
-@import url(https://fonts.googleapis.com/css2?family=Manrope&display=swap);
+@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600&display=swap');
 
 /*Primary Thematic Colors*/
 :root {


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
User and team reports of `Manrope` font not displaying properly on Firefox. This PR should fix it by adding additional weights to the google font `@import`.

Side by side comparison of Production / Local Dev (respectively):
![image](https://user-images.githubusercontent.com/1619968/159205454-8f192d41-fb6a-4a77-b814-302749c3d79c.png)


### Location
- docs/stylesheets/extra.css

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
