### PR TITLE
build: bump mkdocs-material -> 8.3.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==8.2.15
+mkdocs-material==8.3.3
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary
Upstream updates to mkdocs-material

- Bump required Jinja version to 3.0.2 

-- New Features --
- Added support for custom admonition icons
- Added support for linking of content tabs
- Added support for boosting pages in search <- Great to integrate into our docs pages
- Added support for hiding footer navigation
- Added previous/next indicators to content tabs
- Improved typeset link colors in light and dark modes

-- Compatibility Fixes --
- Fixed: Mermaid diagrams too dark in dark mode (8.3.0 regression)
- Fixed: Custom admonition icons don't work when defining color palette
- Fixed: Content tabs snapping oddly in Firefox
- Fixed: Missing condition in footer partial (8.3.0 regression)

### Location
- requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
