### PR TITLE
docs(exp): add pause at TOD

### DIFF
--- a/docs/fbw-a32nx/support/exp.md
+++ b/docs/fbw-a32nx/support/exp.md
@@ -20,7 +20,7 @@ thread to report any issues - [How to Report Issues](#how-to-report-issues).
 
 - New setting in located in the EFB under Realism - Pause at TOD (configurable by distance between 0-50 nm before TOD)
 - When enabled, flight will pause at the specified distance before TOD
-    - If the TOD point shifts before your present position, or AP mode reverts in CRZ, this will pause the simulation.
+- If the TOD point shifts before your present position, or AP mode reverts in CRZ, this will pause the simulation.
 
 ### Hydraulic Gear System
 
@@ -51,36 +51,9 @@ These features are not yet available but will be implemented at a later time.
 
 ### flyPadOS Version 3 (EFB)
 
-- Completely new design
-- Improved Dashboard
-    - Flight info
-    - Customizable info section for:
-        - Weather
-        - Pinned charts
-        - Pinned checklists 
-        - Maintenance 
-- Stateful (remembers tabs and content of pages)
-- Improved ground service pages
-- Improved pushback tool
-- Improved performance calculators
-- Improved navigation charts page
-    - Improved Navigraph chart support 
-        - Current position on chart
-        - Fullscreen mode
-        - Easier search and selection
-    - Support for pinning of charts
-- Improved online ATC page
-- Improved failure support incl. categories and search
-- Interactive checklists incl. autofill and option to pin to dashboard
-- Presets for customizable lighting settings and predefined aircraft states
-- Improved settings (better structure and more configuration options)
-- Onscreen keyboard
-- Tooltips
-- Themes
-    - Blue
-    - Dark
-    - Light
-- Multilingual - English, French, Spanish, German, Russian - more to come....
+Featured released in Development Version. See our guide for usage and known issues.
+
+[flyPadOS 3](../feature-guides/flypados3/index.md){.md-button}
 
 #### EFB Planned Implementations
 
@@ -106,15 +79,6 @@ These features are not yet available but are generally planned and might be impl
 - Fuel predictions in the MCDU are not very accurate.
 - Descent guidance is sensitive to QNH changes. This is partially due to an inaccuracy in MSFS' atmospheric model.
 - Winds are not yet taken into account for all phases of flight.
-
-### flyPadOSv3 Issues
-
-- Local files does not work yet. Needs additional feature PR ([local-api](https://github.com/flybywiresim/a32nx/pull/6411/){target=new})
-- Pushback page: not yet fully functional or complete - changes to be expected
-- Stuck notifications are caused by CSS animations being disabled.
-    - Fix: `General Options` -> `Accessibility` -> Turn On `Menu Animations` under `User Interface` 
-- Translations not yet complete / Missing translations and layout issues to be expected
-- Tooltips not yet complete
 
 ## How to Report Issues
 

--- a/docs/fbw-a32nx/support/exp.md
+++ b/docs/fbw-a32nx/support/exp.md
@@ -24,7 +24,7 @@ thread to report any issues - [How to Report Issues](#how-to-report-issues).
 
 ### Hydraulic Gear System
 
-Featured released in Development Version. See our guide for usage and known issues.
+Feature released in Development Version. See our guide for usage and known issues.
 
 [Custom Hydraulics Guide](../feature-guides/custom-hydraulics.md){.md-button}
 
@@ -51,7 +51,7 @@ These features are not yet available but will be implemented at a later time.
 
 ### flyPadOS Version 3 (EFB)
 
-Featured released in Development Version. See our guide for usage and known issues.
+Feature released in Development Version. See our guide for usage and known issues.
 
 [flyPadOS 3](../feature-guides/flypados3/index.md){.md-button}
 

--- a/docs/fbw-a32nx/support/exp.md
+++ b/docs/fbw-a32nx/support/exp.md
@@ -16,6 +16,12 @@ thread to report any issues - [How to Report Issues](#how-to-report-issues).
 
 ## Implemented Features for Testing
 
+### Pause at Top of Descent (TOD)
+
+- New setting in located in the EFB under Realism - Pause at TOD (configurable by distance between 0-50 nm before TOD)
+- When enabled, flight will pause at the specified distance before TOD
+    - If the TOD point shifts before your present position, or AP mode reverts in CRZ, this will pause the simulation.
+
 ### Hydraulic Gear System
 
 Featured released in Development Version. See our guide for usage and known issues.
@@ -83,6 +89,10 @@ These features are not yet available but are generally planned and might be impl
 - Support for local files (PFD, images) - requires FlyByWire SimBridge (not yet merged)
 
 ## Known Issues
+
+### Pause at TOD Issues
+
+- Since the feature is linked to vertical guidance, having an inaccurate T/D or missing T/D may not pause the simulation.
 
 ### Vertical Guidance Issues
 

--- a/docs/fbw-a32nx/support/exp.md
+++ b/docs/fbw-a32nx/support/exp.md
@@ -67,6 +67,15 @@ These features are not yet available but are generally planned and might be impl
 
 - Since the feature is linked to vertical guidance, having an inaccurate T/D or missing T/D may not pause the simulation.
 
+!!! warning "Sim Limitations"
+    Note that while aircraft simulation is suspended (i.e. fuel consumption, airspeed, altitude, physics), environmental simulation will continue (Notably Live Weather, Live Traffic/AI Traffic). Consequences of this include that TCAS TA/RAs will still be issued and if there is a significant change in the weather over time (say a few hours), your vertical descent profile and performance figures may no longer be accurate, which means that the actual T/D point may now have shifted from the originally calculated value.
+
+    The timestamp issued in the pause pop-up shows your real local system's time (localized to your locale) to help mitigate against this problem.
+
+    This is considered a sim limitation as the pause event we utilize does not affect the MSFS world environment. Along this line of thinking, we speculate that without historical live weather and traffic, it would not possible to inject or restore the state that the world was in when the pause was initiated (the time slider in the weather toolbar only affects lighting and will still reflect live wind and weather data).
+
+    Flying using a weather preset and without AI/live traffic avoids this limitation entirely, but would also be a compromise in other ways.
+
 ### Vertical Guidance Issues
 
 - There has been a large number of reports indicating that the T/D was placed too late. This will be investigated this further, but we ask you to please check your arrival routing for any odd path drawings. These are not unusual for the speed predictions of VNAV do not affect the LNAV path computations yet, which causes certain turns to be drawn at a larger radius than what will actually be flown. Consequently, VNAV will calculate a profile with more track mileage than what is realistically available and place the T/D too late.


### PR DESCRIPTION
## Summary
Supports A32NX PR for exp testing:
- https://github.com/flybywiresim/a32nx/pull/7165

Additionally makes note that the flyPadOS 3 is now released in Development.

### Location
- docs/fbw-a32nx/support/exp.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
