### PR TITLE
docs(exp): update page with new testing information

### DIFF
--- a/docs/fbw-a32nx/fbw-versions.md
+++ b/docs/fbw-a32nx/fbw-versions.md
@@ -27,11 +27,14 @@ This version will not always be up to date but we work hard at ensuring its comp
 
 This version is similar to the development version, but contains custom systems in earlier development phases.
 
-Currently, experimental is undergoing updates that can break the aircraft and is not 100% ready for public use. It is not meant to be used for daily use or when you try to do a serious flight on VATSIM.
+We use this version to find problems, issues and to improve functionality based on your feedback. It is not meant to be used for daily use or when you try to do a serious flight on VATSIM.
 
 !!! warning
 
-The Experimental version has a less strict QA process and is used for actual QA testing. Bugs and Issues are to be expected. Please read [Experimental Version Support Page](support/exp.md) before using this version. 
+The Experimental version has a less strict QA process and is used for actual QA testing. Bugs and Issues are to be expected. 
+
+!!! danger ""
+    Before using this version please read [Experimental Version Support Page](support/exp.md) to see what is currently being tested. 
 
 The experimental version will be updated regularly and also with the latest changes to the Development version. Expect updates about once a week (not guaranteed).
 

--- a/docs/fbw-a32nx/support/exp.md
+++ b/docs/fbw-a32nx/support/exp.md
@@ -4,42 +4,59 @@ The Experimental version is a test version to find problems and issues and to im
 
 {--
 
-**Currently experimental is undergoing updates that can break the aircraft and is not 100% ready for public use. All previous features have been moved to our development version. Please see below for features planned for testing.**
+**Currently experimental is geared toward testing the initial version of VNAV. Please use the appropriate discord thread #exp-vnav-reporting to discuss any issues.**
 
 --}
 
 !!! danger "No Support for Experimental - use at own risk"
     Please do not seek support for the Experimental Version on Discord and only report issues if you have read this page and the reported and known issues.
 
-## Planned Feature Testing
+## Implemented Features for Testing
 
-- New PFD based on MSFS Avoinics framework
-- Improved FLARE law (*highly experimental and may not be included*)
-- Improved stringing logic
-- Coarse LNAV speed predictions
-- Hydraulic elevator/rudder control
+- Speed and altitude predictions in the flight plan page, including magenta or amber asterisks.
+- Reworked fuel burn and time predictions in the flight plan page (no flight plan B page).
+- Pseudowaypoints in the flight plan (SPD/LIM, T/C, T/D, S/C, S/D, DECEL).
+- Display of pseudowaypoints on the ND (T/C, T/D, predicted speed changes, etc.)
+- Partial implementation of step climbs/descent.
+- Linear deviation indication during the descent.
+- Following of speed and altitude constraints in the climb phase (credits to tracernz).
+- Partial implementation of descent guidance.
+- Ability to enter winds for climb, cruise, and descent.
+
+## Known Issues
+
+- LNAV does not use VNAV speed predictions yet. This means that an approach path will not be forecasted properly. Furthermore, the T/D (Top of Descent) could be misplaced, since the system expects more track miles.
+- The descent guidance does not use the speed margins properly yet. The aircraft does not speed up to catch a profile below it.
+- The linear deviation indication (green "yoyo") on the PFD might jump around during the descent. This effect is particularly noticable when new waypoints are sequenced.
+- Layout inaccuracies in the MCDU, mostly on the PERF page.
+- Predicted speed changes in the descent might seem to show up erratically. The same for the level off arrow while in descent mode.
+- Fuel predictions in the MCDU are not very accurate.
+- Descent guidance is sensitive to QNH changes. This is partially due to an inaccuracy in MSFS' atmospheric model.
+- Winds are not yet taken into account for all phases of flight.
 
 ## How to Report Issues
 
-!!! warning
-    We are not taking issue reports at this time.
-
 <!--
 !!! warning
