### PR TITLE
docs: wind request simbrief integration

### DIFF
--- a/docs/fbw-a32nx/feature-guides/simbrief.md
+++ b/docs/fbw-a32nx/feature-guides/simbrief.md
@@ -13,6 +13,7 @@ In addition to the obvious route planning there are several other aspects which 
     - Routing and Constraints
 - Fuel Calculation
 - Weather Forecast
+- Wind Profiles
 - Cost and Time Optimization
 
 See [Flight Planning](https://en.wikipedia.org/wiki/Flight_planning){target=new} on Wikipedia for more information.
@@ -94,6 +95,20 @@ This will load your flight plan from simBrief directly into the MCDU
 ![MCDU INIT A](../../fbw-a32nx/assets/feature-guides/simbrief/mcdu1b.png "MCDU INIT A"){loading=lazy}
 
 To learn how to set up the MCDU you can read the [**^^F^^**LIGHT PLAN](../../pilots-corner/beginner-guide/preparing-mcdu.md#flight-plan) section in our beginner's guide.
+
+### Wind Profiles
+
+<!-- Insert Init A page with WIND/TEMP highlighted -->
+
+On the `INIT A` page, select `WIND/TEMP` by pressing LSK4R. This brings you to the `CLIMB WIND` page.
+
+<!-- Insert Climb Wind page photo -->
+
+To request the wind data from the simbrief flight plan, select `WIND REQUEST` by pressing LSK3R. This will calculate the wind profiles during the climb phase based on the simbrief-provided wind data.
+
+Press LSK5R to go to the `NEXT PHASE`, `CRZ WIND`. The same procedure of pressing LSK3R for `WIND REQUEST` applies here. Per-waypoint entry and request of cruise winds is still being implemented.
+
+Finally, press LSK5R to go to the `NEXT PHASE`, `DESCENT WIND`. Pressing LSK3R for `WIND REQUEST` will calculate the wind profiles during the descent phase based on the simbrief-provided wind data.
 
 ### Fuel and Weight
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->
Relates #561

## Summary
Started documenting the wind request feature in the Simbrief Integration page. I figure it should be added to the Beginner's Guide under Preparing the MCDU, but I'm not sure which step under DIFSRIP the wind request would typically occur. I would appreciate input on this.

### Location
`fbw-a32nx/feature-guides/simbrief` or `fbw-a32nx/feature-guides/simbrief/#initialize-flight-plan` specifically

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): USA-RedDragon#1776
