### PR TITLE
docs(wb): GW, check weight, and init fuel pred changes

### DIFF
--- a/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
+++ b/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
@@ -198,12 +198,10 @@ Please note the following:
 
 When starting the aircraft from a **Cold and Dark** state please be aware of the following important information:
 
-!!! warning ""
-    - **INIT FUEL PRED** must be completed prior to departure. (This is detailed in our [beginner guide](../../pilots-corner/beginner-guide/preparing-mcdu.md#init-fuel-pred). 
-    Please ensure that you complete this step when preparing the MCDU.)
-    - Failure to complete the `INIT FUEL PRED` page before starting an engine will display `INITIALIZE WEIGHT/CG` on the MCDU Scratchpad.   
-    - When there is a GW mismatch of more than 7 tonnes between the values calculated aerodynamically and the value calculated using the inputted ZFW and fuel flow `CHECK 
-    WEIGHT` will be displayed in amber on the MCDU Scratchpad.
+- **INIT FUEL PRED** must be completed prior to departure. (This is detailed in our [beginner guide](../../pilots-corner/beginner-guide/preparing-mcdu.md#init-fuel-pred). Please ensure that you complete this step when preparing the MCDU.)
+- Failure to complete the `INIT FUEL PRED` page before starting an engine will display `INITIALIZE WEIGHT/CG` on the MCDU Scratchpad.    
+- When there is a GW mismatch of more than 7 tonnes between the values calculated aerodynamically and the value calculated using the inputted ZFW and fuel flow `CHECK 
+  WEIGHT` will be displayed in amber on the MCDU Scratchpad.
 
 See [flyPadOS 2 - Stable Version](flypados2/settings.md#aircraft-configuration) or [flyPadOS 3 - Development Version](flypados3/settings.md#aircraft-options--pin-programs) settings 
 page if you wish to change the weight unit used by the aircraft systems.

--- a/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
+++ b/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
@@ -93,12 +93,12 @@ Make sure you have our latest [simBrief Profile](../installation.md#simbrief-air
 - MTOW (Max Takeoff Weight): 79000 kg / 174165 lbs
 - MLW (Max Landing Weight): 67400 kg / 148591 lbs
 
-!!! tip "Gear Weight (GW)"
-    Gear weight is calculated as: 
+!!! tip "Gross Weight (GW)"
+    Gross weight is calculated as: 
 
     Fuel Quantity (Using fuel flow on engine start) + ZFW input in the MCDU.
 
-    The Gear Weight (GW) value on the ECAM will appear only when certain conditions are satsified:
+    The Gross Weight (GW) value on the ECAM will appear only when certain conditions are satsified:
 
     - This page (Init Fuel Pred) has a ZFW/ZFWCG value.
     - At least one engine is running.

--- a/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
+++ b/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
@@ -94,7 +94,7 @@ Make sure you have our latest [simBrief Profile](../installation.md#simbrief-air
 !!! tip "FMS Gross Weight (FMS GW)"
     Gross weight is calculated as: 
 
-    Fuel Quantity (Using fuel flow on engine start) + ZFW input in the MCDU.
+    Fuel Quantity (directly from the simulator's fuel system) + ZFW input in the MCDU.
 
     The Gross Weight (GW) value on the ECAM will appear only when certain conditions are satsified:
 

--- a/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
+++ b/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
@@ -91,7 +91,7 @@ Make sure you have our latest [simBrief Profile](../installation.md#simbrief-air
 - MTOW (Max Takeoff Weight): 79000 kg / 174165 lbs
 - MLW (Max Landing Weight): 67400 kg / 148591 lbs
 
-!!! tip "Gross Weight (GW)"
+!!! tip "FMS Gross Weight (FMS GW)"
     Gross weight is calculated as: 
 
     Fuel Quantity (Using fuel flow on engine start) + ZFW input in the MCDU.

--- a/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
+++ b/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
@@ -94,7 +94,8 @@ Make sure you have our latest [simBrief Profile](../installation.md#simbrief-air
 !!! tip "FMS Gross Weight (FMS GW)"
     Gross weight is calculated as: 
 
-    Fuel Quantity (directly from the simulator's fuel system) + ZFW input in the MCDU.
+    !!! info ""
+        Fuel Quantity (directly from the simulator's fuel system) + ZFW input in the MCDU.
 
     The Gross Weight (GW) value on the ECAM will appear only when certain conditions are satsified:
 

--- a/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
+++ b/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
@@ -98,6 +98,11 @@ Make sure you have our latest [simBrief Profile](../installation.md#simbrief-air
 
     Fuel Quantity (Using fuel flow on engine start) + ZFW input in the MCDU.
 
+    The Gear Weight (GW) value on the ECAM will appear only when certain conditions are satsified:
+
+    - This page (Init Fuel Pred) has a ZFW/ZFWCG value.
+    - At least one engine is running.
+
 ### Fuel
 - Max Fuel Capacity: 41989lbs/19.046kg
 - Fuel tanks: 5

--- a/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
+++ b/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
@@ -93,6 +93,11 @@ Make sure you have our latest [simBrief Profile](../installation.md#simbrief-air
 - MTOW (Max Takeoff Weight): 79000 kg / 174165 lbs
 - MLW (Max Landing Weight): 67400 kg / 148591 lbs
 
+!!! tip "Gear Weight (GW)"
+    Gear weight is calculated as: 
+
+    Fuel Quantity (Using fuel flow on engine start) + ZFW input in the MCDU.
+
 ### Fuel
 - Max Fuel Capacity: 41989lbs/19.046kg
 - Fuel tanks: 5
@@ -185,6 +190,15 @@ Please note the following:
 
 - The cargo hold field now depicts either metric tons or thousands of pounds depending on the unit selected in the EFB Settings for aircraft configuration.
 - **Highly recommend** ensuring that you select the same weights (KGS or LBS) in the EFB and in simBrief's OFP/Airframe before importing to prevent any mismatch in values.
+
+When starting the aircraft from a **Cold and Dark** state please be aware of the following important information:
+
+!!! warning ""
+    - **INIT FUEL PRED** must be completed prior to departure. (This is detailed in our [beginner guide](../../pilots-corner/beginner-guide/preparing-mcdu.md#init-fuel-pred). 
+    Please ensure that you complete this step when preparing the MCDU.)
+    - Failure to complete the `INIT FUEL PRED` page before starting an engine will display `INITIALIZE WEIGHT/CG` on the MCDU Scratchpad.   
+    - When there is a GW mismatch of more than 7 tones between the values calculated aerodynamically and the value calculated using the inputted ZFW and fuel flow `CHECK 
+    WEIGHT` will be displayed in amber on th MCDU Scratchpad.
 
 See [flyPadOS 2 - Stable Version](flypados2/settings.md#aircraft-configuration) or [flyPadOS 3 - Development Version](flypados3/settings.md#aircraft-options--pin-programs) settings 
 page if you wish to change the weight unit used by the aircraft systems.

--- a/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
+++ b/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
@@ -84,8 +84,6 @@ Make sure you have our latest [simBrief Profile](../installation.md#simbrief-air
     - Fuel: Now done via the [EFB](flypados3/dispatch.md#fuel-page).
     - Payload: Done through the [W&B in the MCDU](#weights-and-balance)
 
-
-
 ### Weights
 - OEW (Empty Weight): 42500 kg / 93697 lbs
     - Also referred to as DOW (Dry Operating Weight) which can be seen in other simBrief OFP formats such as EZY
@@ -199,7 +197,7 @@ Please note the following:
 When starting the aircraft from a **Cold and Dark** state please be aware of the following important information:
 
 - **INIT FUEL PRED** must be completed prior to departure. (This is detailed in our [beginner guide](../../pilots-corner/beginner-guide/preparing-mcdu.md#init-fuel-pred). Please ensure that you complete this step when preparing the MCDU.)
-- Failure to complete the `INIT FUEL PRED` page before starting an engine will display `INITIALIZE WEIGHT/CG` on the MCDU Scratchpad.    
+- Failure to complete the `INIT FUEL PRED` page before starting an engine will display `INITIALIZE WEIGHT/CG` in amber on the MCDU Scratchpad.    
 - When there is a GW mismatch of more than 7 tonnes between the values calculated aerodynamically and the value calculated using the inputted ZFW and fuel flow `CHECK 
   WEIGHT` will be displayed in amber on the MCDU Scratchpad.
 

--- a/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
+++ b/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
@@ -100,7 +100,7 @@ Make sure you have our latest [simBrief Profile](../installation.md#simbrief-air
 
     The Gross Weight (GW) value on the ECAM will appear only when certain conditions are satsified:
 
-    - This page (Init Fuel Pred) has a ZFW/ZFWCG value.
+    - The (INIT FUEL PRED page) has a ZFW/ZFWCG value. **Reminder:** After engines are started INIT FUEL PRED changes to the FUEL PRED page.
     - At least one engine is running.
 
 ### Fuel
@@ -202,8 +202,8 @@ When starting the aircraft from a **Cold and Dark** state please be aware of the
     - **INIT FUEL PRED** must be completed prior to departure. (This is detailed in our [beginner guide](../../pilots-corner/beginner-guide/preparing-mcdu.md#init-fuel-pred). 
     Please ensure that you complete this step when preparing the MCDU.)
     - Failure to complete the `INIT FUEL PRED` page before starting an engine will display `INITIALIZE WEIGHT/CG` on the MCDU Scratchpad.   
-    - When there is a GW mismatch of more than 7 tones between the values calculated aerodynamically and the value calculated using the inputted ZFW and fuel flow `CHECK 
-    WEIGHT` will be displayed in amber on th MCDU Scratchpad.
+    - When there is a GW mismatch of more than 7 tonnes between the values calculated aerodynamically and the value calculated using the inputted ZFW and fuel flow `CHECK 
+    WEIGHT` will be displayed in amber on the MCDU Scratchpad.
 
 See [flyPadOS 2 - Stable Version](flypados2/settings.md#aircraft-configuration) or [flyPadOS 3 - Development Version](flypados3/settings.md#aircraft-options--pin-programs) settings 
 page if you wish to change the weight unit used by the aircraft systems.

--- a/docs/pilots-corner/beginner-guide/preparing-mcdu.md
+++ b/docs/pilots-corner/beginner-guide/preparing-mcdu.md
@@ -309,7 +309,12 @@ On this page, we can input our zero fuel weight (ZFW) and zero fuel weight cente
 !!! warning "Important Info"
     Fuel and payload have to be set in the aircraft (see link below) and passenger boarding has to be complete for the ZFW/ZFWCG to be correct.
 
-    Please see our [Fuel and Weights Guide](../../fbw-a32nx/feature-guides/loading-fuel-weight.md) for more information.
+    Gear Weight (GW) value on the ECAM will appear only when certain conditions are satsified:
+
+    - This page (Init Fuel Pred) has a ZFW/ZFWCG value.
+    - At least one engine is running.
+
+    Please see our [Fuel and Weights Guide](../../fbw-a32nx/feature-guides/loading-fuel-weight.md) for more detailed information.
 
 The A32NX can auto populate this information.
 

--- a/docs/pilots-corner/beginner-guide/preparing-mcdu.md
+++ b/docs/pilots-corner/beginner-guide/preparing-mcdu.md
@@ -306,7 +306,7 @@ To navigate to the `INIT FUEL PRED` page we first have to select the `INIT` butt
 
 On this page, we can input our zero fuel weight (ZFW) and zero fuel weight center of gravity (ZFWCG).
 
-!!! warning "Important Info"
+!!! warning "Important Info - FMS Gross Weight (FMS GW)"
     Fuel and payload have to be set in the aircraft (see link below) and passenger boarding has to be complete for the ZFW/ZFWCG to be correct.
 
     Gross Weight (GW) value on the ECAM will appear only when certain conditions are satsified:

--- a/docs/pilots-corner/beginner-guide/preparing-mcdu.md
+++ b/docs/pilots-corner/beginner-guide/preparing-mcdu.md
@@ -309,7 +309,7 @@ On this page, we can input our zero fuel weight (ZFW) and zero fuel weight cente
 !!! warning "Important Info"
     Fuel and payload have to be set in the aircraft (see link below) and passenger boarding has to be complete for the ZFW/ZFWCG to be correct.
 
-    Gear Weight (GW) value on the ECAM will appear only when certain conditions are satsified:
+    Gross Weight (GW) value on the ECAM will appear only when certain conditions are satsified:
 
     - This page (Init Fuel Pred) has a ZFW/ZFWCG value.
     - At least one engine is running.

--- a/docs/pilots-corner/beginner-guide/preparing-mcdu.md
+++ b/docs/pilots-corner/beginner-guide/preparing-mcdu.md
@@ -311,7 +311,7 @@ On this page, we can input our zero fuel weight (ZFW) and zero fuel weight cente
 
     Gross Weight (GW) value on the ECAM will appear only when certain conditions are satsified:
 
-    - This page (Init Fuel Pred) has a ZFW/ZFWCG value.
+    - This page (INIT FUEL PRED) has a ZFW/ZFWCG value. **Reminder:** After engines are started INIT FUEL PRED changes to the FUEL PRED page.
     - At least one engine is running.
 
     Please see our [Fuel and Weights Guide](../../fbw-a32nx/feature-guides/loading-fuel-weight.md) for more detailed information.


### PR DESCRIPTION
closes #589 

## Summary
Provides changes to support A32NX PR:

- https://github.com/flybywiresim/a32nx/pull/7291

Expanding primary information in the weight and balance page. Additionally updated the beginner guide to reference gross weight and the conditions upon which they appear. This information appears on both pages for posterity.

### Location
- docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
- docs/pilots-corner/beginner-guide/preparing-mcdu.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
 Valastiri#8902
