### PR TITLE
build: external markdown plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,7 @@ plugins:
   - awesome-pages
   - git-revision-date-localized:
       type: date
+  - external-markdown
   - redirects:
       redirect_maps:
         # Folder: /start/

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects
 mkdocs-exclude-search
+mkdocs-embed-external-markdown


### PR DESCRIPTION
## Summary
Adds the embed external markdown dependency to requirements.txt

Will support future PRs that pull external documentation from other FBW repositories. 

### Location
- requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
