### PR TITLE
build: bump mkdocs-material -> 8.2.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==8.2.7
+mkdocs-material==8.2.8
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary
**Note:** Mkdocs version is now 1.3.0 as part of the material version bump. [Mkdocs Release Notes](https://www.mkdocs.org/about/release-notes/)

Material changes:

- Bumped MkDocs version to 1.3.0 to mitigate breaking changes in Jinja
- Reverted Jinja version range limitation (added in 8.2.7)
- Improved styling of annotations and fixed borders of code blocks in tabs
- Added background color to code blocks in focused/hovered links
- Added check-in tags plugin whether tags overview page exists
- Content tab indicator on wrong position when using back button <- fix for firefox browsers (most notable)

Test for breaking changes to docs before merging.

### Location
- mkdocs.yml

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
