### PR TITLE
docs: A32NX FLight Deck API to reflect Autobrake and LS buttons change

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/a32nx_api.md
+++ b/docs/pilots-corner/a32nx-briefing/a32nx_api.md
@@ -31,100 +31,100 @@ Find the complete list of Custom Event and Custom LVARS of the A32NX:
 
 Flight Deck:  [ELEC Panel](flight-deck/ovhd/elec.md)
 
-| Function    | API Usage                                 | Values     | Read/Write | Type             | Remark                                     |
-|:------------|:------------------------------------------|:-----------|:-----------|:-----------------|:-------------------------------------------|
-| BAT 1       | A32NX_OVHD_ELEC_BAT_1_PB_IS_AUTO          | 0 &#124; 1 | R/W        | Custom LVAR      |                                            |
-|             | A32NX_OVHD_ELEC_BAT_1_PB_IS_FAULT         | 0 &#124; 1 | R/W        | Custom LVAR      |                                            |
-| BAT 2       | A32NX_OVHD_ELEC_BAT_2_PB_IS_AUTO          | 0 &#124; 1 | R/W        | Custom LVAR      |                                            |
-|             | A32NX_OVHD_ELEC_BAT_2_PB_IS_FAULT         | 0 &#124; 1 | R/W        | Custom LVAR      |                                            |
-|             |                                           |            |            |                  |                                            |
-| EXT PWR     | TOGGLE_EXTERNAL_POWER                     | -          | -          | MSFS EVENT       |                                            |
-|             | EXTERNAL POWER AVAILABLE                  | 0 &#124; 1 | R          | MSFS VAR         |                                            |
-|             | EXTERNAL POWER ON                         | 0 &#124; 1 | R          | MSFS VAR         |                                            |
-|             |                                           |            |            |                  |                                            |
-| GEN 1       | TOGGLE_ALTERNATOR:1                       | -          | -          | SIMCONNECT EVENT |                                            |
-|             | GENERAL ENG MASTER ALTERNATOR:1           | 0 &#124; 1 | R/W        | SIMCONNECT VAR   |                                            |
-|             | A32NX_OVHD_ELEC_ENG_GEN_1_PB_HAS_FAULT    | 0 &#124; 1 | R          | Custom LVAR      |                                            |
-| GEN 2       | TOGGLE_ALTERNATOR:2                       | -          | -          | SIMCONNECT EVENT |                                            |
-|             | GENERAL ENG MASTER ALTERNATOR:2           | 0 &#124; 1 | R/W        | SIMCONNECT VAR   |                                            |
-|             | A32NX_OVHD_ELEC_ENG_GEN_2_PB_HAS_FAULT    | 0 &#124; 1 | R          | Custom LVAR      |                                            |
-|             |                                           |            |            |                  |                                            |
-| APU GEN     | APU_GENERATOR_SWITCH_TOGGLE               | -          | -          | SIMCONNECT EVENT |                                            |
-|             | APU_GENERATOR_SWITCH_SET                  | 0 &#124; 1 | -          | SIMCONNECT EVENT |                                            |
-|             | APU GENERATOR SWITCH                      | 0 &#124; 1 | R/W        | SIMCONNECT LVAR  |                                            |
-|             | A32NX_OVHD_ELEC_APU_GEN_1_PB_HAS_FAULT    | 0 &#124; 1 | R          | Custom LVAR      |                                            |
-|             |                                           |            |            |                  |                                            |
-| BUS TIE     | A32NX_OVHD_ELEC_BUS_TIE_PB_IS_AUTO        | 0 &#124; 1 | R/W        | Custom LVAR      |                                            |
-|             | A32NX_OVHD_ELEC_BUS_TIE_PB_HAS_FAULT      | 0 &#124; 1 | R          | Custom LVAR      |                                            |
-|             |                                           |            |            |                  |                                            |
-| AC ESS FEED | A32NX_OVHD_ELEC_AC_ESS_FEED_PB_IS_NORMAL  | 0 &#124; 1 | R/W        | Custom LVAR      |                                            |
-|             | A32NX_OVHD_ELEC_AC_ESS_FEED_PB_HAS_FAULT  | 0 &#124; 1 | R          | Custom LVAR      |                                            |
-|             |                                           |            |            |                  |                                            |
-| IDG 1       | A32NX_OVHD_ELEC_IDG_1_PB_IS_RELEASED      | 0 -> 1     | R/W        | Custom LVAR      | Cannot be undone - flight restart required |
-| IDG 1       | A32NX_OVHD_ELEC_IDG_1_PB_HAS_FAULT        | 0 &#124; 1 | R          | Custom LVAR      |                                            |
-|             |                                           |            |            |                  |                                            |
-| IDG 2       | A32NX_OVHD_ELEC_IDG_2_PB_IS_RELEASED      | 0 -> 1     | R/W        | Custom LVAR      | Cannot be undone - flight restart required |
-| IDG 2       | A32NX_OVHD_ELEC_IDG_2_PB_HAS_FAULT        | 0 &#124; 1 | R          | Custom LVAR      |                                            |
-|             |                                           |            |            |                  |                                            |
-| GALY & CAB  | A32NX_OVHD_ELEC_GALY_AND_CAB_PB_IS_AUTO   | 0 &#124; 1 | R/W        | Custom LVAR      |                                            |
-|             | A32NX_OVHD_ELEC_GALY_AND_CAB_PB_HAS_FAULT | 0 &#124; 1 | R          | Custom LVAR      |                                            |
-|             |                                           |            |            |                  |                                            |
-| COMMERCIAL  | A32NX_OVHD_ELEC_COMMERCIAL_PB_IS_AUTO     | 0 &#124; 1 | R/W        | Custom LVAR      |                                            |
-|             | A32NX_OVHD_ELEC_COMMERCIAL_PB_HAS_FAULT   | 0 &#124; 1 | R          | Custom LVAR      |                                            |
-|             |                                           |            |            |                  |                                            |
+| Function    | API Usage                                 | Values   | Read/Write | Type             | Remark                                     |
+|:------------|:------------------------------------------|:---------|:-----------|:-----------------|:-------------------------------------------|
+| BAT 1       | A32NX_OVHD_ELEC_BAT_1_PB_IS_AUTO          | 0&#124;1 | R/W        | Custom LVAR      |                                            |
+|             | A32NX_OVHD_ELEC_BAT_1_PB_IS_FAULT         | 0&#124;1 | R/W        | Custom LVAR      |                                            |
+| BAT 2       | A32NX_OVHD_ELEC_BAT_2_PB_IS_AUTO          | 0&#124;1 | R/W        | Custom LVAR      |                                            |
+|             | A32NX_OVHD_ELEC_BAT_2_PB_IS_FAULT         | 0&#124;1 | R/W        | Custom LVAR      |                                            |
+|             |                                           |          |            |                  |                                            |
+| EXT PWR     | TOGGLE_EXTERNAL_POWER                     | -        | -          | MSFS EVENT       |                                            |
+|             | EXTERNAL POWER AVAILABLE                  | 0&#124;1 | R          | MSFS VAR         |                                            |
+|             | EXTERNAL POWER ON                         | 0&#124;1 | R          | MSFS VAR         |                                            |
+|             |                                           |          |            |                  |                                            |
+| GEN 1       | TOGGLE_ALTERNATOR:1                       | -        | -          | SIMCONNECT EVENT |                                            |
+|             | GENERAL ENG MASTER ALTERNATOR:1           | 0&#124;1 | R/W        | SIMCONNECT VAR   |                                            |
+|             | A32NX_OVHD_ELEC_ENG_GEN_1_PB_HAS_FAULT    | 0&#124;1 | R          | Custom LVAR      |                                            |
+| GEN 2       | TOGGLE_ALTERNATOR:2                       | -        | -          | SIMCONNECT EVENT |                                            |
+|             | GENERAL ENG MASTER ALTERNATOR:2           | 0&#124;1 | R/W        | SIMCONNECT VAR   |                                            |
+|             | A32NX_OVHD_ELEC_ENG_GEN_2_PB_HAS_FAULT    | 0&#124;1 | R          | Custom LVAR      |                                            |
+|             |                                           |          |            |                  |                                            |
+| APU GEN     | APU_GENERATOR_SWITCH_TOGGLE               | -        | -          | SIMCONNECT EVENT |                                            |
+|             | APU_GENERATOR_SWITCH_SET                  | 0&#124;1 | -          | SIMCONNECT EVENT |                                            |
+|             | APU GENERATOR SWITCH                      | 0&#124;1 | R/W        | SIMCONNECT LVAR  |                                            |
+|             | A32NX_OVHD_ELEC_APU_GEN_1_PB_HAS_FAULT    | 0&#124;1 | R          | Custom LVAR      |                                            |
+|             |                                           |          |            |                  |                                            |
+| BUS TIE     | A32NX_OVHD_ELEC_BUS_TIE_PB_IS_AUTO        | 0&#124;1 | R/W        | Custom LVAR      |                                            |
+|             | A32NX_OVHD_ELEC_BUS_TIE_PB_HAS_FAULT      | 0&#124;1 | R          | Custom LVAR      |                                            |
+|             |                                           |          |            |                  |                                            |
+| AC ESS FEED | A32NX_OVHD_ELEC_AC_ESS_FEED_PB_IS_NORMAL  | 0&#124;1 | R/W        | Custom LVAR      |                                            |
+|             | A32NX_OVHD_ELEC_AC_ESS_FEED_PB_HAS_FAULT  | 0&#124;1 | R          | Custom LVAR      |                                            |
+|             |                                           |          |            |                  |                                            |
+| IDG 1       | A32NX_OVHD_ELEC_IDG_1_PB_IS_RELEASED      | 0 -> 1   | R/W        | Custom LVAR      | Cannot be undone - flight restart required |
+| IDG 1       | A32NX_OVHD_ELEC_IDG_1_PB_HAS_FAULT        | 0&#124;1 | R          | Custom LVAR      |                                            |
+|             |                                           |          |            |                  |                                            |
+| IDG 2       | A32NX_OVHD_ELEC_IDG_2_PB_IS_RELEASED      | 0 -> 1   | R/W        | Custom LVAR      | Cannot be undone - flight restart required |
+| IDG 2       | A32NX_OVHD_ELEC_IDG_2_PB_HAS_FAULT        | 0&#124;1 | R          | Custom LVAR      |                                            |
+|             |                                           |          |            |                  |                                            |
+| GALY & CAB  | A32NX_OVHD_ELEC_GALY_AND_CAB_PB_IS_AUTO   | 0&#124;1 | R/W        | Custom LVAR      |                                            |
+|             | A32NX_OVHD_ELEC_GALY_AND_CAB_PB_HAS_FAULT | 0&#124;1 | R          | Custom LVAR      |                                            |
+|             |                                           |          |            |                  |                                            |
+| COMMERCIAL  | A32NX_OVHD_ELEC_COMMERCIAL_PB_IS_AUTO     | 0&#124;1 | R/W        | Custom LVAR      |                                            |
+|             | A32NX_OVHD_ELEC_COMMERCIAL_PB_HAS_FAULT   | 0&#124;1 | R          | Custom LVAR      |                                            |
+|             |                                           |          |            |                  |                                            |
 
 ### External Lights Panel
 
 Flight Deck:  [EXT LT Panel](flight-deck/ovhd/ext-lt.md)
 
