### PR TITLE
fix(beginner): cat2/3 minima often given as RA

### DIFF
--- a/docs/pilots-corner/beginner-guide/descent.md
+++ b/docs/pilots-corner/beginner-guide/descent.md
@@ -198,10 +198,10 @@ ACKNOWLEDGE RECEIPT OF INFORMATION K AND ADVISE AIRCRAFT
 TYPE ON FIRST CONTACT
 ```
 
-From the chart we get `Trans level` and `BARO` (=MDA) or `RADIO` (=DH). 
+From the chart we get `Trans level` and `BARO` (=DA or MDA) or `RADIO` (=RA or DH). 
 
-- CAT I ILS uses MDA and is entered into the `BARO` field.
-- CAT II/III ILS use DH which is put in the `RADIO` field.
+- CAT I ILS uses DA or MDA and is entered into the `BARO` field.
+- CAT II/III ILS use RA or DH which is put in the `RADIO` field.
 - `BARO` is based on barometric altitude whereas `RADIO` is based on radio altitude (distance to ground).
 
 !!! tip "Trans level: By ATC"


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
Cat II/III minima are often given as RA rather than DH, due to elevation differences between the runway and the surface at the minima point. Additionally, ILS approaches usually use DA rather than MDA.
![image](https://user-images.githubusercontent.com/9995998/161385996-ab806181-3731-4ecd-8c0e-e4255ee3c607.png)


### Location
<!-- Please provide the original URL of the page modified or directory location here -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
