### PR TITLE
docs: Fix spelling mistakes

### DIFF
--- a/docs/pilots-corner/advanced-guides/protections/afloor.md
+++ b/docs/pilots-corner/advanced-guides/protections/afloor.md
@@ -30,7 +30,7 @@ To recover from the A.FLOOR condition and prevent further stall conditions, manu
 
 ## TOGA LK
 
-This indication typically appears after triggering A.FLOOR protection where TOGA (take off go around) thrust has been set automatically and "locked". This autothurst mode will be kept active until the crew has safely resolved the previous A.FLOOR condition.
+This indication typically appears after triggering A.FLOOR protection where TOGA (take off go around) thrust has been set automatically and "locked". This autothrust mode will be kept active until the crew has safely resolved the previous A.FLOOR condition.
 
 ![tglk](../../assets/advanced-guides/protections/afloor/tglk1.png){width=80% loading=lazy}
 

--- a/docs/pilots-corner/beginner-guide/takeoff-climb-cruise.md
+++ b/docs/pilots-corner/beginner-guide/takeoff-climb-cruise.md
@@ -302,7 +302,7 @@ The aircraft will now climb to the altitude selected in the FCU (in our case 5.0
 
 **Activate the __Autopilot__ at this point by pressing the AP1 button on the FCU.**
 
-![Autopilot and Autothurst buttons](../assets/beginner-guide/takeoff-climb-cruise/AP1.png "Autopilot and Autothurst buttons"){loading=lazy}
+![Autopilot and Autothrust buttons](../assets/beginner-guide/takeoff-climb-cruise/AP1.png "Autopilot and Autothurst buttons"){loading=lazy}
 
 The FMA now shows AP1 in white in the upper right corner.
 


### PR DESCRIPTION
## Summary
Fixes all cases of spelling `autothrust` as `autothurst`.

### Location
https://docs.flybywiresim.com/pilots-corner/advanced-guides/protections/afloor/#resolving-afloor
