### PR TITLE
docs(issues): add the multiple throttle profile issue

### DIFF
--- a/docs/fbw-a32nx/feature-guides/flyPad/throttle-calibration.md
+++ b/docs/fbw-a32nx/feature-guides/flyPad/throttle-calibration.md
@@ -639,18 +639,6 @@ This can easily be fixed by carefully following the steps [above](#4-start-with-
 
 Another solution is to simply delete the current configuration file (as described in the next chapter) and start over your configuration from default values.
 
-### Multiple Throttle Profiles
-
-If you have used different throttles with your system that have custom profiles saved in the simulator this may cause conflicts with calibration. One example is a reported rare case with the TurtleBeach yoke and the Thrustmaster quadrant creating a conflict when both throttles have a saved profile in the sim. 
-
-Even if you have disconnected any "not in use" throttle quadrants the sim **may** assume the profile is active and conflict with the hardware that you do have plugged in for your flight. 
-
-We suggest either:
-
-- Change the profile not in use to a different type of engine mapping that does not have the throttle levers mapped. 
-    - For example: change it to a single engine profile.
-- Removing one of the profiles that you don't use.
-
 ---
 
 ## Manual Configuration

--- a/docs/fbw-a32nx/feature-guides/flyPad/throttle-calibration.md
+++ b/docs/fbw-a32nx/feature-guides/flyPad/throttle-calibration.md
@@ -639,6 +639,15 @@ This can easily be fixed by carefully following the steps [above](#4-start-with-
 
 Another solution is to simply delete the current configuration file (as described in the next chapter) and start over your configuration from default values.
 
+### Multiple Throttle Profiles
+
+If you have used different throttles with your system that have custom profiles saved in the simulator this may cause conflicts with calibration. One example is a reported rare case with the TurtleBeach yoke and the Thrustmaster quadrant creating a conflict when both throttles have a saved profile in the sim. 
+
+Even if you have disconnected any "not in use" throttle quadrants the sim **may** assume the profile is active and conflict with the hardware that you do have plugged in for your flight. We suggest either:
+
+- Change the profile not in use to a different type of engine mapping that does not have the throttle levers mapped. For example: change it to a single engine profile.
+- Removing one of the profiles that you don't use.
+
 ---
 
 ## Manual Configuration

--- a/docs/fbw-a32nx/feature-guides/flyPad/throttle-calibration.md
+++ b/docs/fbw-a32nx/feature-guides/flyPad/throttle-calibration.md
@@ -643,9 +643,12 @@ Another solution is to simply delete the current configuration file (as describe
 
 If you have used different throttles with your system that have custom profiles saved in the simulator this may cause conflicts with calibration. One example is a reported rare case with the TurtleBeach yoke and the Thrustmaster quadrant creating a conflict when both throttles have a saved profile in the sim. 
 
-Even if you have disconnected any "not in use" throttle quadrants the sim **may** assume the profile is active and conflict with the hardware that you do have plugged in for your flight. We suggest either:
+Even if you have disconnected any "not in use" throttle quadrants the sim **may** assume the profile is active and conflict with the hardware that you do have plugged in for your flight. 
 
-- Change the profile not in use to a different type of engine mapping that does not have the throttle levers mapped. For example: change it to a single engine profile.
+We suggest either:
+
+- Change the profile not in use to a different type of engine mapping that does not have the throttle levers mapped. 
+    - For example: change it to a single engine profile.
 - Removing one of the profiles that you don't use.
 
 ---

--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -714,7 +714,7 @@ TEMPLATE
 
 ## Common MSFS Issues Impacting All Aircraft
 
-??? bug "MSFSPerformance Degradation In-Flight"
+??? bug "MSFS Performance Degradation In-Flight"
     ### MSFS Performance Degradation In-Flight
 
     !!! tip ""
@@ -869,6 +869,26 @@ TEMPLATE
     Check your content manager for missing packages
 
     ^^Additional Information^^
+
+??? warning "Multiple Throttle Profiles Conflict"
+    ### Multiple Throttle Profiles Conflict
+
+    !!! tip ""
+        *Affected versions: Stable, Development*
+
+    ^^Description^^
+
+    If you have used different throttles with your system that have custom profiles saved in the simulator this may cause conflicts with calibration. One example is a reported rare case with the TurtleBeach yoke and the Thrustmaster quadrant creating a conflict when both throttles have a saved profile in the sim.
+
+    ^^Root Cause^^
+
+    Even if you have disconnected any "not in use" throttle quadrants the sim **may** assume the profile is active and conflict with the hardware that you do have plugged in for your flight.
+
+    ^^Possible Solution or Workaround^^
+
+    - Change the profile not in use to a different type of engine mapping that does not have the throttle levers mapped.
+        - For example: change it to a single engine profile.
+    - Removing one of the profiles that you don't use.
 
 ??? warning "Difficulty Accurately Clicking Controls"
     ### Difficulty Accurately Clicking Controls


### PR DESCRIPTION
closes #517 

## Summary
User reported an issue with hardware that had saved profiles conflicting with each other.

~~Briefly explains the issue in #troubleshooting section and provides some workarounds.~~

~~**Note:** If merged would need to be copied over to the flyPadOS3 PR.~~

**Changed:** Moved to reported-issues instead

### Location
- docs/fbw-a32nx/support/reported-issues.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902