### PR TITLE
docs(release-notes): v0.8.1 release notes + update settings.md

### DIFF
--- a/docs/fbw-a32nx/settings.md
+++ b/docs/fbw-a32nx/settings.md
@@ -30,8 +30,7 @@ Set the `Glass Cockpit Refresh Rate` to `Medium` or `Low` to avoid unnecessary d
 
 ### Deactivate MSFS Assistance Features
 
-We have disabled all assistance and AI features to prevent compatibility issues with A32NX custom systems. You may manually enable some AI features through MSFS settings 
-accessible when pressing `ESC`. You can see what settings you can customize in the image below. 
+A warning will be displayed if you have certain AI assistance features turned on. Please ensure you have disabled them.
 
 !!! tip ""
     Having any AI features or assistance features switched on created some stability issues with our custom systems:
@@ -41,16 +40,15 @@ accessible when pressing `ESC`. You can see what settings you can customize in t
     - Constant right or left rudder.
     - Inability to taxi.
 
-![AI Settings New](assets/settings/ai-settings-new.png){loading=lazy}
+<!--![AI Settings New](assets/settings/ai-settings-new.png){loading=lazy}-->
 
-<!-- Information kept in case of future changes to Asobo base implementation
 ??? tip "Verify Settings"
     You can verify the assistance and AI features are switched off by checking the following settings.
 
     ![MSFS Assistance Options](assets/settings/assistance-options.png "MSFS Assistance Options"){loading=lazy}
 
     ![MSFS AI Options](assets/settings/ai-options.png "MSFS AI Options"){loading=lazy}
--->
+
 
 ### Legacy Cockpit Interaction System
 

--- a/docs/release-notes/.pages
+++ b/docs/release-notes/.pages
@@ -6,6 +6,7 @@
 title: Release Notes
 nav:
     - ...
+    - Stable Release v0.8.0: v080.md
     - Stable Release v0.7.5: v075.md
     - Stable Release v0.7.4: v074.md
     - Stable Release v0.7.3: v073.md

--- a/docs/release-notes/v081.md
+++ b/docs/release-notes/v081.md
@@ -2,7 +2,7 @@
 
 This release includes various bugfixes and a notable change to how our *disable AI assists* feature works. See the warning below!
 
