### PR TITLE
docs(efb): make note of VDL3 simulation and add warning

### DIFF
--- a/docs/fbw-a32nx/feature-guides/flyPad/settings.md
+++ b/docs/fbw-a32nx/feature-guides/flyPad/settings.md
@@ -124,8 +124,9 @@ Settings for realism aspects of the A32NX aircraft.
 !!! warning "DATALINK Transmission Time"
     This setting has been removed in Stable 0.8.0. We are no using VDL3 communication protocols.
     
-    The real datalink uses in VHF-areas VDL2 or VDL3 communication protocols to exchange ACARS/CPDLC data between ground stations and air stations. The current implementation 
-    works with fixed timings to simulate transmission delays. This provides better simulation capabilities and includes a VHR signal quality simulation.  
+    The real datalink used in VHF-areas is VDL2. For simulation purposes we have chosen to utilize the VDL3 communication protocols to exchange ACARS/CPDLC data between ground 
+    stations and airstations. The current implementation works with fixed timings to simulate transmission delays. This provides better simulation capabilities and includes a 
+    VHF signal quality simulation. 
 
 <div style="position: relative;">
     <img src="/fbw-a32nx/assets/flypad/flypad-settings-realism.png" style="width: 100%; height: auto;" loading="lazy">

--- a/docs/fbw-a32nx/feature-guides/flyPad/settings.md
+++ b/docs/fbw-a32nx/feature-guides/flyPad/settings.md
@@ -122,7 +122,7 @@ Settings for simulation aspects of the A32NX aircraft.
 Settings for realism aspects of the A32NX aircraft.
 
 !!! warning "DATALINK Transmission Time"
-    This setting has been removed in Stable 0.8.0. We are no using VDL3 communication protocols.
+    This setting has been removed in Stable 0.8.0. We are now using VDL3 communication protocols.
     
     The real datalink used in VHF-areas is VDL2. For simulation purposes we have chosen to utilize the VDL3 communication protocols to exchange ACARS/CPDLC data between ground 
     stations and airstations. The current implementation works with fixed timings to simulate transmission delays. This provides better simulation capabilities and includes a 

--- a/docs/fbw-a32nx/feature-guides/flyPad/settings.md
+++ b/docs/fbw-a32nx/feature-guides/flyPad/settings.md
@@ -121,6 +121,12 @@ Settings for simulation aspects of the A32NX aircraft.
 
 Settings for realism aspects of the A32NX aircraft.
 
+!!! warning "DATALINK Transmission Time"
+    This setting has been removed in Stable 0.8.0. We are no using VDL3 communication protocols.
+    
+    The real datalink uses in VHF-areas VDL2 or VDL3 communication protocols to exchange ACARS/CPDLC data between ground stations and air stations. The current implementation 
+    works with fixed timings to simulate transmission delays. This provides better simulation capabilities and includes a VHR signal quality simulation.  
+
 <div style="position: relative;">
     <img src="/fbw-a32nx/assets/flypad/flypad-settings-realism.png" style="width: 100%; height: auto;" loading="lazy">
     <a href="../dashboard/">   <div class="imagemap" style="position: absolute; left: 1.3%; top:  7.7%; width: 5.8%; height: 7.6%;"><span class="imagemapname">Dashboard</span></div></a>
@@ -157,10 +163,7 @@ Settings for realism aspects of the A32NX aircraft.
     - Removes backlight bleed from PFD, ND, and ECAMs
     - Removes reflection from the ISIS
 - DATALINK transmission time
-    - Instant: sends and receives messages within two seconds
-    - Fast: sends and receives messages within twenty seconds
-    - Real: sends and receives messages within sixty seconds
-    - See [Hoppie ACARS](../hoppie.md)
+    - Removed in favor of VDL3 simulation time -- [see warning above](#realism).
 
 ## ATSU/AOC
 

--- a/docs/fbw-a32nx/feature-guides/flyPad/settings.md
+++ b/docs/fbw-a32nx/feature-guides/flyPad/settings.md
@@ -124,7 +124,8 @@ Settings for realism aspects of the A32NX aircraft.
 !!! warning "DATALINK Transmission Time"
     This setting has been removed in Stable 0.8.0. We are now using VDL3 communication protocols.
     
-    The real datalink used in VHF-areas is VDL2. For simulation purposes we have chosen to utilize the VDL3 communication protocols to exchange ACARS/CPDLC data between ground stations and air stations. The current implementation works with fixed timings to simulate transmission delays. This provides better simulation capabilities and includes a VHF signal quality simulation. 
+    The real datalink used in VHF areas is VDL2. For simulation purposes we have chosen to utilize the VDL3 communication protocols to exchange ACARS/CPDLC data between ground 
+stations and air stations. The current implementation works with fixed timings to simulate transmission delays. This provides better simulation capabilities and includes a VHF signal quality simulation. 
 
 <div style="position: relative;">
     <img src="/fbw-a32nx/assets/flypad/flypad-settings-realism.png" style="width: 100%; height: auto;" loading="lazy">

--- a/docs/fbw-a32nx/feature-guides/flyPad/settings.md
+++ b/docs/fbw-a32nx/feature-guides/flyPad/settings.md
@@ -124,9 +124,7 @@ Settings for realism aspects of the A32NX aircraft.
 !!! warning "DATALINK Transmission Time"
     This setting has been removed in Stable 0.8.0. We are now using VDL3 communication protocols.
     
-    The real datalink used in VHF-areas is VDL2. For simulation purposes we have chosen to utilize the VDL3 communication protocols to exchange ACARS/CPDLC data between ground 
-    stations and airstations. The current implementation works with fixed timings to simulate transmission delays. This provides better simulation capabilities and includes a 
-    VHF signal quality simulation. 
+    The real datalink used in VHF-areas is VDL2. For simulation purposes we have chosen to utilize the VDL3 communication protocols to exchange ACARS/CPDLC data between ground stations and air stations. The current implementation works with fixed timings to simulate transmission delays. This provides better simulation capabilities and includes a VHF signal quality simulation. 
 
 <div style="position: relative;">
     <img src="/fbw-a32nx/assets/flypad/flypad-settings-realism.png" style="width: 100%; height: auto;" loading="lazy">


### PR DESCRIPTION
## Summary
In lieu of pending NOTAM added and lack of new EFB images for stable version added a warning clause to the outdated DATALINK image and section in our flyPadOS 2 documentation.

![image](https://user-images.githubusercontent.com/1619968/168666809-8b8821f1-f200-48d5-b325-ea6d4dee5f13.png)
![image](https://user-images.githubusercontent.com/1619968/168666829-c5995ef4-2d4e-43a4-8a91-0ae4b7da4291.png)

### Location
- docs/fbw-a32nx/feature-guides/flyPad/settings.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
