### PR TITLE
style: clean up header styles and alter h4

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -25,16 +25,19 @@
   font-weight: 400;
   size: 2em;
 }
-h2 {
+/*Specific Header Modifications*/
+.md-typeset h2 {
   color: #00E0FE; /*Cyan*/
   /*text-transform: uppercase;*/
   padding-bottom: 0.5em;
 }
-h3 {
+.md-typeset h3 {
   color: #00CCFF;
 }
-h4 {
+.md-typeset h4 {
   padding-top: 1em;
+  text-decoration: underline;
+  font-weight: bold;
 }
 .md-typeset h5 {
   color: hsl(0, 0%, 100%);


### PR DESCRIPTION
## Summary
- Cleans up the extra.css header modifications.
- H4 now has an underline and the font-weight is `bold` to help with readability and assist without having to format the header in-line in various pages where it is in use.

Sample:
![image](https://user-images.githubusercontent.com/1619968/161050886-6a8956f1-a864-4969-b04f-1dc22639e54c.png)


### Location
- extra.css

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
