### PR TITLE
docs(beg): add reference to descent.md to approaches.md

### DIFF
--- a/docs/pilots-corner/airliner-flying-guide/approaches.md
+++ b/docs/pilots-corner/airliner-flying-guide/approaches.md
@@ -111,11 +111,11 @@ the parking stands completely blind. The A320 family are capable of everything i
 
 So, you have picked your approach and are flying towards the runway, but how close can you get before you decide it is a bad idea and to try again somewhere else? This is where the minimums come into effect. These are fixed values that decide how low you can go on the approach, and when you get to this altitude, you cannot go any lower until you can see the runway.
 
-| Minimum Type                         | Defined As                               | Approaches Used In                             |
-| :-------------:                      | :--------------:                         | :-----------:                                  |
-| MDA <br>\(Minimum Descent Altitude\) | Altitude Above Mean Sea Level            | LOC, LDA, SDF, VOR <br> NDB, LNAV, ASR, Visual |
-| DA <br>(Decision Altitude)           | Barometric Altitude Above Mean Sea Level | CAT I ILS <br> LNAV / VNAV, LPV, RNP, PAR, GLS |
-| DH <br>\(Decision Height\)           | Radio Altitude Above Ground Level        | CAT II ILS <br> CAT III A/B/C ILS              |
+|                Minimum Type                 |                Defined As                |               Approaches Used In               |
+|:-------------------------------------------:|:----------------------------------------:|:----------------------------------------------:|
+|    MDA <br>\(Minimum Descent Altitude\)     |      Altitude Above Mean Sea Level       | LOC, LDA, SDF, VOR <br> NDB, LNAV, ASR, Visual |
+|         DA <br>(Decision Altitude)          | Barometric Altitude Above Mean Sea Level | CAT I ILS <br> LNAV / VNAV, LPV, RNP, PAR, GLS |
+| DH/RA <br>\(Decision Height/Radio Altitude) |    Radio Altitude Above Ground Level     |       CAT II ILS <br> CAT III A/B/C ILS        |
 
 These are defined in feet, \(or meters if that airspace uses meter altitudes\) and can be found at the bottom of the aeronautical chart that is published for that approach. Each approach to each airport will have a separate value, changing due to obstacles, terrain, and other things that may get in the way while descending towards the runway.
 

--- a/docs/pilots-corner/beginner-guide/descent.md
+++ b/docs/pilots-corner/beginner-guide/descent.md
@@ -204,6 +204,8 @@ From the chart we get `Trans level` and `BARO` (=DA or MDA) or `RADIO` (=RA or D
 - CAT II/III ILS use RA or DH which is put in the `RADIO` field.
 - `BARO` is based on barometric altitude whereas `RADIO` is based on radio altitude (distance to ground).
 
+For more information on the different types of minimums see the [Minimums and MDA/DH](../airliner-flying-guide/approaches.md#minimums-and-mdadh) section on the [Approaches](../airliner-flying-guide/approaches.md) page in the airliner flying guide.
+
 !!! tip "Trans level: By ATC"
     In the particular example below the `Trans level` field states `By ATC`. If you are not flying on a network such as Vatsim or IVAO you can try the following things:
 


### PR DESCRIPTION
## Summary
In support of merged PR [#518](https://github.com/flybywiresim/docs/pull/518) a quick addition to link to additional information about minimums.

![image](https://user-images.githubusercontent.com/1619968/161423233-57776e95-48af-4323-8523-4f89c090c31a.png)

Additionally adds RA to the chart found on the approaches minimum section.

### Location
- docs/pilots-corner/beginner-guide/descent.md
- docs/pilots-corner/airliner-flying-guide/approaches.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
