### PR TITLE
fix(flyPad): change "battery symbol" to "power symbol" to match picture.

### DIFF
--- a/docs/fbw-a32nx/feature-guides/flyPad/index.md
+++ b/docs/fbw-a32nx/feature-guides/flyPad/index.md
@@ -47,7 +47,7 @@ To **TURN ON** and **TURN OFF** the flyPad you can either:
 
     - To turn it on or off click on the "hardware" button on the top right of the tablet.
     - To turn it on click anywhere on the screen.
-    - To turn it off click on the battery symbol in the top right corner.
+    - To turn it off click on the power symbol in the top right corner.
 
 ## flyPad Pages
 


### PR DESCRIPTION
## Summary
Changes the "battery symbol" text to "power symbol" to match with the image and latest version of the flyPad.

### Location
docs/docs/fbw-a32nx/feature-guides/flyPad/index.md
https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flyPad/#general-usage

Discord username (if different from GitHub):
iamdumdum1234#6921
