### PR TITLE
docs(efb): create quick links and correct typo

### DIFF
--- a/docs/fbw-a32nx/feature-guides/flyPad/index.md
+++ b/docs/fbw-a32nx/feature-guides/flyPad/index.md
@@ -1,4 +1,5 @@
 <link rel="stylesheet" href="../../../../stylesheets/efb-interactive.css">
+<link rel="stylesheet" href="../../../../stylesheets/toc-tables.css">
 
 # flyPad EFB
 
@@ -51,15 +52,28 @@ To **TURN ON** and **TURN OFF** the flyPad you can either:
 
 ## flyPad Pages
 
-- [flyPad Dashboard](dashboard.md)
-- [flyPad Dispatch](dispatch.md)
-- [flyPad Ground](ground.md)
-- [flyPad Performance](performance.md)
-- [flyPad Naviagtion & Charts](charts.md)
-- [flyPad Online ATC](online-atc.md)
-- [flyPad Failures](failures.md)
-- [flyPad Settings](settings.md)
-- [flyPad Throttle Calibration](throttle-calibration.md)
+|                       Quick Links                        |
+|:--------------------------------------------------------:|
+|             [flyPad Dashboard](dashboard.md)             |
+|              [flyPad Dispatch](dispatch.md)              |
+|                [flyPad Ground](ground.md)                |
+|           [flyPad Performance](performance.md)           |
+|         [flyPad Navigation & Charts](charts.md)          |
+|            [flyPad Online ATC](online-atc.md)            |
+|              [flyPad Failures](failures.md)              |
+|              [flyPad Settings](settings.md)              |
+|  [flyPad Throttle Calibration](throttle-calibration.md)  |
+
+
+
+
+
+
+
+
+
+
+
 
 
 


### PR DESCRIPTION
## Summary
- Fixes typo found by user in flypad index.md
- Changes the bullet point pages section into our custom table for quick links:

![image](https://user-images.githubusercontent.com/1619968/165171462-33536ca2-b3ef-4e22-9697-354e9da15f92.png)

### Location
- docs/fbw-a32nx/feature-guides/flyPad/index.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