-| Function     | API Usage             | Values     | Read/Write | Type             | Remark                                                             |
-|:-------------|:----------------------|:-----------|:-----------|:-----------------|:-------------------------------------------------------------------|
-| STROBE       | STROBES_SET           | 0 &#124; 1 | -          | SIMCONNECT EVENT | OFF and ON (no AUTO)                                               |
-|              | STROBES_TOGGLE        | -          | -          | SIMCONNECT EVENT | OFF and ON (no AUTO)                                               |
-|              | STROBES_ON            | -          | -          | SIMCONNECT EVENT | OFF and ON (no AUTO)                                               |
-|              | STROBES_OFF           | -          | -          | SIMCONNECT EVENT | OFF and ON (no AUTO)                                               |
-|              | LIGHT STROBE          | 0 &#124; 1 | R/W        | SIMCONNECT VAR   | OFF and ON (no AUTO)                                               |
-|              | STROBE_0_AUTO         | 0 &#124; 1 | R/W        | Custom LVAR      | AUTO only when STROBES are ON                                      |
-|              | LIGHTING_STROBE_0     | 0..2       | R/W        |                  | 2=OFF, 1=AUTO, 0=ON                                                |
-|              |                       |            |            |                  |                                                                    |
-| BEACON       | BEACON_SET            | 0 &#124; 1 | -          | SIMCONNECT EVENT |                                                                    |
-|              | BEACON_TOGGLE         | -          | -          | SIMCONNECT EVENT |                                                                    |
-|              | BEACON_ON             | -          | -          | SIMCONNECT EVENT |                                                                    |
-|              | BEACON_OFF            | -          | -          | SIMCONNECT EVENT |                                                                    |
-|              | LIGHT BEACON          | 0 &#124; 1 | R/W        | SIMCONNECT VAR   |                                                                    |
-|              |                       |            |            |                  |                                                                    |
-| WING         | WING_SET              | 0 &#124; 1 | -          | SIMCONNECT EVENT |                                                                    |
-|              | BEACON_TOGGLE         | -          | -          | SIMCONNECT EVENT |                                                                    |
-|              | BEACON_ON             | -          | -          | SIMCONNECT EVENT |                                                                    |
-|              | BEACON_OFF            | -          | -          | SIMCONNECT EVENT |                                                                    |
-|              | LIGHT WING            | 0 &#124; 1 | R/W        | SIMCONNECT VAR   |                                                                    |
-|              |                       |            |            |                  |                                                                    |
-| NAV & LOGO   | NAV_LIGHTS_SET        | 0 &#124; 1 | -          | SIMCONNECT EVENT | LOGO needs to be set separately                                    |
-|              | LIGHT NAV             | 0 &#124; 1 | R/W        | SIMCONNECT VAR   | LOGO needs to be set separately                                    |
-|              | LOGO_LIGHTS_SET       | 0 &#124; 1 | -          | SIMCONNECT EVENT | LOGO does not move switch                                          |
-|              | LIGHT LOGO            | 0 &#124; 1 | R/W        | SIMCONNECT VAR   | LOGO does not move switch                                          |
-|              |                       |            |            |                  |                                                                    |
-| RWY TURN OFF | CIRCUIT SWITCH ON:21  | 0 &#124; 1 | R/W        | MSFS VAR         | Left Rwy Turn Off Light + Switch                                   |
-|              | CIRCUIT SWITCH ON:22  | 0 &#124; 1 | R/W        | MSFS VAR         | Right Rwy Turn Off Light                                           |
-|              | LIGHTING_TAXI_2       | 0 &#124; 1 | R          | Custom LVAR      |                                                                    |
-|              |                       |            |            |                  |                                                                    |
-| LAND L + R   | LANDING_LIGHTS_ON     | 0..3       | -          | SIMCONNECT EVENT | 0=all, 1=NOSE, 2=L, 3=R                                            |
-|              | LANDING_LIGHTS_OFF    | 0..3       | -          | SIMCONNECT EVENT | 0=all, 1=NOSE, 2=L, 3=R                                            |
-|              | LANDING_LIGHTS_TOGGLE | 0..3       | -          | SIMCONNECT EVENT | 0=all, 1=NOSE, 2=L, 3=R                                            |
-|              | CIRCUIT SWITCH ON:18  | 0 &#124; 1 | R/W        | MSFS VAR         | Left landing light                                                 |
-|              | CIRCUIT SWITCH ON:19  | 0 &#124; 1 | R/W        | MSFS VAR         | Right landing light                                                |
-|              | LIGHT_LANDING_1       | 0 &#124; 1 | R/W        | Custom LVAR      | Switch position of the NOSE switch: 2=OFF, 1=TAXI, 0=T.O.          |
-|              | LIGHT_LANDING_2       | 0 &#124; 1 | R/W        | Custom LVAR      | Switch position of the left landing light: 2=RETRACT, 1=OFF, 2=ON  |
-|              | LIGHT_LANDING_3       | 0 &#124; 1 | R/W        | Custom LVAR      | Switch position of the right landing light: 2=RETRACT, 1=OFF, 2=ON |
-|              | LANDING_1_RETRACTED   | 0 &#124; 1 | R/W        | Custom LVAR      | No function - NOSE light can't be retracted                        |
-|              | LANDING_2_RETRACTED   | 0 &#124; 1 | R/W        | Custom LVAR      | Retraction of left landing light: 0=extended, 1=retracted          |
-|              | LANDING_3_RETRACTED   | 0 &#124; 1 | R/W        | Custom LVAR      | Retraction of right landing light 0=extended, 1=retracted          |
-|              |                       |            |            |                  |                                                                    |
-| NOSE         | TOGGLE_TAXI_LIGHTS    | -          | -          | SIMCONNECT EVENT | Also toggles RWY TURN OFF LIGHT                                    |
-|              | LIGHT TAXI            | 0 &#124; 1 | R/W        | SIMCONNECT VAR   | Only switches TAXI light                                           |
-|              | LANDING_LIGHTS_TOGGLE | 1          | -          | SIMCONNECT EVENT | Toggles switch between T.O. and OFF                                |
-|              | CIRCUIT SWITCH ON:20  | 0 &#124; 1 | R/W        | MSFS VAR         | NOSE TAXI                                                          |
-|              | CIRCUIT SWITCH ON:17  | 0 &#124; 1 | R/W        | MSFS VAR         | NOSE T.O.                                                          |
+| Function     | API Usage             | Values   | Read/Write | Type             | Remark                                                             |
+|:-------------|:----------------------|:---------|:-----------|:-----------------|:-------------------------------------------------------------------|
+| STROBE       | STROBES_SET           | 0&#124;1 | -          | SIMCONNECT EVENT | OFF and ON (no AUTO)                                               |
+|              | STROBES_TOGGLE        | -        | -          | SIMCONNECT EVENT | OFF and ON (no AUTO)                                               |
+|              | STROBES_ON            | -        | -          | SIMCONNECT EVENT | OFF and ON (no AUTO)                                               |
+|              | STROBES_OFF           | -        | -          | SIMCONNECT EVENT | OFF and ON (no AUTO)                                               |
+|              | LIGHT STROBE          | 0&#124;1 | R/W        | SIMCONNECT VAR   | OFF and ON (no AUTO)                                               |
+|              | STROBE_0_AUTO         | 0&#124;1 | R/W        | Custom LVAR      | AUTO only when STROBES are ON                                      |
+|              | LIGHTING_STROBE_0     | 0..2     | R/W        |                  | 2=OFF, 1=AUTO, 0=ON                                                |
+|              |                       |          |            |                  |                                                                    |
+| BEACON       | BEACON_SET            | 0&#124;1 | -          | SIMCONNECT EVENT |                                                                    |
+|              | BEACON_TOGGLE         | -        | -          | SIMCONNECT EVENT |                                                                    |
+|              | BEACON_ON             | -        | -          | SIMCONNECT EVENT |                                                                    |
+|              | BEACON_OFF            | -        | -          | SIMCONNECT EVENT |                                                                    |
+|              | LIGHT BEACON          | 0&#124;1 | R/W        | SIMCONNECT VAR   |                                                                    |
+|              |                       |          |            |                  |                                                                    |
+| WING         | WING_SET              | 0&#124;1 | -          | SIMCONNECT EVENT |                                                                    |
+|              | BEACON_TOGGLE         | -        | -          | SIMCONNECT EVENT |                                                                    |
+|              | BEACON_ON             | -        | -          | SIMCONNECT EVENT |                                                                    |
+|              | BEACON_OFF            | -        | -          | SIMCONNECT EVENT |                                                                    |
+|              | LIGHT WING            | 0&#124;1 | R/W        | SIMCONNECT VAR   |                                                                    |
+|              |                       |          |            |                  |                                                                    |
+| NAV & LOGO   | NAV_LIGHTS_SET        | 0&#124;1 | -          | SIMCONNECT EVENT | LOGO needs to be set separately                                    |
+|              | LIGHT NAV             | 0&#124;1 | R/W        | SIMCONNECT VAR   | LOGO needs to be set separately                                    |
+|              | LOGO_LIGHTS_SET       | 0&#124;1 | -          | SIMCONNECT EVENT | LOGO does not move switch                                          |
+|              | LIGHT LOGO            | 0&#124;1 | R/W        | SIMCONNECT VAR   | LOGO does not move switch                                          |
+|              |                       |          |            |                  |                                                                    |
+| RWY TURN OFF | CIRCUIT SWITCH ON:21  | 0&#124;1 | R/W        | MSFS VAR         | Left Rwy Turn Off Light + Switch                                   |
+|              | CIRCUIT SWITCH ON:22  | 0&#124;1 | R/W        | MSFS VAR         | Right Rwy Turn Off Light                                           |
+|              | LIGHTING_TAXI_2       | 0&#124;1 | R          | Custom LVAR      |                                                                    |
+|              |                       |          |            |                  |                                                                    |
+| LAND L + R   | LANDING_LIGHTS_ON     | 0..3     | -          | SIMCONNECT EVENT | 0=all, 1=NOSE, 2=L, 3=R                                            |
+|              | LANDING_LIGHTS_OFF    | 0..3     | -          | SIMCONNECT EVENT | 0=all, 1=NOSE, 2=L, 3=R                                            |
+|              | LANDING_LIGHTS_TOGGLE | 0..3     | -          | SIMCONNECT EVENT | 0=all, 1=NOSE, 2=L, 3=R                                            |
+|              | CIRCUIT SWITCH ON:18  | 0&#124;1 | R/W        | MSFS VAR         | Left landing light                                                 |
+|              | CIRCUIT SWITCH ON:19  | 0&#124;1 | R/W        | MSFS VAR         | Right landing light                                                |
+|              | LIGHT_LANDING_1       | 0&#124;1 | R/W        | Custom LVAR      | Switch position of the NOSE switch: 2=OFF, 1=TAXI, 0=T.O.          |
+|              | LIGHT_LANDING_2       | 0&#124;1 | R/W        | Custom LVAR      | Switch position of the left landing light: 2=RETRACT, 1=OFF, 2=ON  |
+|              | LIGHT_LANDING_3       | 0&#124;1 | R/W        | Custom LVAR      | Switch position of the right landing light: 2=RETRACT, 1=OFF, 2=ON |
+|              | LANDING_1_RETRACTED   | 0&#124;1 | R/W        | Custom LVAR      | No function - NOSE light can't be retracted                        |
+|              | LANDING_2_RETRACTED   | 0&#124;1 | R/W        | Custom LVAR      | Retraction of left landing light: 0=extended, 1=retracted          |
+|              | LANDING_3_RETRACTED   | 0&#124;1 | R/W        | Custom LVAR      | Retraction of right landing light 0=extended, 1=retracted          |
+|              |                       |          |            |                  |                                                                    |
+| NOSE         | TOGGLE_TAXI_LIGHTS    | -        | -          | SIMCONNECT EVENT | Also toggles RWY TURN OFF LIGHT                                    |
+|              | LIGHT TAXI            | 0&#124;1 | R/W        | SIMCONNECT VAR   | Only switches TAXI light                                           |
+|              | LANDING_LIGHTS_TOGGLE | 1        | -          | SIMCONNECT EVENT | Toggles switch between T.O. and OFF                                |
+|              | CIRCUIT SWITCH ON:20  | 0&#124;1 | R/W        | MSFS VAR         | NOSE TAXI                                                          |
+|              | CIRCUIT SWITCH ON:17  | 0&#124;1 | R/W        | MSFS VAR         | NOSE T.O.                                                          |
 
 !!! note "Landing and Taxi lights"
     The default behaviour of the SIMCONNECT events for landing lights and taxi
@@ -177,14 +177,14 @@ Flight Deck: [INT LT Panel](flight-deck/ovhd/int-lt.md)
 
 Flight Deck: [Signs Panel](flight-deck/ovhd/signs.md)
 
-| Function     | API Usage                                    | Values     | Read/Write | Type             | Remark              |
-|:-------------|:---------------------------------------------|:-----------|:-----------|:-----------------|:--------------------|
-| SEAT BELTS   | CABIN_SEATBELTS_ALERT_SWITCH_TOGGLE          | -          | -          | SIMCONNECT EVENT |                     |
-|              | CABIN SEATBELTS ALERT SWITCH                 | 0 &#124; 1 | R          | SIMCONNECT VAR   |                     |
-|              |                                              |            |            |                  |                     |
-| NO SMOKING   | XMLVAR_SWITCH_OVHD_INTLT_NONSMOKING_POSITION | 0..2       | R/W        | Custom LVAR      | 0=ON, 1=AUTO, 2=OFF |
-|              |                                              |            |            |                  |                     |
-| EMER EXIT LT | XMLVAR_SWITCH_OVHD_INTLT_EMEREXIT_POSITION   | 0..2       | R/W        | Custom LVAR      | 0=ON, 1=AUTO, 2=OFF |
+| Function     | API Usage                                    | Values   | Read/Write | Type             | Remark              |
+|:-------------|:---------------------------------------------|:---------|:-----------|:-----------------|:--------------------|
+| SEAT BELTS   | CABIN_SEATBELTS_ALERT_SWITCH_TOGGLE          | -        | -          | SIMCONNECT EVENT |                     |
+|              | CABIN SEATBELTS ALERT SWITCH                 | 0&#124;1 | R          | SIMCONNECT VAR   |                     |
+|              |                                              |          |            |                  |                     |
+| NO SMOKING   | XMLVAR_SWITCH_OVHD_INTLT_NONSMOKING_POSITION | 0..2     | R/W        | Custom LVAR      | 0=ON, 1=AUTO, 2=OFF |
+|              |                                              |          |            |                  |                     |
+| EMER EXIT LT | XMLVAR_SWITCH_OVHD_INTLT_EMEREXIT_POSITION   | 0..2     | R/W        | Custom LVAR      | 0=ON, 1=AUTO, 2=OFF |
 
 ### ADIRS Panel
 
@@ -192,31 +192,31 @@ Flight Deck: [ADIRS Panel](flight-deck/ovhd/adirs.md)
 
 !!! note "The below table shows the API for ADIR 1. Replace `1` with `2` or `3` for the other ADIRS."
 
-| Function                 | API Usage                                | Values     | Read/Write | Type        | Remark              |
-|:-------------------------|:-----------------------------------------|:-----------|:-----------|:------------|:--------------------|
-| ADIR 1 knob              | A32NX_OVHD_ADIRS_IR_1_MODE_SELECTOR_KNOB | 0..2       | R/W        | Custom LVAR | 0=OFF, 1=NAV, 2=ATT |
-|                          |                                          |            |            |             |                     |
-| IR 1                     | A32NX_OVHD_ADIRS_IR_1_PB_IS_ON           | 0 &#124; 1 | R/W        | Custom LVAR |                     |
-|                          | A32NX_OVHD_ADIRS_IR_1_PB_HAS_FAULT       | 0 &#124; 1 | R          | Custom LVAR |                     |
-|                          |                                          |            |            |             |                     |
-| ADR 1                    | A32NX_OVHD_ADIRS_ADR_1_PB_IS_ON          | 0 &#124; 1 | R/W        | Custom LVAR |                     |
-|                          | A32NX_OVHD_ADIRS_ADR_1_PB_HAS_FAULT      | 0 &#124; 1 | R          | Custom LVAR |                     |
-|                          |                                          |            |            |             |                     |
-| Remaining Alignment Time | A32NX_ADIRS_REMAINING_IR_ALIGNMENT_TIME  | seconds    | R          | Custom LVAR |                     |
-|                          |                                          |            |            |             |                     |
-| ON BAT light             | A32NX_OVHD_ADIRS_ON_BAT_IS_ILLUMINATED   | 0 &#124; 1 | R          | Custom LVAR |                     |
+| Function                 | API Usage                                | Values   | Read/Write | Type        | Remark              |
+|:-------------------------|:-----------------------------------------|:---------|:-----------|:------------|:--------------------|
+| ADIR 1 knob              | A32NX_OVHD_ADIRS_IR_1_MODE_SELECTOR_KNOB | 0..2     | R/W        | Custom LVAR | 0=OFF, 1=NAV, 2=ATT |
+|                          |                                          |          |            |             |                     |
+| IR 1                     | A32NX_OVHD_ADIRS_IR_1_PB_IS_ON           | 0&#124;1 | R/W        | Custom LVAR |                     |
+|                          | A32NX_OVHD_ADIRS_IR_1_PB_HAS_FAULT       | 0&#124;1 | R          | Custom LVAR |                     |
+|                          |                                          |          |            |             |                     |
+| ADR 1                    | A32NX_OVHD_ADIRS_ADR_1_PB_IS_ON          | 0&#124;1 | R/W        | Custom LVAR |                     |
+|                          | A32NX_OVHD_ADIRS_ADR_1_PB_HAS_FAULT      | 0&#124;1 | R          | Custom LVAR |                     |
+|                          |                                          |          |            |             |                     |
+| Remaining Alignment Time | A32NX_ADIRS_REMAINING_IR_ALIGNMENT_TIME  | seconds  | R          | Custom LVAR |                     |
+|                          |                                          |          |            |             |                     |
+| ON BAT light             | A32NX_OVHD_ADIRS_ON_BAT_IS_ILLUMINATED   | 0&#124;1 | R          | Custom LVAR |                     |
 
 ### APU Panel
 
 Flight Deck: [APU Panel](flight-deck/ovhd/apu.md)
 
