### PR TITLE
fix: various typos and corrections

### DIFF
--- a/docs/fbw-a32nx/feature-guides/cFMS.md
+++ b/docs/fbw-a32nx/feature-guides/cFMS.md
@@ -112,7 +112,7 @@ When using either method will allow for the following:
 If you choose to use our built-in simBrief import on the MCDU to bypass the world menu planner (as we recommend), we have provided a feature that helps sync the aircraft's 
 flight plan back to the MSFS' built-in flight planner. This feature can be configured on the EFB and is set to `None` by default.
 
-Using this method MSFS ATC will most likely not detected your planned cruising flight level. You would need to request further climb once established on your initial cleared 
+Using this method MSFS ATC will most likely not detect your planned cruising flight level. You would need to request further climb once established on your initial cleared 
 altitude after takeoff.
 
 !!! info "How to Turn on Flight Plan Sync"

--- a/docs/fbw-a32nx/feature-guides/flypados3/settings.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/settings.md
@@ -262,12 +262,6 @@ To get your simBrief username or Pilot ID you can go to your simBrief Account se
 
 ![simBrief Account Data](../../assets/flypados3/simbrief-account-data.png "simBrief Account Data")
 
-!!! attention ""
-    If you use the Stable version please omit any space characters in your username. If for example your username is 
-    "Mr Pilot" then please use "MrPilot" as username.
-
-    Also the Stable version does only allow the username to be entered here, not the Pilot ID.
-
 ## Audio
 
 Settings for various audio sources and sounds.


### PR DESCRIPTION
## Summary
Minor correction to cFMS page and removal of stable version simbrief username information from flyPadOS 3 page.

### Location
- docs/fbw-a32nx/feature-guides/flypados3/settings.md
- docs/fbw-a32nx/feature-guides/cFMS.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
