### PR TITLE
docs(wb): update documentation with latest implementation

### DIFF
--- a/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
+++ b/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
@@ -175,11 +175,20 @@ Fuel loading is now exclusively done via our EFB which has a great UI to see the
 
 ### Weights and Balance
 
-In our development version we have introduced a new flight model paired with a new weight and balance payload method that incorporates seat rows and the correct center of gravity.
+We have introduced a new flight model paired with a new weight and balance payload method that incorporates seat rows and the correct center of gravity.
 
-Get our [simBrief Profile](../installation.md#simbrief-airframe) for the Development and Experimental versions.
+Get our [simBrief Profile](../installation.md#simbrief-airframe).
 
-!!! warning "Fuel, Weights and Balance When not Starting Cold & Dark"
+{==
+
+Please note that the cargo hold field now depicts either metric tons or metric pounds depending on the unit selected in the EFB Settings for aircraft configuration.
+
+See [flyPadOS 2 - Stable Version](flypados2/settings.md#aircraft-configuration) or [flyPadOS 3 - Development Version](flypados3/settings.md#aircraft-options--pin-programs) settings 
+page if you wish to change the weight unit used by the aircraft systems.
+
+==}
+
+!!! warning "Fuel, Weights and Balance When Not Starting Cold & Dark"
     The process described in this section is for starting the flight at a gate/ramp in a cold and dark state.
 
     If you start your flight on the runway or in the air the loading process will only work if the Boarding Time [settings](flypados3/settings.md#sim-options) in the flyPad EFB are set to `Instant`. This is deliberate as simulating fueling or boarding and loading when starting from the runway does not make sense.
@@ -206,6 +215,21 @@ Get our [simBrief Profile](../installation.md#simbrief-airframe) for the Develop
     * Click on `AOC MENU` (AOC = Airline Operational Center)
     * Click on `PERF/W&B`
 
+???+ tip "Information on Loading A32NX Manually"
+
+    ##### Loading Manually
+
+    It is possible to input these values manually to customize your passenger loading. Please note the following information when customizing your pax loading manually:
+
+    - To assign a value to a row (station) enter the amount into your scratchpad using the MCDU keyboard and press the relevant LSK next to the desired station.
+        - When inputting pax into individual rows this only accounts for the passenger's weight. Baggage and additional friend needs to be added separtely.
+    - If inputting a value into the `TOTAL PAX` using LSK1L this will automatically distribute passengers based on an ideal CG.
+        - The bag weight is added to the cargo hold when using the `TOTAL PAX` field.
+    - Make sure to input pax values (either total or individual row-wise values) BEFORE inputting cargo. Check-in baggage weight is calculated automatically (Pax * 20 KG).
+    - Once the above weights are accounted for you can input remaining weight (cargo weight) in a `X.X` format denoting either metric tons or metric pounds depending what the 
+    unit selected in the EFB Settings.
+        - Cargo weight is limited to max capacity if it exceeds the cargo hold limits.
+
 #### Load OFP Payload Info
 
 !!! block ""
@@ -229,18 +253,6 @@ Get our [simBrief Profile](../installation.md#simbrief-airframe) for the Develop
     Press OFP Request for this specific page and your `W&B` page will show total pax, pax per row and cargo hold (in metric tonnes) which populate automatically.
 
     Note: this does not start the boarding process. Also Cargo will be limited as a protection to a max capacity if the simBrief OFP cargo exceeds the cargo hold limits).
-
-??? info "Loading Manually"
-
-    ##### Loading Manually
-
-    It is possible to input these values manually to customize your passenger loading. Please note the following information when customizing your pax loading manually:
-
-    - To assign a value to a row (station) enter the amount into your scratchpad using the MCDU keyboard and press the relevant LSK next to the desired station.
-    - If inputting a value into the `TOTAL PAX` using LSK1L this will automatically distribute passengers based on an ideal CG.
-    - Make sure to input pax values (either total or individual row-wise values) BEFORE inputting cargo. Check-in baggage weight is calculated automatically (Pax * 20 KG).
-    - Once the above weights are accounted for you can input remaining weight (cargo weight) in a `X.X` format denoting metric tonnes.
-        - Cargo weight is limited to max capacity if it exceeds the cargo hold limits.
 
 #### Board Passengers
 

--- a/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
+++ b/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
@@ -195,7 +195,7 @@ page if you wish to change the weight unit used by the aircraft systems.
     The process described in this section is for starting the flight at a gate/ramp in a cold and dark state.
 
     If you start your flight on the runway or in the air the loading process will only work if the Boarding Time [settings](flypados3/settings.md#sim-options) in the flyPad EFB 
-are set to `Instant`. This is deliberate as simulating the entire fueling or boarding process when starting from the runway does not make sense.
+    are set to `Instant`. This is deliberate as simulating the entire fueling or boarding process when starting from the runway does not make sense.
 
 ??? info "Dynamic Fields and Colors"
     Payload, ZFW, ZFWCG are dynamic fields that are updated alongside the loading/boarding process.

--- a/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
+++ b/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
@@ -184,7 +184,7 @@ Get our [simBrief Profile](../installation.md#simbrief-airframe).
 Please note the following:
 
 - The cargo hold field now depicts either metric tons or metric pounds depending on the unit selected in the EFB Settings for aircraft configuration.
-- **Highly recommend** ensuring that you select the same weights (metric tons or pounds) in the EFB and in simBrief's OFP/Airframe before importing to prevent any values 
+- **Highly recommend** ensuring that you select the same weights (KGS or LBS) in the EFB and in simBrief's OFP/Airframe before importing to prevent any values 
   mismatch.  
 
 See [flyPadOS 2 - Stable Version](flypados2/settings.md#aircraft-configuration) or [flyPadOS 3 - Development Version](flypados3/settings.md#aircraft-options--pin-programs) settings 
@@ -217,7 +217,7 @@ page if you wish to change the weight unit used by the aircraft systems.
     * Click on `MCDU MENU`
     * Click on `ATSU` (ATSU = Air Traffic Service Unit)
     * Click on `AOC MENU` (AOC = Airline Operational Center)
-    * Click on `PERF/W&B`
+    * Click on `W/B`
 
 ???+ tip "Information on Loading A32NX Manually"
 
@@ -226,10 +226,9 @@ page if you wish to change the weight unit used by the aircraft systems.
     It is possible to input these values manually to customize your passenger loading. Please note the following information when customizing your pax loading manually:
 
     - To assign a value to a row (station) enter the amount into your scratchpad using the MCDU keyboard and press the relevant LSK next to the desired station.
-        - When inputting pax into individual rows this only accounts for the passenger's weight. Baggage and additional friend needs to be added separtely.
+        - When inputting pax into individual rows this only accounts for the passenger's weight. Baggage and additional freight needs to be added separtely.
     - If inputting a value into the `TOTAL PAX` using LSK1L this will automatically distribute passengers based on an ideal CG.
         - The bag weight is added to the cargo hold when using the `TOTAL PAX` field.
-    - Make sure to input pax values (either total or individual row-wise values) BEFORE inputting cargo. Check-in baggage weight is calculated automatically (Pax * 20 KG).
     - Once the above weights are accounted for you can input remaining weight (cargo weight) in a `X.X` format denoting either metric tons or metric pounds depending what the 
     unit selected in the EFB Settings.
         - Cargo weight is limited to max capacity if it exceeds the cargo hold limits.
@@ -254,7 +253,7 @@ page if you wish to change the weight unit used by the aircraft systems.
 !!! block ""
     ![W&B 3](../assets/feature-guides/simbrief/wb1.jpg){align=right width=50% loading=lazy}
 
-    Press OFP Request for this specific page and your `W&B` page will show total pax, pax per row and cargo hold (in metric tonnes) which populate automatically.
+    Press OFP Request for this specific page and your `W&B` page will show total pax, pax per row and cargo hold which populate automatically.
 
     Note: this does not start the boarding process. Also Cargo will be limited as a protection to a max capacity if the simBrief OFP cargo exceeds the cargo hold limits).
 

--- a/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
+++ b/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
@@ -171,7 +171,7 @@ Change the default weights as required and make sure you select Save Aircraft at
 
 ### Fuel
 
-Fuel loading is now exclusively done via our EFB which has a great UI to see the status of fuel tanks and other options. [Guide Here](flypados3/dispatch.md#fuel-page).
+Fuel loading is now exclusively done via our EFB which has a great UI to see the status of fuel tanks and other options. [Guide Here](flypados3/ground.md#fuel-page).
 
 ### Weights and Balance
 
@@ -181,7 +181,11 @@ Get our [simBrief Profile](../installation.md#simbrief-airframe).
 
 {==
 
-Please note that the cargo hold field now depicts either metric tons or metric pounds depending on the unit selected in the EFB Settings for aircraft configuration.
+Please note the following:
+
+- The cargo hold field now depicts either metric tons or metric pounds depending on the unit selected in the EFB Settings for aircraft configuration.
+- **Highly recommend** ensuring that you select the same weights (metric tons or pounds) in the EFB and in simBrief's OFP/Airframe before importing to prevent any values 
+  mismatch.  
 
 See [flyPadOS 2 - Stable Version](flypados2/settings.md#aircraft-configuration) or [flyPadOS 3 - Development Version](flypados3/settings.md#aircraft-options--pin-programs) settings 
 page if you wish to change the weight unit used by the aircraft systems.

--- a/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
+++ b/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
@@ -184,8 +184,7 @@ Get our [simBrief Profile](../installation.md#simbrief-airframe).
 Please note the following:
 
 - The cargo hold field now depicts either metric tons or metric pounds depending on the unit selected in the EFB Settings for aircraft configuration.
-- **Highly recommend** ensuring that you select the same weights (KGS or LBS) in the EFB and in simBrief's OFP/Airframe before importing to prevent any values 
-  mismatch.  
+- **Highly recommend** ensuring that you select the same weights (KGS or LBS) in the EFB and in simBrief's OFP/Airframe before importing to prevent any mismatch in values.
 
 See [flyPadOS 2 - Stable Version](flypados2/settings.md#aircraft-configuration) or [flyPadOS 3 - Development Version](flypados3/settings.md#aircraft-options--pin-programs) settings 
 page if you wish to change the weight unit used by the aircraft systems.
@@ -195,7 +194,8 @@ page if you wish to change the weight unit used by the aircraft systems.
 !!! warning "Fuel, Weights and Balance When Not Starting Cold & Dark"
     The process described in this section is for starting the flight at a gate/ramp in a cold and dark state.
 
-    If you start your flight on the runway or in the air the loading process will only work if the Boarding Time [settings](flypados3/settings.md#sim-options) in the flyPad EFB are set to `Instant`. This is deliberate as simulating fueling or boarding and loading when starting from the runway does not make sense.
+    If you start your flight on the runway or in the air the loading process will only work if the Boarding Time [settings](flypados3/settings.md#sim-options) in the flyPad EFB 
+are set to `Instant`. This is deliberate as simulating the entire fueling or boarding process when starting from the runway does not make sense.
 
 ??? info "Dynamic Fields and Colors"
     Payload, ZFW, ZFWCG are dynamic fields that are updated alongside the loading/boarding process.
@@ -226,12 +226,13 @@ page if you wish to change the weight unit used by the aircraft systems.
     It is possible to input these values manually to customize your passenger loading. Please note the following information when customizing your pax loading manually:
 
     - To assign a value to a row (station) enter the amount into your scratchpad using the MCDU keyboard and press the relevant LSK next to the desired station.
-        - When inputting pax into individual rows this only accounts for the passenger's weight. Baggage and additional freight needs to be added separtely.
+        - When inputting pax into individual rows this only accounts for the passenger's weight (84 kg or 185 lbs per passenger). Baggage and additional freight needs to be added 
+        separately.
     - If inputting a value into the `TOTAL PAX` using LSK1L this will automatically distribute passengers based on an ideal CG.
-        - The bag weight is added to the cargo hold when using the `TOTAL PAX` field.
-    - Once the above weights are accounted for you can input remaining weight (cargo weight) in a `X.X` format denoting either metric tons or metric pounds depending what the 
-    unit selected in the EFB Settings.
-        - Cargo weight is limited to max capacity if it exceeds the cargo hold limits.
+        - The check-in baggage weight (20 kg or 44 lbs) is added to the cargo hold when using the `TOTAL PAX` field.
+    - Once the above weights are accounted for you can input remaining weight (cargo weight) in a `X.X` format denoting either metric tons or thousands of pounds depending what 
+    the unit selected in the EFB Settings.
+        - Cargo weight is limited to max capacity if it exceeds the cargo hold limits (9435 kg or 20800 lbs).
 
 #### Load OFP Payload Info
 


### PR DESCRIPTION
closes #576 

## Summary
Documents changes as per A32NX PR:
- https://github.com/flybywiresim/a32nx/pull/6969

### Location
- docs/fbw-a32nx/feature-guides/loading-fuel-weight.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