-| Function  | API Usage                             | Values     | Read/Write | Type        | Remark |
-|:----------|:--------------------------------------|:-----------|:-----------|:------------|:-------|
-| MASTER SW | A32NX_OVHD_APU_MASTER_SW_PB_IS_ON     | 0 &#124; 1 | R/W        | Custom LVAR |        |
-|           | A32NX_OVHD_APU_MASTER_SW_PB_HAS_FAULT | 0 &#124; 1 | R          | Custom LVAR |        |
-|           |                                       |            |            |             |        |
-| START     | A32NX_OVHD_APU_START_PB_IS_ON         | 0 &#124; 1 | R/W        | Custom LVAR |        |
-|           | A32NX_OVHD_APU_START_PB_IS_AVAILABLE  | 0 &#124; 1 | R          | Custom LVAR |        |
+| Function  | API Usage                             | Values   | Read/Write | Type        | Remark |
+|:----------|:--------------------------------------|:---------|:-----------|:------------|:-------|
+| MASTER SW | A32NX_OVHD_APU_MASTER_SW_PB_IS_ON     | 0&#124;1 | R/W        | Custom LVAR |        |
+|           | A32NX_OVHD_APU_MASTER_SW_PB_HAS_FAULT | 0&#124;1 | R          | Custom LVAR |        |
+|           |                                       |          |            |             |        |
+| START     | A32NX_OVHD_APU_START_PB_IS_ON         | 0&#124;1 | R/W        | Custom LVAR |        |
+|           | A32NX_OVHD_APU_START_PB_IS_AVAILABLE  | 0&#124;1 | R          | Custom LVAR |        |
 
 !!! note "Search for APU in our [list for all Custom LVARS](https://github.com/flybywiresim/a32nx/blob/master/docs/a320-simvars.md){target=new} for further variables."
 
@@ -224,25 +224,25 @@ Flight Deck: [APU Panel](flight-deck/ovhd/apu.md)
 
 Flight Deck: [RCDR Panel](flight-deck/ovhd/voice-recorder.md)
 
-| Function  | API Usage                    | Values     | Read/Write | Type        | Remark |
-|:----------|:-----------------------------|:-----------|:-----------|:------------|:-------|
-| GND CTL   | A32NX_RCDR_GROUND_CONTROL_ON | 0 &#124; 1 | R/W        | Custom LVAR |        |
-|           |                              |            |            |             |        |
-| CVR ERASE | N/A                          |            |            |             |        |
-|           |                              |            |            |             |        |
-| CVR TEST  | A32NX_RCDR_TEST              | 0 &#124; 1 | R/W        | Custom LVAR |        |
+| Function  | API Usage                    | Values   | Read/Write | Type        | Remark |
+|:----------|:-----------------------------|:---------|:-----------|:------------|:-------|
+| GND CTL   | A32NX_RCDR_GROUND_CONTROL_ON | 0&#124;1 | R/W        | Custom LVAR |        |
+|           |                              |          |            |             |        |
+| CVR ERASE | N/A                          |          |            |             |        |
+|           |                              |          |            |             |        |
+| CVR TEST  | A32NX_RCDR_TEST              | 0&#124;1 | R/W        | Custom LVAR |        |
 
 ### Oxygen Panel
 
 Flight Deck: [Oxygen Panel](flight-deck/ovhd/oxygen.md)
 
-| Function    | API Usage                       | Values     | Read/Write | Type        | Remark |
-|:------------|:--------------------------------|:-----------|:-----------|:------------|:-------|
-| MASK MAN ON | A32NX_OXYGEN_MASKS_DEPLOYED     | 0 &#124; 1 | R/W        | Custom LVAR |        |
-|             |                                 |            |            |             |        |
-| PASSENGER   | A32NX_OXYGEN_PASSENGER_LIGHT_ON | 0 &#124; 1 | R/W        | Custom LVAR |        |
-|             |                                 |            |            |             |        |
-| CREW SUPPLY | PUSH_OVHD_OXYGEN_CREW           | 0 &#124; 1 | R/W        | Custom LVAR |        |
+| Function    | API Usage                       | Values   | Read/Write | Type        | Remark |
+|:------------|:--------------------------------|:---------|:-----------|:------------|:-------|
+| MASK MAN ON | A32NX_OXYGEN_MASKS_DEPLOYED     | 0&#124;1 | R/W        | Custom LVAR |        |
+|             |                                 |          |            |             |        |
+| PASSENGER   | A32NX_OXYGEN_PASSENGER_LIGHT_ON | 0&#124;1 | R/W        | Custom LVAR |        |
+|             |                                 |          |            |             |        |
+| CREW SUPPLY | PUSH_OVHD_OXYGEN_CREW           | 0&#124;1 | R/W        | Custom LVAR |        |
 
 ### Fire Panel
 
@@ -250,25 +250,25 @@ Flight Deck: [Fire Panel](flight-deck/ovhd/fire.md)
 
 !!! note "The below table shows the API for ENG 1. Replace `1` with `2`for ENG 2."
 
-| Function         | API Usage                        | Values     | Read/Write | Type        | Remark                                   |
-|:-----------------|:---------------------------------|:-----------|:-----------|:------------|:-----------------------------------------|
-| APU FIRE Test    | A32NX_FIRE_TEST_APU              | 0 &#124; 1 | R/W        | Custom LVAR |                                          |
-|                  |                                  |            |            |             |                                          |
-| APU FIRE GUARD   | A32NX_FIRE_GUARD_APU             | 0 &#124; 1 | R/W        | Custom LVAR |                                          |
-|                  |                                  |            |            |             |                                          |
-| APU FIRE         | A32NX_FIRE_BUTTON_APU            | 0 -> 1     | R/W        | Custom LVAR | Open Guard first. Can't be reset.        |
-|                  |                                  |            |            |             |                                          |
-| APU DISCH        | A32NX_FIRE_APU_AGENT1_DISCHARGE  | 0 -> 1     | R/W        | Custom LVAR | Press Fire button first. Can't be reset. |
-|                  |                                  |            |            |             |                                          |
-| ENG 1 FIRE TEST  | A32NX_FIRE_TEST_ENG1             | 0 &#124; 1 | R/W        | Custom LVAR |                                          |
-|                  |                                  |            |            |             |                                          |
-| ENG 1 FIRE GUARD | A32NX_FIRE_GUARD_ENG1            | 0 &#124; 1 | R/W        | Custom LVAR |                                          |
-|                  |                                  |            |            |             |                                          |
-| ENG 1 FIRE       | A32NX_FIRE_BUTTON_ENG1           | 0 -> 1     | R/W        | Custom LVAR | Open Guard first. Can't be reset.        |
-|                  |                                  |            |            |             |                                          |
-| ENG 1 AGENT 1    | A32NX_FIRE_ENG1_AGENT1_DISCHARGE | 0 -> 1     | R/W        | Custom LVAR | Press Fire button first. Can't be reset. |
-|                  |                                  |            |            |             |                                          |
-| ENG 1 AGENT 2    | A32NX_FIRE_ENG2_AGENT1_DISCHARGE | 0 -> 1     | R/W        | Custom LVAR | Press Fire button first. Can't be reset. |
+| Function         | API Usage                        | Values   | Read/Write | Type        | Remark                                   |
+|:-----------------|:---------------------------------|:---------|:-----------|:------------|:-----------------------------------------|
+| APU FIRE Test    | A32NX_FIRE_TEST_APU              | 0&#124;1 | R/W        | Custom LVAR |                                          |
+|                  |                                  |          |            |             |                                          |
+| APU FIRE GUARD   | A32NX_FIRE_GUARD_APU             | 0&#124;1 | R/W        | Custom LVAR |                                          |
+|                  |                                  |          |            |             |                                          |
+| APU FIRE         | A32NX_FIRE_BUTTON_APU            | 0 -> 1   | R/W        | Custom LVAR | Open Guard first. Can't be reset.        |
+|                  |                                  |          |            |             |                                          |
+| APU DISCH        | A32NX_FIRE_APU_AGENT1_DISCHARGE  | 0 -> 1   | R/W        | Custom LVAR | Press Fire button first. Can't be reset. |
+|                  |                                  |          |            |             |                                          |
+| ENG 1 FIRE TEST  | A32NX_FIRE_TEST_ENG1             | 0&#124;1 | R/W        | Custom LVAR |                                          |
+|                  |                                  |          |            |             |                                          |
+| ENG 1 FIRE GUARD | A32NX_FIRE_GUARD_ENG1            | 0&#124;1 | R/W        | Custom LVAR |                                          |
+|                  |                                  |          |            |             |                                          |
+| ENG 1 FIRE       | A32NX_FIRE_BUTTON_ENG1           | 0 -> 1   | R/W        | Custom LVAR | Open Guard first. Can't be reset.        |
+|                  |                                  |          |            |             |                                          |
+| ENG 1 AGENT 1    | A32NX_FIRE_ENG1_AGENT1_DISCHARGE | 0 -> 1   | R/W        | Custom LVAR | Press Fire button first. Can't be reset. |
+|                  |                                  |          |            |             |                                          |
+| ENG 1 AGENT 2    | A32NX_FIRE_ENG2_AGENT1_DISCHARGE | 0 -> 1   | R/W        | Custom LVAR | Press Fire button first. Can't be reset. |
 
 ### Fuel Panel
 
@@ -277,118 +277,118 @@ Flight Deck: [Fuel Panel](flight-deck/ovhd/fuel.md)
 !!! note "The below table shows the API for PUMP 1. Replace `1` with `2..6` for the other pumps."
     L1=2, L2=5. C1=1, C2=4, R1=3, R2=6
 
-| Function    | API Usage                 | Values     | Read/Write | Type       | Remark |
-|:------------|:--------------------------|:-----------|:-----------|:-----------|:-------|
-| Fuel Pump 1 | FUELSYSTEM_PUMP_TOGGLE    | 1..6       | -          | MSFS EVENT |        |
-|             | FUELSYSTEM PUMP ACTIVE:1  | 0 &#124; 1 | R          | MSFS VAR   |        |
-|             | FUELSYSTEM PUMP SWITCH:1  | 0 &#124; 1 | R          | MSFS VAR   |        |
-|             |                           |            |            |            |        |
-| X FEED      | FUELSYSTEM_VALVE_TOGGLE   | 3          | -          | MSFS EVENT |        |
-|             | FUELSYSTEM VALVE SWITCH:3 | 0 &#124; 1 | R          | MSFS VAR   |        |
-|             |                           |            |            |            |        |
-| MODE SEL    | N/A                       |            |            |            |        |
+| Function    | API Usage                 | Values   | Read/Write | Type       | Remark |
+|:------------|:--------------------------|:---------|:-----------|:-----------|:-------|
+| Fuel Pump 1 | FUELSYSTEM_PUMP_TOGGLE    | 1..6     | -          | MSFS EVENT |        |
+|             | FUELSYSTEM PUMP ACTIVE:1  | 0&#124;1 | R          | MSFS VAR   |        |
+|             | FUELSYSTEM PUMP SWITCH:1  | 0&#124;1 | R          | MSFS VAR   |        |
+|             |                           |          |            |            |        |
+| X FEED      | FUELSYSTEM_VALVE_TOGGLE   | 3        | -          | MSFS EVENT |        |
+|             | FUELSYSTEM VALVE SWITCH:3 | 0&#124;1 | R          | MSFS VAR   |        |
+|             |                           |          |            |            |        |
+| MODE SEL    | N/A                       |          |            |            |        |
 
 ### Air Condition Panel
 
 Flight Deck: [AC Panel](flight-deck/ovhd/ac.md)
 
