### PR TITLE
docs(disco): add inaccuracy with Honeywell FMS implementation fms-v1

### DIFF
--- a/docs/pilots-corner/advanced-guides/flight-planning/disco.md
+++ b/docs/pilots-corner/advanced-guides/flight-planning/disco.md
@@ -11,11 +11,13 @@ There are basically two types of discontinuities:
 
 ### Special Case
 
-!!! warning "STAR and Approach Discontinuity - Special Case"
+!!! warning "STAR and Approach Discontinuity - Inaccuracy"
     If your STAR contains other waypoints after the IAF (initial approach fix) that you have selected via an approach transition (VIA), the FMS will not automatically connect 
     the STAR to the approach at at the IAF.
 
-    This is due a quirk in the stringing algorithm of the real Honeywell FMS, which is accurately present on the A32NX and the A380X.
+    This is a small problem with our current implementation. It will be corrected when we 
+    update to version 2 (fms-v2) of our implementation which contains even better simulation of the 
+    Honeywell FMS.
 
 ## Discontinuities Between Waypoints
 

--- a/docs/pilots-corner/advanced-guides/flight-planning/disco.md
+++ b/docs/pilots-corner/advanced-guides/flight-planning/disco.md
@@ -9,6 +9,14 @@ There are basically two types of discontinuities:
 - Discontinuities between two waypoints in the flight plan
 - Discontinuities after a MANUAL leg (Manual Termination)
 
+### Special Case
+
+!!! warning "STAR and Approach Discontinuity - Special Case"
+    If your STAR contains other waypoints after the IAF (initial approach fix) that you have selected via an approach transition (VIA), the FMS will not automatically connect 
+    the STAR to the approach at at the IAF.
+
+    This is due a quirk in the stringing algorithm of the real Honeywell FMS, which is accurately present on the A32NX and the A380X.
+
 ## Discontinuities Between Waypoints
 
 These discontinuities <span style=color:red>should not</span> be cleared from the flight plan in normal operations. Typically, you will notice a discontinuity in the following 

--- a/docs/pilots-corner/beginner-guide/preparing-mcdu.md
+++ b/docs/pilots-corner/beginner-guide/preparing-mcdu.md
@@ -259,7 +259,10 @@ Verify the flight plan by using the vertical slew keys to scroll through it.
     Sometimes discontinuities are also part of a procedure to indicate that manual input is required (mostly clearance by ATC). The preceding legs are called MANUAL legs.
 
     See our detailed documentation for [Discontinuities](../advanced-guides/flight-planning/disco.md) to understand how to appropriately handle these when encountered on your 
-    F-PLN page.
+    F-PLN page. 
+    
+    !!! warning ""
+        Additionally, make note of this [Special Case](../advanced-guides/flight-planning/disco.md#special-case) on the discontinuity page.
 
 !!! info "Viewing Flight Plan on ND"
     We can also verify the route looks correct by selecting `Plan` on the EFIS control panel and watching the ND as we scroll through.


### PR DESCRIPTION
## Summary
As requested by holland to provide a warning on conditions why the FMS strings certain STARs  + Approaches together without automatically connecting.

Avail on the Discontinuity page with a small extra mention in the beginner guide to be aware of the *special case*

![image](https://user-images.githubusercontent.com/1619968/178631133-5f471c2e-73cf-46ef-ae0f-a579e8f0f720.png)

### Location
- docs/pilots-corner/advanced-guides/flight-planning/disco.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