-    Please read the above Known Issues list and also use the search of  Discord to see if your issue has already been reported.
-
-At this time please only report issues via our Discord channel thread:
-
- [Experimental - Issue Reports [NO SUPPORT]](https://discord.com/channels/738864299392630914/926586416820011098/926592547059531866){target=new .md-button}
-
-Do not expect support or immediate solutions for your issues. We will collect all issues and fix and improve continuously.
-
+    We are not taking issue reports at this time.
 -->
 
-**Do not open any issues on Github for the Experimental Version!**
+!!! warning
+    Please read the above Known Issues list and also use the search of Discord to see if your issue has already been reported.
 
-<!--### Download and Install
+    At this time please only report issues via our Discord channel thread:
+
+    [Experimental - VNAV Reporting [NO SUPPORT]](#){target=new .md-button}
+
+    {--
+
+    Do not expect support or immediate solutions for your issues. We will collect all issues and fix and improve continuously.
+
+    --}
+
+**Do not open any issues on GitHub for the Experimental Version!**
+
+### Download and Install
 
 See [Installation Guide](../installation.md#downloads).
 
--->

--- a/docs/fbw-a32nx/support/exp.md
+++ b/docs/fbw-a32nx/support/exp.md
@@ -23,6 +23,15 @@ The Experimental version is a test version to find problems and issues and to im
 - Partial implementation of descent guidance.
 - Ability to enter winds for climb, cruise, and descent.
 
+### Planned Implementations
+
+These features are not yet available but will be implemented at a later time.
+
+- Time constraints, RTA
+- Flight plan B
+- Constant Mach segments
+- Vertical guidance for RNAV approaches
+
 ## Known Issues
 
 - LNAV does not use VNAV speed predictions yet. This means that an approach path will not be forecasted properly. Furthermore, the T/D (Top of Descent) could be misplaced, since the system expects more track miles.

--- a/docs/fbw-a32nx/support/exp.md
+++ b/docs/fbw-a32nx/support/exp.md
@@ -4,7 +4,7 @@ The Experimental version is a test version to find problems and issues and to im
 
 {--
 
-**Currently experimental is geared toward testing the initial version of VNAV. Please use the appropriate discord thread #exp-vnav-reporting to discuss any issues.**
+Currently experimental is geared toward testing the initial version of VNAV. Please use the appropriate discord thread **#cFMS LNAV+VNAV Issue Reports** to discuss any issues.
 
 --}
 
@@ -55,11 +55,11 @@ These features are not yet available but will be implemented at a later time.
 
     At this time please only report issues via our Discord channel thread:
 
-    [Experimental - VNAV Reporting [NO SUPPORT]](#){target=new .md-button}
+    [cFMS LNAV+VNAV Issue Reports [NO SUPPORT]](https://discord.com/channels/738864299392630914/926586416820011098){target=new .md-button}
 
     {--
 
-    Do not expect support or immediate solutions for your issues. We will collect all issues and fix and improve continuously.
+    Do not expect support or immediate solutions for your issues. We will collect all issues to fix and improve features in testing continuously.
 
     --}
 

--- a/docs/fbw-a32nx/support/exp.md
+++ b/docs/fbw-a32nx/support/exp.md
@@ -1,6 +1,6 @@
 # Experimental Version
 
-The Experimental version is a test version to find problems and issues and to improve functionality based on your feedback. It is not meant to be used for daily use or when you try to do a serious flight on an Online ATC service.
+The Experimental version is a test version to find problems, issues and to improve functionality based on your feedback. It is not meant to be used for daily **use or serious flights with** an Online ATC service.
 
 {--
 


### PR DESCRIPTION
closes: #497 

Courtesy Preview Link: https://docs-git-fork-valastiri-updt-exp-flybywire.vercel.app/exp/

## Summary
As requested by @BlueberryKing for the latest round of experimental testing. 

### TODO

- [x] Ensure referenced reporting thread is correct when it's created on Discord
- [x] Update the button on the page with the hyperlink for the thread
- [x] Add not implemented section (requires some clarification)

### Location
- docs/fbw-a32nx/support/exp.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