-| Function       | API Usage                                                 | Values     | Read/Write | Type        | Remark       |
-|:---------------|:----------------------------------------------------------|:-----------|:-----------|:------------|:-------------|
-| APU BLEED      | A32NX_OVHD_PNEU_APU_BLEED_PB_IS_ON                        | 0 &#124; 1 | R/W        | Custom LVAR |              |
-|                |                                                           |            |            |             |              |
-| ENG 1 BLEED    | ENGINE_BLEED_AIR_SOURCE_TOGGLE                            | 1          | -          | MSFS EVENT  |              |
-|                | XMLVAR_MOMENTARY_PUSH_<br/>OVHD_AIRCOND_ENG1BLEED_PRESSED | 0 &#124; 1 | R          | Custom LVAR |              |
-|                |                                                           |            |            |             |              |
-| ENG 2 BLEED    | ENGINE_BLEED_AIR_SOURCE_TOGGLE                            | 2          | -          | MSFS EVENT  |              |
-|                | XMLVAR_MOMENTARY_PUSH_<br/>OVHD_AIRCOND_ENG2BLEED_PRESSED | 0 &#124; 1 | R          | Custom LVAR |              |
-|                |                                                           |            |            |             |              |
-| X BLEED knob   | A32NX_KNOB_OVHD_AIRCOND_XBLEED_POSITION                   | 0..2       | R/W        | Custom LVAR |              |
-|                | A32NX_PNEU_XBLEED_VALVE_OPEN                              | 0 &#124; 1 | R          | Custom LVAR |              |
-|                | APU_BLEED_PRESSURE                                        | ..         | R          | Custom LVAR |              |
-|                |                                                           |            |            |             |              |
-| PACK 1         | A32NX_OVHD_COND_PACK_1_PB_IS_ON                           | 0 &#124; 1 | R/W        | Custom LVAR |              |
-|                | A32NX_OVHD_COND_PACK_1_PB_HAS_FAULT                       | 0 &#124; 1 | R/W        | Custom LVAR |              |
-|                | A32NX_COND_PACK_FLOW_VALVE_1_IS_OPEN                      | 0 &#124; 1 | R          | Custom LVAR |              |
-|                |                                                           |            |            |             |              |
-| PACK 2         | A32NX_OVHD_COND_PACK_2_PB_IS_ON                           | 0 &#124; 1 | R/W        | Custom LVAR |              |
-|                | A32NX_OVHD_COND_PACK_2_PB_HAS_FAULT                       | 0 &#124; 1 | R/W        | Custom LVAR |              |
-|                | A32NX_COND_PACK_FLOW_VALVE_2_IS_OPEN                      | 0 &#124; 1 | R          | Custom LVAR |              |
-|                |                                                           |            |            |             |              |
-| PACK FLOW knob | A32NX_KNOB_OVHD_AIRCOND_PACKFLOW_POSITION                 | 0..2       | R/W        | Custom LVAR |              |
-|                | A32NX_COND_PACK_FLOW                                      | 0..120     | R          | Custom LVAR |              |
-|                |                                                           |            |            |             |              |
-| COCKPIT knob   | A32NX_OVHD_COND_CKPT_SELECTOR_KNOB                        | 0..100     | R/W        | Custom LVAR |              |
-|                | A32NX_COND_CKPT_TEMP                                      | °          | R          | Custom LVAR |              |
-|                | A32NX_COND_CKPT_DUCT_TEMP                                 | °          | R          | Custom LVAR |              |
-|                |                                                           |            |            |             |              |
-| FWD CABIN knob | A32NX_OVHD_COND_FWD_SELECTOR_KNOB                         | 0..100     | R/W        | Custom LVAR |              |
-|                | A32NX_COND_FWD_TEMP                                       | °          | R          | Custom LVAR |              |
-|                | A32NX_COND_FWD_DUCT_TEMP                                  | °          | R          | Custom LVAR |              |
-|                |                                                           |            |            |             |              |
-| AFT CABIN knob | A32NX_OVHD_COND_AFT_SELECTOR_KNOB                         | 0..100     | R/W        | Custom LVAR |              |
-|                | A32NX_COND_AFT_TEMP                                       | °          | R          | Custom LVAR |              |
-|                | A32NX_COND_AFT_DUCT_TEMP                                  | °          | R          | Custom LVAR |              |
-|                |                                                           |            |            |             |              |
-| HOT AIR        | A32NX_AIRCOND_HOTAIR_TOGGLE                               | 0 &#124; 1 | R/W        | Custom LVAR |              |
-|                | A32NX_AIRCOND_HOTAIR_FAULT                                | 0 &#124; 1 | R/W        | Custom LVAR |              |
-|                |                                                           |            |            |             |              |
-| RAM AIR        | A32NX_AIRCOND_RAMAIR_TOGGLE_LOCK                          | 0 &#124; 1 | R          | Custom LVAR | Switch Guard |
-|                | A32NX_AIRCOND_RAMAIR_TOGGLE                               | 0 &#124; 1 | R/W        | Custom LVAR |              |
+| Function       | API Usage                                                 | Values   | Read/Write | Type        | Remark       |
+|:---------------|:----------------------------------------------------------|:---------|:-----------|:------------|:-------------|
+| APU BLEED      | A32NX_OVHD_PNEU_APU_BLEED_PB_IS_ON                        | 0&#124;1 | R/W        | Custom LVAR |              |
+|                |                                                           |          |            |             |              |
+| ENG 1 BLEED    | ENGINE_BLEED_AIR_SOURCE_TOGGLE                            | 1        | -          | MSFS EVENT  |              |
+|                | XMLVAR_MOMENTARY_PUSH_<br/>OVHD_AIRCOND_ENG1BLEED_PRESSED | 0&#124;1 | R          | Custom LVAR |              |
+|                |                                                           |          |            |             |              |
+| ENG 2 BLEED    | ENGINE_BLEED_AIR_SOURCE_TOGGLE                            | 2        | -          | MSFS EVENT  |              |
+|                | XMLVAR_MOMENTARY_PUSH_<br/>OVHD_AIRCOND_ENG2BLEED_PRESSED | 0&#124;1 | R          | Custom LVAR |              |
+|                |                                                           |          |            |             |              |
+| X BLEED knob   | A32NX_KNOB_OVHD_AIRCOND_XBLEED_POSITION                   | 0..2     | R/W        | Custom LVAR |              |
+|                | A32NX_PNEU_XBLEED_VALVE_OPEN                              | 0&#124;1 | R          | Custom LVAR |              |
+|                | APU_BLEED_PRESSURE                                        | ..       | R          | Custom LVAR |              |
+|                |                                                           |          |            |             |              |
+| PACK 1         | A32NX_OVHD_COND_PACK_1_PB_IS_ON                           | 0&#124;1 | R/W        | Custom LVAR |              |
+|                | A32NX_OVHD_COND_PACK_1_PB_HAS_FAULT                       | 0&#124;1 | R/W        | Custom LVAR |              |
+|                | A32NX_COND_PACK_FLOW_VALVE_1_IS_OPEN                      | 0&#124;1 | R          | Custom LVAR |              |
+|                |                                                           |          |            |             |              |
+| PACK 2         | A32NX_OVHD_COND_PACK_2_PB_IS_ON                           | 0&#124;1 | R/W        | Custom LVAR |              |
+|                | A32NX_OVHD_COND_PACK_2_PB_HAS_FAULT                       | 0&#124;1 | R/W        | Custom LVAR |              |
+|                | A32NX_COND_PACK_FLOW_VALVE_2_IS_OPEN                      | 0&#124;1 | R          | Custom LVAR |              |
+|                |                                                           |          |            |             |              |
+| PACK FLOW knob | A32NX_KNOB_OVHD_AIRCOND_PACKFLOW_POSITION                 | 0..2     | R/W        | Custom LVAR |              |
+|                | A32NX_COND_PACK_FLOW                                      | 0..120   | R          | Custom LVAR |              |
+|                |                                                           |          |            |             |              |
+| COCKPIT knob   | A32NX_OVHD_COND_CKPT_SELECTOR_KNOB                        | 0..100   | R/W        | Custom LVAR |              |
+|                | A32NX_COND_CKPT_TEMP                                      | °        | R          | Custom LVAR |              |
+|                | A32NX_COND_CKPT_DUCT_TEMP                                 | °        | R          | Custom LVAR |              |
+|                |                                                           |          |            |             |              |
+| FWD CABIN knob | A32NX_OVHD_COND_FWD_SELECTOR_KNOB                         | 0..100   | R/W        | Custom LVAR |              |
+|                | A32NX_COND_FWD_TEMP                                       | °        | R          | Custom LVAR |              |
+|                | A32NX_COND_FWD_DUCT_TEMP                                  | °        | R          | Custom LVAR |              |
+|                |                                                           |          |            |             |              |
+| AFT CABIN knob | A32NX_OVHD_COND_AFT_SELECTOR_KNOB                         | 0..100   | R/W        | Custom LVAR |              |
+|                | A32NX_COND_AFT_TEMP                                       | °        | R          | Custom LVAR |              |
+|                | A32NX_COND_AFT_DUCT_TEMP                                  | °        | R          | Custom LVAR |              |
+|                |                                                           |          |            |             |              |
+| HOT AIR        | A32NX_AIRCOND_HOTAIR_TOGGLE                               | 0&#124;1 | R/W        | Custom LVAR |              |
+|                | A32NX_AIRCOND_HOTAIR_FAULT                                | 0&#124;1 | R/W        | Custom LVAR |              |
+|                |                                                           |          |            |             |              |
+| RAM AIR        | A32NX_AIRCOND_RAMAIR_TOGGLE_LOCK                          | 0&#124;1 | R          | Custom LVAR | Switch Guard |
+|                | A32NX_AIRCOND_RAMAIR_TOGGLE                               | 0&#124;1 | R/W        | Custom LVAR |              |
 
 ### Anti Ice Panel
 
 Flight Deck: [Anti Ice Panel](flight-deck/ovhd/anti-ice.md)
 
-| Function          | API Usage                                            | Values     | Read/Write | Type             | Remark                  |
-|:------------------|:-----------------------------------------------------|:-----------|:-----------|:-----------------|:------------------------|
-| WING              | TOGGLE_STRUCTURAL_DEICE                              | -          | -          | SIMCONNECT EVENT | Function & Button light |
-|                   | STRUCURAL DEICE SWITCH                               | 0 &#124; 1 | R/W        | SIMCONNECT VAR   | Function & Button light |
-|                   | XMLVAR_MOMENTARY_PUSH_OVHD_<br/>ANTIICE_WING_PRESSED | 0 &#124; 1 | R/W        | Custom LVAR      | Button state            |
-|                   |                                                      |            |            |                  |                         |
-| ENG 1             | ANTI_ICE_TOGGLE_ENG1                                 | -          | -          | SIMCONNECT EVENT | Function & Button light |
-|                   | ENG ANTI ICE:1                                       | 0 &#124; 1 | R/W        | SIMCONNECT VAR   | Function & Button light |
-|                   | XMLVAR_MOMENTARY_PUSH_OVHD_<br/>ANTIICE_ENG1_PRESSED | 0 &#124; 1 | R/W        | Custom LVAR      | Button state            |
-|                   |                                                      |            |            |                  |                         |
-| ENG 2             | ANTI_ICE_TOGGLE_ENG2                                 | -          | -          | SIMCONNECT EVENT | Function & Button light |
-|                   | ENG ANTI ICE:2                                       | 0 &#124; 1 | R/W        | SIMCONNECT VAR   | Function & Button light |
-|                   | XMLVAR_MOMENTARY_PUSH_OVHD_<br/>ANTIICE_ENG2_PRESSED | 0 &#124; 1 | R/W        | Custom LVAR      | Button state            |
-|                   |                                                      |            |            |                  |                         |
-| PROBE/WINDOW HEAT | A32NX_MAN_PITOT_HEAT                                 | 0 &#124; 1 | R/W        | Custom LVAR      | Function & Button light |
-|                   | XMLVAR_MOMENTARY_PUSH_OVHD_<br/>PROBESWINDOW_PRESSED | 0 &#124; 1 | R/W        | Custom LVAR      | Button state            |
+| Function          | API Usage                                            | Values   | Read/Write | Type             | Remark                  |
+|:------------------|:-----------------------------------------------------|:---------|:-----------|:-----------------|:------------------------|
+| WING              | TOGGLE_STRUCTURAL_DEICE                              | -        | -          | SIMCONNECT EVENT | Function & Button light |
+|                   | STRUCURAL DEICE SWITCH                               | 0&#124;1 | R/W        | SIMCONNECT VAR   | Function & Button light |
+|                   | XMLVAR_MOMENTARY_PUSH_OVHD_<br/>ANTIICE_WING_PRESSED | 0&#124;1 | R/W        | Custom LVAR      | Button state            |
+|                   |                                                      |          |            |                  |                         |
+| ENG 1             | ANTI_ICE_TOGGLE_ENG1                                 | -        | -          | SIMCONNECT EVENT | Function & Button light |
+|                   | ENG ANTI ICE:1                                       | 0&#124;1 | R/W        | SIMCONNECT VAR   | Function & Button light |
+|                   | XMLVAR_MOMENTARY_PUSH_OVHD_<br/>ANTIICE_ENG1_PRESSED | 0&#124;1 | R/W        | Custom LVAR      | Button state            |
+|                   |                                                      |          |            |                  |                         |
+| ENG 2             | ANTI_ICE_TOGGLE_ENG2                                 | -        | -          | SIMCONNECT EVENT | Function & Button light |
+|                   | ENG ANTI ICE:2                                       | 0&#124;1 | R/W        | SIMCONNECT VAR   | Function & Button light |
+|                   | XMLVAR_MOMENTARY_PUSH_OVHD_<br/>ANTIICE_ENG2_PRESSED | 0&#124;1 | R/W        | Custom LVAR      | Button state            |
+|                   |                                                      |          |            |                  |                         |
+| PROBE/WINDOW HEAT | A32NX_MAN_PITOT_HEAT                                 | 0&#124;1 | R/W        | Custom LVAR      | Function & Button light |
+|                   | XMLVAR_MOMENTARY_PUSH_OVHD_<br/>PROBESWINDOW_PRESSED | 0&#124;1 | R/W        | Custom LVAR      | Button state            |
 
 ### Calls Panel
 
 Flight Deck: [Calls Panel](flight-deck/ovhd/calls.md)
 
-| Function | API Usage                | Values     | Read/Write | Type        | Remark |
-|:---------|:-------------------------|:-----------|:-----------|:------------|:-------|
-| MECH     | PUSH_OVHD_CALLS_MECH     | 0 &#124; 1 | R/W        | Custom LVAR |        |
-|          |                          |            |            |             |        |
-| ALL      | PUSH_OVHD_CALLS_ALL      | 0 &#124; 1 | R/W        | Custom LVAR |        |
-|          |                          |            |            |             |        |
-| FWD      | PUSH_OVHD_CALLS_FWD      | 0 &#124; 1 | R/W        | Custom LVAR |        |
-|          |                          |            |            |             |        |
-| AFT      | PUSH_OVHD_CALLS_AFT      | 0 &#124; 1 | R/W        | Custom LVAR |        |
-|          |                          |            |            |             |        |
-| EMER     | A32NX_CALLS_EMER_ON_LOCK | 0 &#124; 1 | R          | Custom LVAR |        |
-|          | A32NX_CALLS_EMER_ON      | 0 &#124; 1 | R/W        | Custom LVAR |        |
+| Function | API Usage                | Values   | Read/Write | Type        | Remark |
+|:---------|:-------------------------|:---------|:-----------|:------------|:-------|
+| MECH     | PUSH_OVHD_CALLS_MECH     | 0&#124;1 | R/W        | Custom LVAR |        |
+|          |                          |          |            |             |        |
+| ALL      | PUSH_OVHD_CALLS_ALL      | 0&#124;1 | R/W        | Custom LVAR |        |
+|          |                          |          |            |             |        |
+| FWD      | PUSH_OVHD_CALLS_FWD      | 0&#124;1 | R/W        | Custom LVAR |        |
+|          |                          |          |            |             |        |
+| AFT      | PUSH_OVHD_CALLS_AFT      | 0&#124;1 | R/W        | Custom LVAR |        |
+|          |                          |          |            |             |        |
+| EMER     | A32NX_CALLS_EMER_ON_LOCK | 0&#124;1 | R          | Custom LVAR |        |
+|          | A32NX_CALLS_EMER_ON      | 0&#124;1 | R/W        | Custom LVAR |        |
 
 ### Wiper Panel
 
 Flight Deck: [Wiper Panel](flight-deck/ovhd/wipers.md)
 
-| Function     | API Usage                            | Values     | Read/Write | Type        | Remark                                 |
-|:-------------|:-------------------------------------|:-----------|:-----------|:------------|:---------------------------------------|
-| WIPER L knob | CIRCUIT ON:77                        | 0 &#124; 1 | R          | MSFS VAR    |                                        |
-|              | ELECTRICAL_CIRCUIT_POWER_SETTING_SET | 77         |            | MSFS Event  | ~~Unclear how to set power correctly~~ |
-|              | ELECTRICAL_CIRCUIT_TOGGLE            | 77         |            | MSFS Event  |                                        |
-|              |                                      |            |            |             |                                        |
-| WIPER R knob | CIRCUIT ON:88                        | 0 &#124; 1 | R          | MSFS        |                                        |
-|              | ELECTRICAL_CIRCUIT_TOGGLE            | 88         |            | MSFS VAR    |                                        |
-|              | ELECTRICAL_CIRCUIT_POWER_SETTING_SET | 88         |            | MSFS Event  | ~~Unclear how to set power correctly~~ |
-|              |                                      |            |            |             |                                        |
-| RAIN RPLNT   | A32NX_RAIN_REPELLENT_LEFT_ON         | 0 &#124; 1 | R          | Custom LVAR |                                        |
-|              | A32NX_RAIN_REPELLENT_RIGHT_ON        | 0 &#124; 1 | R          | Custom LVAR |                                        |
+| Function     | API Usage                            | Values   | Read/Write | Type        | Remark                                 |
+|:-------------|:-------------------------------------|:---------|:-----------|:------------|:---------------------------------------|
+| WIPER L knob | CIRCUIT ON:77                        | 0&#124;1 | R          | MSFS VAR    |                                        |
+|              | ELECTRICAL_CIRCUIT_POWER_SETTING_SET | 77       |            | MSFS Event  | ~~Unclear how to set power correctly~~ |
+|              | ELECTRICAL_CIRCUIT_TOGGLE            | 77       |            | MSFS Event  |                                        |
+|              |                                      |          |            |             |                                        |
+| WIPER R knob | CIRCUIT ON:88                        | 0&#124;1 | R          | MSFS        |                                        |
+|              | ELECTRICAL_CIRCUIT_TOGGLE            | 88       |            | MSFS VAR    |                                        |
+|              | ELECTRICAL_CIRCUIT_POWER_SETTING_SET | 88       |            | MSFS Event  | ~~Unclear how to set power correctly~~ |
+|              |                                      |          |            |             |                                        |
+| RAIN RPLNT   | A32NX_RAIN_REPELLENT_LEFT_ON         | 0&#124;1 | R          | Custom LVAR |                                        |
+|              | A32NX_RAIN_REPELLENT_RIGHT_ON        | 0&#124;1 | R          | Custom LVAR |                                        |
 
 ## Glareshield
 
