### PR TITLE
build: add mike plugin to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects
 mkdocs-exclude-search
 mkdocs-embed-external-markdown
+mike


### PR DESCRIPTION
## Summary
Adds the mike plugin to build dependencies to prep build work for future PRs and general testing. The mkdocs.yml is not configured so no extra steps are required and will not impact local branches if rebased. 

*Note: This PR once merged can be cherry-picked into branches to test out mike versioning.*

### Location
- /requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
