### PR TITLE
build: bump mkdocs-material -> 8.2.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==8.2.10
+mkdocs-material==8.2.13
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary
Contains upstream fixes and minor support. Dependency changes as part of the version bump.

Dependency changes (handled via `pip install -r requirements.txt`):
- Pygments >2.12
- Py Markdown Extensions  >9.4
- Due to the above requirements minimum Python version is 3.7+

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