@@ -419,14 +419,13 @@ Flight Deck: [EFIS Control Panel](flight-deck/glareshield/efis_control.md)
 |              | KOHLMAN_INC                      | -                | -          | SIMCONNECT EVENT |                                                   |
 |              | XMLVAR_Baro1_Mode                | 0..2             | R/W        | Custom LVAR      | 0=QFE, 1=QNH, 2=STD                               |
 |              |                                  |                  |            |                  |                                                   |
-| inHG / hPa   | XMLVAR_BARO_SELECTOR_HPA_1       | 0 &#124; 1       | R/W        | Custom LVAR      | 0=Hg, 1=hPa                                       |
+| inHG / hPa   | XMLVAR_BARO_SELECTOR_HPA_1       | 0&#124;1         | R/W        | Custom LVAR      | 0=Hg, 1=hPa                                       |
 |              |                                  |                  |            |                  |                                                   |
-| FD           | AUTOPILOT FLIGHT DIRECTOR ACTIVE | 0 &#124; 1       | R          | SIMCONNECT VAR   |                                                   |
+| FD           | AUTOPILOT FLIGHT DIRECTOR ACTIVE | 0&#124;1         | R          | SIMCONNECT VAR   |                                                   |
 |              | TOGGLE_FLIGHT_DIRECTOR           | -                | -          | SIMCONNECT EVENT |                                                   |
 |              |                                  |                  |            |                  |                                                   |
-| LS Capt.     | BTN_LS_1_FILTER_ACTIVE           | 0 &#124; 1       | R          | Custom LVAR      | ~~Not working currently.~~                        |
-| LS F.O.      | BTN_LS_2_FILTER_ACTIVE           | 0 &#124; 1       | R          | Custom LVAR      | ~~Not working currently.~~                        |
-|              |                                  |                  |            |                  |                                                   |
+| LS Capt.     | BTN_LS_1_FILTER_ACTIVE           | 0&#124;1         | R          | Custom LVAR      |                                                   |
+| LS F.O.      | BTN_LS_2_FILTER_ACTIVE           | 0&#124;1         | R          | Custom LVAR      |                                                   |
 |              |                                  |                  |            |                  |                                                   |
 | ND Filter    | A32NX_EFIS_L_OPTION              | 0..5             | R/W        | Custom LVAR      | 0=none, 1=CSTR, 2=VOR, 3=WPT, 4=NDB, 5=ARPT       |
 |              | A32NX_EFIS_R_OPTION              | 0..5             | R/W        | Custom LVAR      | 0=none, 1=CSTR, 2=VOR, 3=WPT, 4=NDB, 5=ARPT       |
@@ -446,115 +445,115 @@ Flight Deck: [EFIS Control Panel](flight-deck/glareshield/efis_control.md)
 
 Flight Deck: [FCU Panel](flight-deck/glareshield/fcu.md)
 