-For our VR users we have added the missing PilotVR default camera entry to work around an MSFS issues. You can read more about the issue - [here](https://forums.flightsimulator.com/t/bug-fs2020-using-3d-cockpit-camera-in-vr-wrong-horizontal-plane-rotation-ex-fbw-a320-salty-747-asobo-787-sdk-sample/428618?u=cptlucky8).
+For our VR users we have added the missing PilotVR default camera entry to work around an MSFS issue. You can read more about the issue - [here](https://forums.flightsimulator.com/t/bug-fs2020-using-3d-cockpit-camera-in-vr-wrong-horizontal-plane-rotation-ex-fbw-a320-salty-747-asobo-787-sdk-sample/428618?u=cptlucky8).
 
 !!! danger "MSFS AI Assistance"
     Due to 3rd party mods that bypass the method we have implemented to disable AI assists we have decided to no longer force the assistance functions. This would cause issues 

--- a/docs/release-notes/v081.md
+++ b/docs/release-notes/v081.md
@@ -1,0 +1,68 @@
+# Stable Version v0.8.1
+
+This release includes various bugfixes and a notable change to how our *disable AI assists* feature works. See the warning below!
+
+!!! danger "MSFS AI Assistance"
+    Due to 3rd party mods that bypass the method we have implemented to disable AI assists we have decided to no longer force the assistance functions. This would cause issues 
+    if we update our flight model and these 3rd party mods are installed.
+
+    {--
+
+    Having any AI features or assistance features switched on created some stability issues with our custom systems:
+
+    - A/THR failing to arm or activate.
+    - Engines turning off in-flight or after takeoff.
+    - Constant right or left rudder.
+    - Inability to taxi.
+
+    --}
+
+    Read our [Recommended Settings Page](../fbw-a32nx/settings.md)
+
+[See Previous Release - v0.8.0](v080.md){.md-button}
+
+For a full release changelog - [see here](#changelog)
+
+!!! tip "Recommended Settings"
+    Before your first flight please make sure to read our [Recommended Settings](../fbw-a32nx/settings.md) guide.
+
+!!! warning "Important User Experience Changes"
+
+    Please note the following changes:
+
+    - Custom Flight Management System
+        - See the [Special Notes Section](../fbw-a32nx/feature-guides/cFMS.md#special-notes) on our custom FMS page for details on the topics below:
+            - Weather and Terrain are now inoperable as we wait for Asobo implementations.
+            - MSFS Built-in ATC and VFR maps are on limited support.
+    - [Discontinuities](../pilots-corner/advanced-guides/flight-planning/disco.md) may now appear in your flight plan — they are a feature and not a bug.
+    - [Throttle calibration](../fbw-a32nx/feature-guides/flyPad/throttle-calibration.md) is mandatory.
+
+!!! info ""
+    Downloads available through our [installer](../fbw-a32nx/installation.md).
+
+    Please see our [Support Guide](../fbw-a32nx/support/index.md) and [Reported Issues](../fbw-a32nx/support/reported-issues.md).
+
+## Changelog
+
+### Bug Fixes
+
+- Update cameras.cfg (#7125)
+- chore(fmgc): clean up unneeded changes from #7114 (#7141)
+- feat: do no longer force disable assistance (#7176)
+- fix(atsu): Fixes for NXApi-Freetext and CPDLC Logon-issues (#7174)
+- fix(isis): force css animations (#7128)
+- fix(sounds): Prevent autopilot sound on Cold and Dark spawn (#7149)
+- fix: only show warning due to enabled assistants when in cockpit (#7157)
+
+### Build System
+
+- build: port metadata script to nodejs (#7133)
+- ci: Upload to GitHub Pre-Release Assets (#7154)
+- ci: recognise external downloads in installer (#7062)
+- fix(ci): GitHub workflows failing on old assets (#7160)
+- fix(ci): upload addon packages for manual download to CDN (#7153)
+- fix(ci): workflow failing
+
+### Miscellaneous
+
+- feat: added new events to SPAD.neXt reference (#7172)

--- a/docs/release-notes/v081.md
+++ b/docs/release-notes/v081.md
@@ -46,15 +46,17 @@ For a full release changelog - [see here](#changelog)
 
 ## Changelog
 
-### Bug Fixes
-
-- Update cameras.cfg (#7125)
-- chore(fmgc): clean up unneeded changes from #7114 (#7141)
-- feat: do no longer force disable assistance (#7176)
-- fix(atsu): Fixes for NXApi-Freetext and CPDLC Logon-issues (#7174)
-- fix(isis): force css animations (#7128)
-- fix(sounds): Prevent autopilot sound on Cold and Dark spawn (#7149)
-- fix: only show warning due to enabled assistants when in cockpit (#7157)
+- [ATHR] Initialize throttle position to IDLE
+- [ATSU] Fixes for NXApi-Freetext and CPDLC Logon-issues
+- [BUILD] Installer version detection
+- [FBW] Rudder stuck on one side
+- [FMGC] Clean up unneeded changes from #7114 (DIR TO with anticipated turn)
+- [GENERAL] Do no longer force disable assistance
+- [GENERAL] Ensure notifications are dismissed on exit to main menu
+- [GENERAL] Only show warning due to enabled assistants when in cockpit
+- [ISIS] Force css animations
+- [SOUND] Prevent autopilot sound on Cold and Dark spawn
+- [VR] Update cameras.cfg
 
 ### Build System
 

--- a/docs/release-notes/v081.md
+++ b/docs/release-notes/v081.md
@@ -1,6 +1,8 @@
-# Stable Version v0.8.1
+# Stable Release v0.8.1
 
 This release includes various bugfixes and a notable change to how our *disable AI assists* feature works. See the warning below!
+
+For our VR users we have added the missing PilotVR default camera entry to work around an MSFS issues. You can read more about the issue - [here](https://forums.flightsimulator.com/t/bug-fs2020-using-3d-cockpit-camera-in-vr-wrong-horizontal-plane-rotation-ex-fbw-a320-salty-747-asobo-787-sdk-sample/428618?u=cptlucky8).
 
 !!! danger "MSFS AI Assistance"
     Due to 3rd party mods that bypass the method we have implemented to disable AI assists we have decided to no longer force the assistance functions. This would cause issues 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,7 +88,7 @@ plugins:
         'fdr.md': 'https://docs.flybywiresim.com/fbw-a32nx/support/#fdr-files'
         'exp.md': 'fbw-a32nx/support/exp.md'
         # Release Notes Permalink
-        'latest-release.md': 'release-notes/v080.md'
+        'latest-release.md': 'release-notes/v081.md'
         # ########################################
         # Needed for URL within the A32NX aircraft
         # ########################################


### PR DESCRIPTION
## Summary
Supports A32NX v0.8.1 release.

- Includes changes to the settings.md page to reflect the old assistance function
- Includes notable warning on the release page about assistance features and 3rd party tools that override it.

### Location
- docs/release-notes/v081.md
- docs/fbw-a32nx/settings.md
- config

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
