### PR TITLE
build: bump mkdocs-material -> 8.2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==8.2.5
+mkdocs-material==8.2.7
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary
Provides an upstream fix from `mkdocs-material` to solve build problems with jinja2 dependency changes in `mkdocs`.

Open pull requests with outdated `requirements.txt` should update to this version or cherry pick this commit once merged.

### Location
- mkdocs.yml

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