-| Function          | API Usage                           | Values                   | Read/Write | Type             | Remark                                                                   |
-|:------------------|:------------------------------------|:-------------------------|:-----------|:-----------------|:-------------------------------------------------------------------------|
-| SPD knob          | A32NX_AUTOPILOT_SPEED_SELECTED      | 0..399                   | R          | Custom LVAR      |                                                                          |
-|                   | A32NX.FCU_SPD_INC                   | -                        | -          | Custom EVENT     |                                                                          |
-|                   | A32NX.FCU_SPD_DEC                   | -                        | -          | Custom EVENT     |                                                                          |
-|                   | A32NX.FCU_SPD_SET                   | 0..399                   | -          | Custom EVENT     |                                                                          |
-|                   | A32NX.FCU_SPD_PUSH                  | -                        | -          | Custom EVENT     |                                                                          |
-|                   | A32NX.FCU_SPD_PULL                  | -                        | -          | Custom EVENT     |                                                                          |
-|                   | AP_AIRSPEED_ON                      | -                        | -          | SIMCONNECT EVENT | Push                                                                     |
-|                   | AP_AIRSPEED_OFF                     | -                        | -          | SIMCONNECT EVENT | Pull                                                                     |
-|                   | AP_SPD_VAR_INC                      | -                        | -          | SIMCONNECT EVENT |                                                                          |
-|                   | AP_SPD_VAR_DEC                      | -                        | -          | SIMCONNECT EVENT |                                                                          |
-|                   | AP_MACH_VAR_INC                     | -                        | -          | SIMCONNECT EVENT |                                                                          |
-|                   | AP_MACH_VAR_DEC                     | -                        | -          | SIMCONNECT EVENT |                                                                          |
-|                   |                                     |                          |            |                  |                                                                          |
-| HDG knob          | A32NX_AUTOPILOT_HEADING_SELECTED    | 0..359                   | R          | Custom LVAR      |                                                                          |
-|                   | A32NX.FCU_HDG_INC                   | -                        | -          | Custom EVENT     |                                                                          |
-|                   | A32NX.FCU_HDG_DEC                   | -                        | -          | Custom EVENT     |                                                                          |
-|                   | A32NX.FCU_HDG_SET                   | 0..359                   | -          | Custom EVENT     |                                                                          |
-|                   | A32NX.FCU_HDG_PUSH                  | -                        | -          | Custom EVENT     |                                                                          |
-|                   | A32NX.FCU_HDG_PULL                  | -                        | -          | Custom EVENT     |                                                                          |
-|                   | AP_HDG_HOLD_ON                      | -                        | -          | SIMCONNECT EVENT | Push                                                                     |
-|                   | AP_HDG_HOLD_OFF                     | -                        | -          | SIMCONNECT EVENT | Pull                                                                     |
-|                   | HEADING_BUG_INC                     | -                        | -          | SIMCONNECT EVENT |                                                                          |
-|                   | HEADING_BUG_DEC                     | -                        | -          | SIMCONNECT EVENT |                                                                          |
-|                   |                                     |                          |            |                  |                                                                          |
-| LOC               | A32NX_FCU_LOC_MODE_ACTIVE           | 0 &#124; 1               | R          | Custom LVAR      |                                                                          |
-|                   | A32NX.FCU_LOC_PUSH                  | -                        | -          | Custom EVENT     |                                                                          |
-|                   | AP_LOC_HOLD                         | -                        | -          | SIMCONNECT EVENT |                                                                          |
-|                   |                                     |                          |            |                  |                                                                          |
-| ALT knob          | AUTOPILOT ALTITUDE LOCK VAR:3       | 100..49000               |            | MSFS VAR         |                                                                          |
-|                   | A32NX.FCU_ALT_INC                   | 0 &#124; 100 &#124; 1000 | R          | Custom EVENT     | 0=Use FCU Setting, 100=100, 1000=1000                                    |
-|                   | A32NX.FCU_ALT_DEC                   | 0 &#124; 100 &#124; 1000 | R          | Custom EVENT     | 0=Use FCU Setting, 100=100, 1000=1000                                    |
-|                   | A32NX.FCU_ALT_SET                   | 100..49000               | -          | Custom EVENT     |                                                                          |
-|                   | A32NX.FCU_ALT_PUSH                  | -                        | -          | Custom EVENT     |                                                                          |
-|                   | A32NX.FCU_ALT_PULL                  | -                        | -          | Custom EVENT     |                                                                          |
-|                   | AP_ALT_HOLD_ON                      | -                        | -          | SIMCONNECT EVENT | Push                                                                     |
-|                   | AP_ALT_HOLD_OFF                     | -                        | -          | SIMCONNECT EVENT | Pull                                                                     |
-|                   | AP_ALT_VAR_INC                      | -                        | -          | SIMCONNECT EVENT |                                                                          |
-|                   | AP_ALT_VAR_DEC                      | -                        | -          | SIMCONNECT EVENT |                                                                          |
-|                   |                                     |                          |            |                  |                                                                          |
-| ALT INC 100-1000  | A32NX.FCU_ALT_INCREMENT_TOGGLE      | -                        | -          | Custom EVENT     |                                                                          |
-|                   | A32NX.FCU_ALT_INCREMENT_SET         | 100 &#124; 1000          | -          | Custom EVENT     |                                                                          |
-|                   | XMLVAR_AUTOPILOT_ALTITUDE_INCREMENT | 100 &#124; 1000          | R          | Custom LVAR      |                                                                          |
-|                   | AP_ALT_HOLD                         | -                        | -          | SIMCONNECT EVENT | Repurposed event as Simconnect has no standard event for this otherwise. |
-|                   |                                     |                          |            |                  |                                                                          |
-| EXPED             | A32NX_FMA_EXPEDITE_MODE             | 0 &#124; 1               | R          | Custom LVAR      |                                                                          |
-|                   | A32NX.FCU_EXPED_PUSH                | -                        | -          | Custom EVENT     |                                                                          |
-|                   | AP_ATT_HOLD                         | -                        | -          | SIMCONNECT EVENT | Repurposed event as Simconnect has no standard event for this otherwise. |
-|                   |                                     |                          |            |                  |                                                                          |
-| V/S FPA knob      | A32NX_AUTOPILOT_VS_SELECTED         | -6000..6000              | R          | Custom LVAR      |                                                                          |
-|                   | A32NX.FCU_VS_INC                    | -                        | -          | Custom LVAR      | FPA: -9.9..9.9                                                           |
-|                   | A32NX.FCU_VS_DEC                    | -                        | -          | Custom EVENT     |                                                                          |
-|                   | A32NX.FCU_VS_SET                    | -6000..6000              | -          | Custom EVENT     |                                                                          |
-|                   | A32NX.FCU_VS_PUSH                   | -                        | -          | Custom EVENT     | FPA: -9.9..9.9                                                           |
-|                   | A32NX.FCU_VS_PULL                   | -                        | -          | Custom EVENT     |                                                                          |
-|                   | AP_VS_HOLD_ON                       | -                        | -          | SIMCONNECT EVENT | Push                                                                     |
-|                   | AP_VS_HOLD_OFF                      | -                        | -          | SIMCONNECT EVENT | Pull                                                                     |
-|                   | AP_VS_VAR_INC                       | -                        | -          | SIMCONNECT EVENT |                                                                          |
-|                   | AP_VS_VAR_DEC                       | -                        | -          | SIMCONNECT EVENT |                                                                          |
-|                   |                                     |                          |            |                  |                                                                          |
-| APPR              | A32NX_FCU_APPR_MODE_ACTIVE          | 0 &#124; 1               | R          | Custom LVAR      |                                                                          |
-|                   | A32NX.FCU_APPR_PUSH                 | -                        | -          | Custom EVENT     |                                                                          |
-|                   | AP_APR_HOLD                         | -                        | -          | SIMCONNECT EVENT |                                                                          |
-|                   |                                     |                          |            |                  |                                                                          |
-| AP 1 + 2          | A32NX_AUTOPILOT_1_ACTIVE            | 0 &#124; 1               | R          | Custom LVAR      |                                                                          |
-|                   | A32NX_AUTOPILOT_2_ACTIVE            | 0 &#124; 1               | R          | Custom LVAR      |                                                                          |
-|                   | A32NX.FCU_AP_1_PUSH                 | -                        | -          | Custom EVENT     |                                                                          |
-|                   | A32NX.FCU_AP_2_PUSH                 | -                        | -          | Custom EVENT     |                                                                          |
-|                   | A32NX.FCU_AP_DISCONNECT_PUSH        | -                        |            | Custom EVENT     |                                                                          |
-|                   | AP_MASTER                           | 1                        | -          | SIMCONNECT EVENT | Toggles                                                                  |
-|                   | AUTOPILOT_ON                        | -                        | -          | SIMCONNECT EVENT | 1st call AP1, 2nd call AP2                                               |
-|                   | AUTOPILOT_OFF                       | -                        | -          | SIMCONNECT EVENT | Turns off any AP                                                         |
-|                   | AUTOPILOT_DISENGAGE_SET             | -                        | -          | SIMCONNECT EVENT | 1 for OFF                                                                |
-|                   | AUTOPILOT_DISENGAGE_TOGGLE          | -                        | -          | SIMCONNECT EVENT | Toggles                                                                  |
-|                   |                                     |                          | -          |                  |                                                                          |
-| A/THR             | A32NX_AUTOTHRUST_STATUS             | 0..2                     | R          | Custom LVAR      | 0=Disengaged, 1=Armed, 2=Active                                          |
-|                   | A32NX.FCU_ATHR_PUSH                 | -                        |            | Custom EVENT     |                                                                          |
-|                   | A32NX.FCU_ATHR_DISCONNECT_PUSH      | -                        | -          | Custom EVENT     |                                                                          |
-|                   | AUTO_THROTTLE_ARM                   | -                        | -          | SIMCONNECT EVENT |                                                                          |
-|                   | AUTO_THROTTLE_DISCONNECT            | -                        | -          | SIMCONNECT EVENT |                                                                          |
-|                   | AUTO_THROTTLE_TO_GA                 | -                        | -          | SIMCONNECT EVENT |                                                                          |
-|                   |                                     |                          |            |                  |                                                                          |
-| SPD/MACH          | AUTOPILOT MANAGED SPEED IN MACH     | 0 &#124; 1               | R          | MSFS VAR         |                                                                          |
-|                   | A32NX.FCU_SPD_MACH_TOGGLE_PUSH      | -                        | -          | Custom EVENT     |                                                                          |
-|                   | AP_MACH_HOLD                        | -                        | -          | SIMCONNECT EVENT | Repurposed event as Simconnect has no standard event for this otherwise. |
-|                   |                                     |                          |            |                  |                                                                          |
-| HDG-TRK / V/S-FPA | A32NX_TRK_FPA_MODE_ACTIVE           | 0 &#124; 1               | R          | Custom LVAR      |                                                                          |
-|                   | A32NX.FCU_TRK_FPA_TOGGLE_PUSH       | -                        | -          | Custom EVENT     |                                                                          |
-|                   | AP_VS_HOLD                          | -                        | -          | SIMCONNECT EVENT | Repurposed event as Simconnect has no standard event for this otherwise. |
+| Function          | API Usage                           | Values               | Read/Write | Type             | Remark                                                                   |
+|:------------------|:------------------------------------|:---------------------|:-----------|:-----------------|:-------------------------------------------------------------------------|
+| SPD knob          | A32NX_AUTOPILOT_SPEED_SELECTED      | 0..399               | R          | Custom LVAR      |                                                                          |
+|                   | A32NX.FCU_SPD_INC                   | -                    | -          | Custom EVENT     |                                                                          |
+|                   | A32NX.FCU_SPD_DEC                   | -                    | -          | Custom EVENT     |                                                                          |
+|                   | A32NX.FCU_SPD_SET                   | 0..399               | -          | Custom EVENT     |                                                                          |
+|                   | A32NX.FCU_SPD_PUSH                  | -                    | -          | Custom EVENT     |                                                                          |
+|                   | A32NX.FCU_SPD_PULL                  | -                    | -          | Custom EVENT     |                                                                          |
+|                   | AP_AIRSPEED_ON                      | -                    | -          | SIMCONNECT EVENT | Push                                                                     |
+|                   | AP_AIRSPEED_OFF                     | -                    | -          | SIMCONNECT EVENT | Pull                                                                     |
+|                   | AP_SPD_VAR_INC                      | -                    | -          | SIMCONNECT EVENT |                                                                          |
+|                   | AP_SPD_VAR_DEC                      | -                    | -          | SIMCONNECT EVENT |                                                                          |
+|                   | AP_MACH_VAR_INC                     | -                    | -          | SIMCONNECT EVENT |                                                                          |
+|                   | AP_MACH_VAR_DEC                     | -                    | -          | SIMCONNECT EVENT |                                                                          |
+|                   |                                     |                      |            |                  |                                                                          |
+| HDG knob          | A32NX_AUTOPILOT_HEADING_SELECTED    | 0..359               | R          | Custom LVAR      |                                                                          |
+|                   | A32NX.FCU_HDG_INC                   | -                    | -          | Custom EVENT     |                                                                          |
+|                   | A32NX.FCU_HDG_DEC                   | -                    | -          | Custom EVENT     |                                                                          |
+|                   | A32NX.FCU_HDG_SET                   | 0..359               | -          | Custom EVENT     |                                                                          |
+|                   | A32NX.FCU_HDG_PUSH                  | -                    | -          | Custom EVENT     |                                                                          |
+|                   | A32NX.FCU_HDG_PULL                  | -                    | -          | Custom EVENT     |                                                                          |
+|                   | AP_HDG_HOLD_ON                      | -                    | -          | SIMCONNECT EVENT | Push                                                                     |
+|                   | AP_HDG_HOLD_OFF                     | -                    | -          | SIMCONNECT EVENT | Pull                                                                     |
+|                   | HEADING_BUG_INC                     | -                    | -          | SIMCONNECT EVENT |                                                                          |
+|                   | HEADING_BUG_DEC                     | -                    | -          | SIMCONNECT EVENT |                                                                          |
+|                   |                                     |                      |            |                  |                                                                          |
+| LOC               | A32NX_FCU_LOC_MODE_ACTIVE           | 0&#124;1             | R          | Custom LVAR      |                                                                          |
+|                   | A32NX.FCU_LOC_PUSH                  | -                    | -          | Custom EVENT     |                                                                          |
+|                   | AP_LOC_HOLD                         | -                    | -          | SIMCONNECT EVENT |                                                                          |
+|                   |                                     |                      |            |                  |                                                                          |
+| ALT knob          | AUTOPILOT ALTITUDE LOCK VAR:3       | 100..49000           |            | MSFS VAR         |                                                                          |
+|                   | A32NX.FCU_ALT_INC                   | 0&#124;100&#124;1000 | R          | Custom EVENT     | 0=Use FCU Setting, 100=100, 1000=1000                                    |
+|                   | A32NX.FCU_ALT_DEC                   | 0&#124;100&#124;1000 | R          | Custom EVENT     | 0=Use FCU Setting, 100=100, 1000=1000                                    |
+|                   | A32NX.FCU_ALT_SET                   | 100..49000           | -          | Custom EVENT     |                                                                          |
+|                   | A32NX.FCU_ALT_PUSH                  | -                    | -          | Custom EVENT     |                                                                          |
+|                   | A32NX.FCU_ALT_PULL                  | -                    | -          | Custom EVENT     |                                                                          |
+|                   | AP_ALT_HOLD_ON                      | -                    | -          | SIMCONNECT EVENT | Push                                                                     |
+|                   | AP_ALT_HOLD_OFF                     | -                    | -          | SIMCONNECT EVENT | Pull                                                                     |
+|                   | AP_ALT_VAR_INC                      | -                    | -          | SIMCONNECT EVENT |                                                                          |
+|                   | AP_ALT_VAR_DEC                      | -                    | -          | SIMCONNECT EVENT |                                                                          |
+|                   |                                     |                      |            |                  |                                                                          |
+| ALT INC 100-1000  | A32NX.FCU_ALT_INCREMENT_TOGGLE      | -                    | -          | Custom EVENT     |                                                                          |
+|                   | A32NX.FCU_ALT_INCREMENT_SET         | 100&#124;1000        | -          | Custom EVENT     |                                                                          |
+|                   | XMLVAR_AUTOPILOT_ALTITUDE_INCREMENT | 100&#124;1000        | R          | Custom LVAR      |                                                                          |
+|                   | AP_ALT_HOLD                         | -                    | -          | SIMCONNECT EVENT | Repurposed event as Simconnect has no standard event for this otherwise. |
+|                   |                                     |                      |            |                  |                                                                          |
+| EXPED             | A32NX_FMA_EXPEDITE_MODE             | 0&#124;1             | R          | Custom LVAR      |                                                                          |
+|                   | A32NX.FCU_EXPED_PUSH                | -                    | -          | Custom EVENT     |                                                                          |
+|                   | AP_ATT_HOLD                         | -                    | -          | SIMCONNECT EVENT | Repurposed event as Simconnect has no standard event for this otherwise. |
+|                   |                                     |                      |            |                  |                                                                          |
+| V/S FPA knob      | A32NX_AUTOPILOT_VS_SELECTED         | -6000..6000          | R          | Custom LVAR      |                                                                          |
+|                   | A32NX.FCU_VS_INC                    | -                    | -          | Custom LVAR      | FPA: -9.9..9.9                                                           |
+|                   | A32NX.FCU_VS_DEC                    | -                    | -          | Custom EVENT     |                                                                          |
+|                   | A32NX.FCU_VS_SET                    | -6000..6000          | -          | Custom EVENT     |                                                                          |
+|                   | A32NX.FCU_VS_PUSH                   | -                    | -          | Custom EVENT     | FPA: -9.9..9.9                                                           |
+|                   | A32NX.FCU_VS_PULL                   | -                    | -          | Custom EVENT     |                                                                          |
+|                   | AP_VS_HOLD_ON                       | -                    | -          | SIMCONNECT EVENT | Push                                                                     |
+|                   | AP_VS_HOLD_OFF                      | -                    | -          | SIMCONNECT EVENT | Pull                                                                     |
+|                   | AP_VS_VAR_INC                       | -                    | -          | SIMCONNECT EVENT |                                                                          |
+|                   | AP_VS_VAR_DEC                       | -                    | -          | SIMCONNECT EVENT |                                                                          |
+|                   |                                     |                      |            |                  |                                                                          |
+| APPR              | A32NX_FCU_APPR_MODE_ACTIVE          | 0&#124;1             | R          | Custom LVAR      |                                                                          |
+|                   | A32NX.FCU_APPR_PUSH                 | -                    | -          | Custom EVENT     |                                                                          |
+|                   | AP_APR_HOLD                         | -                    | -          | SIMCONNECT EVENT |                                                                          |
+|                   |                                     |                      |            |                  |                                                                          |
+| AP 1 + 2          | A32NX_AUTOPILOT_1_ACTIVE            | 0&#124;1             | R          | Custom LVAR      |                                                                          |
+|                   | A32NX_AUTOPILOT_2_ACTIVE            | 0&#124;1             | R          | Custom LVAR      |                                                                          |
+|                   | A32NX.FCU_AP_1_PUSH                 | -                    | -          | Custom EVENT     |                                                                          |
+|                   | A32NX.FCU_AP_2_PUSH                 | -                    | -          | Custom EVENT     |                                                                          |
+|                   | A32NX.FCU_AP_DISCONNECT_PUSH        | -                    |            | Custom EVENT     |                                                                          |
+|                   | AP_MASTER                           | 1                    | -          | SIMCONNECT EVENT | Toggles                                                                  |
+|                   | AUTOPILOT_ON                        | -                    | -          | SIMCONNECT EVENT | 1st call AP1, 2nd call AP2                                               |
+|                   | AUTOPILOT_OFF                       | -                    | -          | SIMCONNECT EVENT | Turns off any AP                                                         |
+|                   | AUTOPILOT_DISENGAGE_SET             | -                    | -          | SIMCONNECT EVENT | 1 for OFF                                                                |
+|                   | AUTOPILOT_DISENGAGE_TOGGLE          | -                    | -          | SIMCONNECT EVENT | Toggles                                                                  |
+|                   |                                     |                      | -          |                  |                                                                          |
+| A/THR             | A32NX_AUTOTHRUST_STATUS             | 0..2                 | R          | Custom LVAR      | 0=Disengaged, 1=Armed, 2=Active                                          |
+|                   | A32NX.FCU_ATHR_PUSH                 | -                    |            | Custom EVENT     |                                                                          |
+|                   | A32NX.FCU_ATHR_DISCONNECT_PUSH      | -                    | -          | Custom EVENT     |                                                                          |
+|                   | AUTO_THROTTLE_ARM                   | -                    | -          | SIMCONNECT EVENT |                                                                          |
+|                   | AUTO_THROTTLE_DISCONNECT            | -                    | -          | SIMCONNECT EVENT |                                                                          |
+|                   | AUTO_THROTTLE_TO_GA                 | -                    | -          | SIMCONNECT EVENT |                                                                          |
+|                   |                                     |                      |            |                  |                                                                          |
+| SPD/MACH          | AUTOPILOT MANAGED SPEED IN MACH     | 0&#124;1             | R          | MSFS VAR         |                                                                          |
+|                   | A32NX.FCU_SPD_MACH_TOGGLE_PUSH      | -                    | -          | Custom EVENT     |                                                                          |
+|                   | AP_MACH_HOLD                        | -                    | -          | SIMCONNECT EVENT | Repurposed event as Simconnect has no standard event for this otherwise. |
+|                   |                                     |                      |            |                  |                                                                          |
+| HDG-TRK / V/S-FPA | A32NX_TRK_FPA_MODE_ACTIVE           | 0&#124;1             | R          | Custom LVAR      |                                                                          |
+|                   | A32NX.FCU_TRK_FPA_TOGGLE_PUSH       | -                    | -          | Custom EVENT     |                                                                          |
+|                   | AP_VS_HOLD                          | -                    | -          | SIMCONNECT EVENT | Repurposed event as Simconnect has no standard event for this otherwise. |
 
 ### Warning Panel
 
 Flight Deck: [Warning Panel](flight-deck/glareshield/warning.md)
 
-| Function            | API Usage                        | Values     | Read/Write | Type                     | Remark |
-|:--------------------|:---------------------------------|:-----------|:-----------|:-------------------------|:-------|
-| MASTER CAUTION      | A32NX_MASTER_CAUTION             | 0 &#124; 1 | R/W        | Custom LVAR              |        |
-|                     |                                  |            |            |                          |        |
-| MASTER WARNING      | A32NX_MASTER_WARNING             | 0 &#124; 1 | R/W        | Custom LVAR              |        |
-|                     |                                  |            |            |                          |        |
-| CHRONO              | H:A32NX_EFIS_L_CHRONO_PUSHED     | -          | -          | HTML Event (aka H Event) |        |
-|                     | H:A32NX_EFIS_R_CHRONO_PUSHED     | -          | -          | HTML Event (aka H Event) |        |
-|                     |                                  |            |            |                          |        |
-| SIDE STICK PRIORITY | N/A                              |            |            |                          |        |
-|                     |                                  |            |            |                          |        |
-| AUTOLAND WARNING    | A32NX_AUTOPILOT_AUTOLAND_WARNING | 0 &#124; 1 | R/W        | Custom LVAR              |        |
-|                     |                                  |            |            |                          |        |
-| ATC MSG             | N/A                              |            |            |                          |        |
+| Function            | API Usage                        | Values   | Read/Write | Type                     | Remark |
+|:--------------------|:---------------------------------|:---------|:-----------|:-------------------------|:-------|
+| MASTER CAUTION      | A32NX_MASTER_CAUTION             | 0&#124;1 | R/W        | Custom LVAR              |        |
+|                     |                                  |          |            |                          |        |
+| MASTER WARNING      | A32NX_MASTER_WARNING             | 0&#124;1 | R/W        | Custom LVAR              |        |
+|                     |                                  |          |            |                          |        |
+| CHRONO              | H:A32NX_EFIS_L_CHRONO_PUSHED     | -        | -          | HTML Event (aka H Event) |        |
+|                     | H:A32NX_EFIS_R_CHRONO_PUSHED     | -        | -          | HTML Event (aka H Event) |        |
+|                     |                                  |          |            |                          |        |
+| SIDE STICK PRIORITY | N/A                              |          |            |                          |        |
+|                     |                                  |          |            |                          |        |
+| AUTOLAND WARNING    | A32NX_AUTOPILOT_AUTOLAND_WARNING | 0&#124;1 | R/W        | Custom LVAR              |        |
+|                     |                                  |          |            |                          |        |
+| ATC MSG             | N/A                              |          |            |                          |        |
 
 
 ## Instrument Panel
@@ -563,52 +562,63 @@ Flight Deck: [Warning Panel](flight-deck/glareshield/warning.md)
 
 Flight Deck: [ILCP Panel](flight-deck/front/ilcp.md)
 
