### PR TITLE
docs(dev-efb): add external markdown for EFB translations process

### DIFF
--- a/docs/dev-corner/dev-guide/specific/.pages
+++ b/docs/dev-corner/dev-guide/specific/.pages
@@ -2,4 +2,5 @@ title: Specific
 nav:
   - index.md
   - flypad-dev.md
+  - flypad-translations.md
   - javascript.md

--- a/docs/dev-corner/dev-guide/specific/flypad-translations.md
+++ b/docs/dev-corner/dev-guide/specific/flypad-translations.md
@@ -1,4 +1,4 @@
-# flyPadOS 3 Translations Process
+# flyPadOS 3 Localization Process
 
 This page is pulled externally from the A32NX repository and describes the processes involved with adding features to the EFB and sourcing translations.
 

--- a/docs/dev-corner/dev-guide/specific/flypad-translations.md
+++ b/docs/dev-corner/dev-guide/specific/flypad-translations.md
@@ -1,0 +1,6 @@
+# flyPadOS 3 Translations Process
+
+This page is pulled externally from the A32NX repository and describes the processes involved with adding features to the EFB and sourcing translations.
+
+{{ external_markdown('https://raw.githubusercontent.com/flybywiresim/a32nx/master/src/instruments/src/EFB/Localization/README.md', '') }}
+


### PR DESCRIPTION
## Summary
Provides hosted documentation for localization process from internal docs in the A32NX repo.

### Location
- docs/dev-corner/dev-guide/specific/flypad-translations.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
