### PR TITLE
docs: Added issue and settings tip for Pause function keyboard mapping

### DIFF
--- a/docs/fbw-a32nx/settings.md
+++ b/docs/fbw-a32nx/settings.md
@@ -74,6 +74,11 @@ Throttle should have linear sensitivity.
 
 See [Throttle Calibration Guide](feature-guides/flyPad/throttle-calibration.md).
 
+### Keyboard Mapping for Pause Function
+
+Make sure that the `Pause` function is only mapped to the ++esc++ key and not to any other key as otherwise this mapped 
+key will trigger `Pause` in input fields of the EFB or the MCDU when using the keyboard input mode. 
+
 ## Windows Settings
 
 ### UTF8 Support

--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -684,6 +684,24 @@ TEMPLATE
 
     ![New Aircraft](../assets/new-aircraft.png){width=50% align=left loading=lazy}
 
+??? tip "Incompatible Keyboard Mapping for Pause Function"
+    ### Incompatible Keyboard Mapping for Pause Function
+
+    !!! tip ""
+        *Affected versions: Stable, Development*
+
+    ^^Description^^
+
+    If the `Pause` function is mapped to any key other than ++esc++ this other key will trigger `Pause` 
+    when typing it into input fields of the EFB or the MCDU when using the keyboard input mode.
+
+    ^^Root Cause^^
+    
+    This is a MSFS limitation for Coherent driven Javascript instruments. 
+
+    ^^Possible Solution or Workaround^^
+
+    Make sure that the `Pause` function is only mapped to the ++esc++ key and not to any other keys.
 ---
 
 ## FBW Installer Issues


### PR DESCRIPTION
## Summary
The sim's `Pause` function cannot be intercepted in the EFP input fields or the MCDU keyboard mode.
Standard mapping is `ESC`.
If mapped to another key this key will trigger `Pause` when used while typing into EFB/MCDU. 

The PR adds a settings tip and a reported issue. 

### Location
https://docs-git-fork-frankkopp-pause-key-mapping-flybywire.vercel.app/fbw-a32nx/settings/#keyboard-mapping-for-pause-function

https://docs-git-fork-frankkopp-pause-key-mapping-flybywire.vercel.app/fbw-a32nx/support/reported-issues/#incompatible-keyboard-mapping-for-pause-function

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Cdr_Maverick#6475