-| Function            | API Usage              | Values        | Read/Write | Type     | Remark |
-|:--------------------|:-----------------------|:--------------|:-----------|:---------|:-------|
-| PFD Brt Cpt.        | LIGHT POTENTIOMETER:88 | 0..100        | R/W        | MSFS VAR |        |
-|                     |                        |               |            |          |        |
-| PFD/ND XFR Cpt.     | N/A                    |               |            |          |        |
-|                     |                        |               |            |          |        |
-| ND Brt Cpt.         | LIGHT POTENTIOMETER:89 | 0..100        | R/W        | MSFS VAR |        |
-|                     |                        |               |            |          |        |
-| WX/Terrain Brt Cpt. | LIGHT POTENTIOMETER:94 | 0..100        | R/W        | MSFS VAR |        |
-|                     |                        |               |            |          |        |
-| Loud Spkr Cpt.      | N/A                    |               |            |          |        |
-|                     |                        |               |            |          |        |
-| CONSOLE/FLOOR Cpt.  | LIGHT POTENTIOMETER:8  | 50 &#124; 100 | R/W        | MSFS VAR |        |
-|                     |                        |               |            |          |        |
-| PFD Brt F.O.        | LIGHT POTENTIOMETER:90 | 0..100        | R/W        | MSFS VAR |        |
-|                     |                        |               |            |          |        |
-| PFD/ND XFR F.O.     | N/A                    |               |            |          |        |
-|                     |                        |               |            |          |        |
-| ND Brt F.O.         | LIGHT POTENTIOMETER:91 | 0..100        | R/W        | MSFS VAR |        |
-|                     |                        |               |            |          |        |
-| WX/Terrain Brt F.O. | LIGHT POTENTIOMETER:95 | 0..100        | R/W        | MSFS VAR |        |
-|                     |                        |               |            |          |        |
-| Loud Spkr F.O.      | N/A                    |               |            |          |        |
-|                     |                        |               |            |          |        |
-| CONSOLE/FLOOR F.O.  | LIGHT POTENTIOMETER:9  | 50 &#124; 100 | R/W        | MSFS VAR |        |
+| Function            | API Usage              | Values      | Read/Write | Type     | Remark |
+|:--------------------|:-----------------------|:------------|:-----------|:---------|:-------|
+| PFD Brt Cpt.        | LIGHT POTENTIOMETER:88 | 0..100      | R/W        | MSFS VAR |        |
+|                     |                        |             |            |          |        |
+| PFD/ND XFR Cpt.     | N/A                    |             |            |          |        |
+|                     |                        |             |            |          |        |
+| ND Brt Cpt.         | LIGHT POTENTIOMETER:89 | 0..100      | R/W        | MSFS VAR |        |
+|                     |                        |             |            |          |        |
+| WX/Terrain Brt Cpt. | LIGHT POTENTIOMETER:94 | 0..100      | R/W        | MSFS VAR |        |
+|                     |                        |             |            |          |        |
+| Loud Spkr Cpt.      | N/A                    |             |            |          |        |
+|                     |                        |             |            |          |        |
+| CONSOLE/FLOOR Cpt.  | LIGHT POTENTIOMETER:8  | 50&#124;100 | R/W        | MSFS VAR |        |
+|                     |                        |             |            |          |        |
+| PFD Brt F.O.        | LIGHT POTENTIOMETER:90 | 0..100      | R/W        | MSFS VAR |        |
+|                     |                        |             |            |          |        |
+| PFD/ND XFR F.O.     | N/A                    |             |            |          |        |
+|                     |                        |             |            |          |        |
+| ND Brt F.O.         | LIGHT POTENTIOMETER:91 | 0..100      | R/W        | MSFS VAR |        |
+|                     |                        |             |            |          |        |
+| WX/Terrain Brt F.O. | LIGHT POTENTIOMETER:95 | 0..100      | R/W        | MSFS VAR |        |
+|                     |                        |             |            |          |        |
+| Loud Spkr F.O.      | N/A                    |             |            |          |        |
+|                     |                        |             |            |          |        |
+| CONSOLE/FLOOR F.O.  | LIGHT POTENTIOMETER:9  | 50&#124;100 | R/W        | MSFS VAR |        |
 
 ### Autobrake, Gear Lever and Gear Annunciation
 
 Flight Deck: [Autobrake and Gear Panel](flight-deck/front/autobrake-gear.md)
 
-| Function              | API Usage                   | Values     | Read/Write | Type             | Remark                    |
-|:----------------------|:----------------------------|:-----------|:-----------|:-----------------|:--------------------------|
-| Gear lever            | GEAR_UP                     | -          | -          | SIMCONNECT EVENT |                           |
-|                       | GEAR_DOWN                   | -          | -          | SIMCONNECT EVENT |                           |
-|                       | GEAR HANDLE POSITION        | 0 &#124; 1 | R/W        | SIMCONNECT VAR   |                           |
-|                       |                             |            |            |                  |                           |
-| LDG GEAR Annunciators | GEAR LEFT POSITION          | 0..100     | R          | SIMCONNECT VAR   |                           |
-|                       | GEAR CENTER POSITION        | 0..100     | R          | SIMCONNECT VAR   |                           |
-|                       | GEAR RIGHT POSITION         | 0..100     | R          | SIMCONNECT VAR   |                           |
-|                       |                             |            |            |                  |                           |
-| AUTO BRK LO/MED/MAX   | A32NX_AUTOBRAKES_ARMED_MODE | 0..3       | R/W        | Custom LVAR      | 0=OFF, 1=LO, 2=MED, 3=MAX |
-|                       |                             |            |            |                  |                           |
-| BRK FAN               | A32NX_BRAKE_FAN_BTN_PRESSED | 0 &#124; 1 | R/W        | Custom LVAR      |                           |
-|                       |                             |            |            |                  |                           |
-| A/SKID & N/W STRG     | ANTISKID_BRAKES_TOGGLE      | -          | -          | SIMCONNECT EVENT |                           |
-|                       | ANTISKID BRAKES ACTIVE      | 0 &#124; 1 | R/W        | SIMCONNECT VAR   |                           |
+| Function              | API Usage                       | Values   | Read/Write | Type             | Remark                             |
+|:----------------------|:--------------------------------|:---------|:-----------|:-----------------|:-----------------------------------|
+| Gear lever            | GEAR_UP                         | -        | -          | SIMCONNECT EVENT |                                    |
+|                       | GEAR_DOWN                       | -        | -          | SIMCONNECT EVENT |                                    |
+|                       | GEAR HANDLE POSITION            | 0&#124;1 | R/W        | SIMCONNECT VAR   |                                    |
+|                       |                                 |          |            |                  |                                    |
+| LDG GEAR Annunciators | GEAR LEFT POSITION              | 0..100   | R          | SIMCONNECT VAR   |                                    |
+|                       | GEAR CENTER POSITION            | 0..100   | R          | SIMCONNECT VAR   |                                    |
+|                       | GEAR RIGHT POSITION             | 0..100   | R          | SIMCONNECT VAR   |                                    |
+|                       |                                 |          |            |                  |                                    |
+| AUTO BRK LO/MED/MAX   | A32NX_AUTOBRAKES_ARMED_MODE     | 0..3     | R          | Custom LVAR      | 0=DIS, 1=LO, 2=MED, 3=MAX          |
+|                       | A32NX_AUTOBRAKES_ARMED_MODE_SET | -1..3    | W          | Custom LVAR      | -1=techn. 0=DIS, 1=LO,2=MED, 3=MAX |
+|                       | A32NX_AUTOBRAKES_ACTIVE         | 0&#124;1 | R          | Custom LVAR      | 0=not braking, 1=braking           |
+|                       | A32NX_AUTOBRAKES_DECEL_LIGHT    | 0&#124;1 |            |                  |                                    |
+|                       | A32NX.AUTOBRAKE_SET             | 1..4     |            | Custom EVENT     | 1=DIS, 2=LO, 3=MED, 4=MAX          |
+|                       | A32NX.AUTOBRAKE_SET_DISARM      | -        | -          | Custom EVENT     |                                    |
+|                       | A32NX.AUTOBRAKE_SET_LO          | -        | -          | Custom EVENT     |                                    |
+|                       | A32NX.AUTOBRAKE_SET_MED         | -        | -          | Custom EVENT     |                                    |
+|                       | A32NX.AUTOBRAKE_SET_MAX         | -        | -          | Custom EVENT     |                                    |
+|                       | A32NX.AUTOBRAKE_BUTTON_LO       | -        | -          | Custom EVENT     |                                    |
+|                       | A32NX.AUTOBRAKE_BUTTON_MED      | -        | -          | Custom EVENT     |                                    |
+|                       | A32NX.AUTOBRAKE_BUTTON_MAX      | -        | -          | Custom EVENT     |                                    |
+|                       |                                 |          |            |                  |                                    |
+| BRK FAN               | A32NX_BRAKE_FAN_BTN_PRESSED     | 0&#124;1 | R/W        | Custom LVAR      |                                    |
+|                       |                                 |          |            |                  |                                    |
+| A/SKID & N/W STRG     | ANTISKID_BRAKES_TOGGLE          | -        | -          | SIMCONNECT EVENT |                                    |
+|                       | ANTISKID BRAKES ACTIVE          | 0&#124;1 | R/W        | SIMCONNECT VAR   |                                    |
 
 ### ISIS
 
@@ -632,10 +642,10 @@ Flight Deck: [Chrono Panel](flight-deck/front/clock.md)
 
 Flight Deck: [ND Panel](flight-deck/front/nd.md)
 
-| Function       | API Usage             | Values     | Read/Write | Type        | Remark                  |
-|:---------------|:----------------------|:-----------|:-----------|:------------|:------------------------|
-| TERR ON ND L+R | BTN_TERRONND_1_ACTIVE | 0 &#124; 1 | R/W        | Custom LVAR | Currently not available |
-|                | BTN_TERRONND_2_ACTIVE | 0 &#124; 1 | R/W        | Custom LVAR | Currently not available |
+| Function       | API Usage             | Values   | Read/Write | Type        | Remark                  |
+|:---------------|:----------------------|:---------|:-----------|:------------|:------------------------|
+| TERR ON ND L+R | BTN_TERRONND_1_ACTIVE | 0&#124;1 | R/W        | Custom LVAR | Currently not available |
+|                | BTN_TERRONND_2_ACTIVE | 0&#124;1 | R/W        | Custom LVAR | Currently not available |
 
 ### DCDU
 
@@ -831,25 +841,25 @@ Flight Deck: [Switching Panel](flight-deck/pedestal/switching.md)
 
 Flight Deck: [ECAM Control Panel](flight-deck/pedestal/ecam-control.md)
 
-| Function              | API Usage                        | Values     | Read/Write | Type        | Remark                                                                     |
-|:----------------------|:---------------------------------|:-----------|:-----------|:------------|:---------------------------------------------------------------------------|
-| Upper Display         | LIGHT POTENTIOMETER:92           | 0..100     | R/W        | MSFS VAR    |                                                                            |
-|                       |                                  |            |            |             |                                                                            |
-| Lower Display         | LIGHT POTENTIOMETER:93           | 0..100     | R/W        | MSFS VAR    |                                                                            |
-|                       |                                  |            |            |             |                                                                            |
-| ECAM SD Page button   | A32NX_ECAM_SD_CURRENT_PAGE_INDEX | -1..12     | R          | Custom LVAR | See below. <br/>~~(changes button, but does not switch ECAM page)~~        |
-|                       |                                  |            |            |             |                                                                            |
-| Left CLR  button      | A32NX_BTN_CLR                    | 0 &#124; 1 | R/W        | Custom LVAR |                                                                            |
-|                       |                                  |            |            |             |                                                                            |
-| Right CLR button      | A32NX_BTN_CLR2                   | 0 &#124; 1 | R/W        | Custom LVAR |                                                                            |
-|                       |                                  |            |            |             |                                                                            |
-| RCL button            | A32NX_BTN_RCL                    | 0 &#124; 1 | R/W        | Custom LVAR |                                                                            |
-|                       |                                  |            |            |             |                                                                            |
-| T.O. CONFIG button    | A32NX_BTN_TOCONFIG               | 0 &#124; 1 | R/W        | Custom LVAR |                                                                            |
-|                       |                                  |            |            |             |                                                                            |
-| EMER CANC button      | A32NX_BTN_EMERCANC               | 0 &#124; 1 | R/W        | Custom LVAR |                                                                            |
-|                       |                                  |            |            |             |                                                                            |
-| Page to show on error | A32NX_ECAM_SFAIL                 | -1..12     | R          | Custom LVAR | See below. <br/>Has the page index of the page called by the error message |
+| Function              | API Usage                        | Values   | Read/Write | Type        | Remark                                                                     |
+|:----------------------|:---------------------------------|:---------|:-----------|:------------|:---------------------------------------------------------------------------|
+| Upper Display         | LIGHT POTENTIOMETER:92           | 0..100   | R/W        | MSFS VAR    |                                                                            |
+|                       |                                  |          |            |             |                                                                            |
+| Lower Display         | LIGHT POTENTIOMETER:93           | 0..100   | R/W        | MSFS VAR    |                                                                            |
+|                       |                                  |          |            |             |                                                                            |
+| ECAM SD Page button   | A32NX_ECAM_SD_CURRENT_PAGE_INDEX | -1..12   | R          | Custom LVAR | See below. <br/>~~(changes button, but does not switch ECAM page)~~        |
+|                       |                                  |          |            |             |                                                                            |
+| Left CLR  button      | A32NX_BTN_CLR                    | 0&#124;1 | R/W        | Custom LVAR |                                                                            |
+|                       |                                  |          |            |             |                                                                            |
+| Right CLR button      | A32NX_BTN_CLR2                   | 0&#124;1 | R/W        | Custom LVAR |                                                                            |
+|                       |                                  |          |            |             |                                                                            |
+| RCL button            | A32NX_BTN_RCL                    | 0&#124;1 | R/W        | Custom LVAR |                                                                            |
+|                       |                                  |          |            |             |                                                                            |
+| T.O. CONFIG button    | A32NX_BTN_TOCONFIG               | 0&#124;1 | R/W        | Custom LVAR |                                                                            |
+|                       |                                  |          |            |             |                                                                            |
+| EMER CANC button      | A32NX_BTN_EMERCANC               | 0&#124;1 | R/W        | Custom LVAR |                                                                            |
+|                       |                                  |          |            |             |                                                                            |
+| Page to show on error | A32NX_ECAM_SFAIL                 | -1..12   | R          | Custom LVAR | See below. <br/>Has the page index of the page called by the error message |
 
 A32NX_ECAM_SD_CURRENT_PAGE_INDEX:
 
@@ -885,7 +895,7 @@ Flight Deck: [Thrust Lever Panel](flight-deck/pedestal/thrust-elev-trim.md)
 | Throttle 1 Axis       | THROTTLE2_AXIS_SET_EX1      | -16383..16384 | -          | MSFS EVENT       |         |
 |                       |                             |               |            |                  |         |
 | AUTO THRUST DISENGAGE | AUTO_THROTTLE_ARM           | -             | -          | SIMCONNECT EVENT | Toggles |
-|                       | A32NX_AUTOTHRUST_DISCONNECT | 0 &#124; 1    | R          | Custom LVAR      |         |
+|                       | A32NX_AUTOTHRUST_DISCONNECT | 0&#124;1      | R          | Custom LVAR      |         |
 
 ### RMP
 
@@ -903,13 +913,13 @@ Flight Deck: [RMP Panel](flight-deck/pedestal/rmp.md)
 |                  |                           |                  |            |                  |                               |
 | RMP MODE         | A32NX_RMP_L_SELECTED_MODE | 0..3             | R/W        | Custom LVAR      | 0=SEL, 1=VHF1, 2=VHF2, 3=VHF3 |
 |                  |                           |                  |            |                  |                               |
-| RMP ON/OFF       | A32NX_RMP_L_TOGGLE_SWITCH | 0 &#124; 1       | R/W        | Custom LVAR      |                               |
+| RMP ON/OFF       | A32NX_RMP_L_TOGGLE_SWITCH | 0&#124;1         | R/W        | Custom LVAR      |                               |
 |                  |                           |                  |            |                  |                               |
-| Transmit VHF1    | COM TRANSMIT:1            | 0 &#124; 1       | R          | SIMCONNECT VAR   |                               |
+| Transmit VHF1    | COM TRANSMIT:1            | 0&#124;1         | R          | SIMCONNECT VAR   |                               |
 |                  |                           |                  |            |                  |                               |
-| Transmit VHF2    | COM TRANSMIT:2            | 0 &#124; 1       | R          | SIMCONNECT VAR   |                               |
+| Transmit VHF2    | COM TRANSMIT:2            | 0&#124;1         | R          | SIMCONNECT VAR   |                               |
 |                  |                           |                  |            |                  |                               |
-| Transmit VHF3    | COM TRANSMIT:3            | 0 &#124; 1       | R          | SIMCONNECT VAR   |                               |
+| Transmit VHF3    | COM TRANSMIT:3            | 0&#124;1         | R          | SIMCONNECT VAR   |                               |
 
 ### Lighting Pedestal Captain Side Panel
 
@@ -927,21 +937,21 @@ Flight Deck: [Lighting Pedestal Cpt. Side Panel](flight-deck/pedestal/lighting-c
 
 Flight Deck: [WX Radar Panel](flight-deck/pedestal/radar.md)
 
-| Function   | API Usage                       | Values     | Read/Write | Type        | Remark                      |
-|:-----------|:--------------------------------|:-----------|:-----------|:------------|:----------------------------|
-| SYS        | XMLVAR_A320_WEATHERRADAR_SYS    | 0..2       | R/W        | Custom LVAR | 0=1, 1=OFF, 2=2             |
-|            |                                 |            |            |             |                             |
-| PWS        | A32NX_SWITCH_RADAR_PWS_POSITION | 0 &#124; 1 | R/W        | Custom LVAR | 0=OFF, 1=AUTO               |
-|            |                                 |            |            |             |                             |
-| MODE       | XMLVAR_A320_WEATHERRADAR_MODE   | 0..3       | R/W        | Custom LVAR | 0=WX, 1=WX+T, 2=TURB, 3=MAP |
-|            |                                 |            |            |             |                             |
-| GAIN       | N/A                             |            |            |             |                             |
-|            |                                 |            |            |             |                             |
-| MULTISCANS | N/A                             |            |            |             |                             |
-|            |                                 |            |            |             |                             |
-| GCS        | N/A                             |            |            |             |                             |
-|            |                                 |            |            |             |                             |
-| TILT       | N/A                             |            |            |             |                             |
+| Function   | API Usage                       | Values   | Read/Write | Type        | Remark                      |
+|:-----------|:--------------------------------|:---------|:-----------|:------------|:----------------------------|
+| SYS        | XMLVAR_A320_WEATHERRADAR_SYS    | 0..2     | R/W        | Custom LVAR | 0=1, 1=OFF, 2=2             |
+|            |                                 |          |            |             |                             |
+| PWS        | A32NX_SWITCH_RADAR_PWS_POSITION | 0&#124;1 | R/W        | Custom LVAR | 0=OFF, 1=AUTO               |
+|            |                                 |          |            |             |                             |
+| MODE       | XMLVAR_A320_WEATHERRADAR_MODE   | 0..3     | R/W        | Custom LVAR | 0=WX, 1=WX+T, 2=TURB, 3=MAP |
+|            |                                 |          |            |             |                             |
+| GAIN       | N/A                             |          |            |             |                             |
+|            |                                 |          |            |             |                             |
+| MULTISCANS | N/A                             |          |            |             |                             |
+|            |                                 |          |            |             |                             |
+| GCS        | N/A                             |          |            |             |                             |
+|            |                                 |          |            |             |                             |
+| TILT       | N/A                             |          |            |             |                             |
 
 
 ### ATC-TCAS
@@ -952,9 +962,9 @@ Flight Deck: [ATC-TCAS Panel](flight-deck/pedestal/atc-tcas.md)
 |:-------------|:-----------------------------------|:------------|:-----------|:-----------------|:----------------------------|
 | ATC MODE     | A32NX_TRANSPONDER_MODE             | 0..2        | R/W        | Custom LVAR      | 0=STBY, 1=AUTO, 2=ON        |
 |              |                                    |             |            |                  |                             |
-| ATC SYSTEM   | A32NX_TRANSPONDER_SYSTEM           | 0 &#124; 1  | R/W        | Custom LVAR      | 0 = System 1, 1 = System 2  |
+| ATC SYSTEM   | A32NX_TRANSPONDER_SYSTEM           | 0&#124;1    | R/W        | Custom LVAR      | 0 = System 1, 1 = System 2  |
 |              |                                    |             |            |                  |                             |
-| ALT RPTG     | A32NX_SWITCH_ATC_ALT               | 0 &#124; 1  | R/W        | Custom LVAR      | 0=OFF, 1=ON                 |
+| ALT RPTG     | A32NX_SWITCH_ATC_ALT               | 0&#124;1    | R/W        | Custom LVAR      | 0=OFF, 1=ON                 |
 |              |                                    |             |            |                  |                             |
 | SQUAWK       | TRANSPONDER CODE:1                 | 0000...7777 | R/W        | SIMCONNECT VAR   |                             |
 |              |                                    |             |            |                  |                             |
@@ -972,8 +982,8 @@ Flight Deck: [ENG Panel](flight-deck/pedestal/engine.md)
 |:---------------|:-----------------------------|:-----------|:-----------|:-----------|:-----------------------|
 | ENG 1+2 MASTER | FUELSYSTEM_VALVE_OPEN        | 1 &#124; 2 | -          | MSFS EVENT | Activates the switch   |
 |                | FUELSYSTEM_VALVE_CLOSE       | 1 &#124; 2 | -          | MSFS EVENT | Deactivates the switch |
-|                | FUELSYSTEM VALVE SWITCH:1    | 0 &#124; 1 | R          | MSFS VAR   |                        |
-|                | FUELSYSTEM VALVE SWITCH:2    | 0 &#124; 1 | R          | MSFS VAR   |                        |
+|                | FUELSYSTEM VALVE SWITCH:1    | 0&#124;1   | R          | MSFS VAR   |                        |
+|                | FUELSYSTEM VALVE SWITCH:2    | 0&#124;1   | R          | MSFS VAR   |                        |
 |                |                              |            |            |            |                        |
 | MODE           | TURBINE_IGNITION_SWITCH_SET1 | 0..2       | -          | MSFS EVENT | 0=CRANK, 1=NORM, 2=IGN |
 |                | TURBINE_IGNITION_SWITCH_SET2 | 0..2       | -          | MSFS EVENT | 0=CRANK, 1=NORM, 2=IGN |
@@ -986,14 +996,14 @@ Flight Deck: [ENG Panel](flight-deck/pedestal/engine.md)
 
 Flight Deck: [Speed Brake Panel](flight-deck/pedestal/speedbrake.md)
 
-| Function         | API Usage                      | Values     | Read/Write | Type             | Remark                           |
-|:-----------------|:-------------------------------|:-----------|:-----------|:-----------------|:---------------------------------|
-| SPEED BRAKE AXIS | SPOILER SET                    | 0..16384   | -          | SIMCONNECT EVENT |                                  |
-|                  | A32NX_SPOILERS_HANDLE_POSITION | 0.0..1.0   | R          | Custom LVAR      | (add. SIMCONNECT VARS available) |
-|                  |                                |            |            |                  |                                  |
-| GND SPOILER ARM  | SPOILERS_ARM_TOGGLE            | -          | -          | SIMCONNECT EVENT |                                  |
-|                  | SPOILERS ARMED                 | 0 &#124; 1 | R/W        | SIMCONNECT VAR   |                                  |
-|                  | A32NX_SPOILER_ARMED            | 0 &#124; 1 | R          | Custom LVAR      |                                  |
+| Function         | API Usage                      | Values   | Read/Write | Type             | Remark                           |
+|:-----------------|:-------------------------------|:---------|:-----------|:-----------------|:---------------------------------|
+| SPEED BRAKE AXIS | SPOILER SET                    | 0..16384 | -          | SIMCONNECT EVENT |                                  |
+|                  | A32NX_SPOILERS_HANDLE_POSITION | 0.0..1.0 | R          | Custom LVAR      | (add. SIMCONNECT VARS available) |
+|                  |                                |          |            |                  |                                  |
+| GND SPOILER ARM  | SPOILERS_ARM_TOGGLE            | -        | -          | SIMCONNECT EVENT |                                  |
+|                  | SPOILERS ARMED                 | 0&#124;1 | R/W        | SIMCONNECT VAR   |                                  |
+|                  | A32NX_SPOILER_ARMED            | 0&#124;1 | R          | Custom LVAR      |                                  |
 
 ### Flaps
 
@@ -1020,9 +1030,9 @@ Flight Deck: [Speed Brake Panel](flight-deck/pedestal/flaps.md)
 
 Flight Deck: [Parking Brake Panel](flight-deck/pedestal/parking-brake.md)
 
-| Function      | API Usage                  | Values     | Read/Write | Type        | Remark |
-|:--------------|:---------------------------|:-----------|:-----------|:------------|:-------|
-| PARKING BRAKE | A32NX_PARK_BRAKE_LEVER_POS | 0 &#124; 1 | R/W        | Custom LVAR |        |
+| Function      | API Usage                  | Values   | Read/Write | Type        | Remark |
+|:--------------|:---------------------------|:---------|:-----------|:------------|:-------|
+| PARKING BRAKE | A32NX_PARK_BRAKE_LEVER_POS | 0&#124;1 | R/W        | Custom LVAR |        |
 
 ### Rudder Trim
 
@@ -1041,11 +1051,11 @@ Flight Deck: [Rudder Trim Panel](flight-deck/pedestal/rudder-trim.md)
 
 Flight Deck: [Cockpit Door Panel](flight-deck/pedestal/cockpit-door.md)
 
-| Function     | API Usage                 | Values     | Read/Write | Type        | Remark |
-|:-------------|:--------------------------|:-----------|:-----------|:------------|:-------|
-| COCKPIT DOOR | A32NX_COCKPIT_DOOR_LOCKED | 0 &#124; 1 | R/W        | Custom LVAR |        |
-|              |                           |            |            |             |        |
-| VIDEO        | PUSH_DOORPANEL_VIDEO      | 0 &#124; 1 | R/W        | Custom LVAR |        |
+| Function     | API Usage                 | Values   | Read/Write | Type        | Remark |
+|:-------------|:--------------------------|:---------|:-----------|:------------|:-------|
+| COCKPIT DOOR | A32NX_COCKPIT_DOOR_LOCKED | 0&#124;1 | R/W        | Custom LVAR |        |
+|              |                           |          |            |             |        |
+| VIDEO        | PUSH_DOORPANEL_VIDEO      | 0&#124;1 | R/W        | Custom LVAR |        |
 
 ## Side Stick
 
@@ -1057,8 +1067,8 @@ Flight Deck: [Cockpit Door Panel](flight-deck/pedestal/cockpit-door.md)
 | Elevator             | ELEVATOR_SET              | -16383..16384 | -          | SIMCONNECT EVENT |                         |
 |                      | ELEVATOR POSITION         | -1.0..1.0     | R          | SIMCONNECT VAR   |                         |
 |                      |                           |               |            |                  |                         |
-| TAKE OVER pushbutton | A32NX_PRIORITY_TAKEOVER:1 | 0 &#124; 1    | R          | Custom LVAR      | Causes AP disconnection |
-|                      | A32NX_PRIORITY_TAKEOVER:2 | 0 &#124; 1    | R          | Custom LVAR      | Causes AP disconnection |
+| TAKE OVER pushbutton | A32NX_PRIORITY_TAKEOVER:1 | 0&#124;1      | R          | Custom LVAR      | Causes AP disconnection |
+|                      | A32NX_PRIORITY_TAKEOVER:2 | 0&#124;1      | R          | Custom LVAR      | Causes AP disconnection |
 
 ## Tiller
 

--- a/docs/pilots-corner/a32nx-briefing/a32nx_api.md
+++ b/docs/pilots-corner/a32nx-briefing/a32nx_api.md
@@ -605,7 +605,7 @@ Flight Deck: [Autobrake and Gear Panel](flight-deck/front/autobrake-gear.md)
 | AUTO BRK LO/MED/MAX   | A32NX_AUTOBRAKES_ARMED_MODE     | 0..3     | R          | Custom LVAR      | 0=DIS, 1=LO, 2=MED, 3=MAX          |
 |                       | A32NX_AUTOBRAKES_ARMED_MODE_SET | -1..3    | W          | Custom LVAR      | -1=techn. 0=DIS, 1=LO,2=MED, 3=MAX |
 |                       | A32NX_AUTOBRAKES_ACTIVE         | 0&#124;1 | R          | Custom LVAR      | 0=not braking, 1=braking           |
-|                       | A32NX_AUTOBRAKES_DECEL_LIGHT    | 0&#124;1 |            |                  |                                    |
+|                       | A32NX_AUTOBRAKES_DECEL_LIGHT    | 0&#124;1 | R          | Custom LVAR      | 0=off, 1=on                        |
 |                       | A32NX.AUTOBRAKE_SET             | 1..4     |            | Custom EVENT     | 1=DIS, 2=LO, 3=MED, 4=MAX          |
 |                       | A32NX.AUTOBRAKE_SET_DISARM      | -        | -          | Custom EVENT     |                                    |
 |                       | A32NX.AUTOBRAKE_SET_LO          | -        | -          | Custom EVENT     |                                    |


### PR DESCRIPTION
## Summary
Changes to A32NX Flight Deck API due to recent changes to Autobrake events/vars and LS 

### Location
https://docs-git-fork-frankkopp-api-update-flybywire.vercel.app/pilots-corner/a32nx-briefing/a32nx_api/#autobrake-gear-lever-and-gear-annunciation

Discord username (if different from GitHub): Cdr_Maverick#6475
