### PR TITLE
feat: markdown syntax for youtube embeds

### DIFF
--- a/docs/dev-corner/development-projects/documentation.md
+++ b/docs/dev-corner/development-projects/documentation.md
@@ -108,6 +108,16 @@ To participate in the FlyByWire Documentation Project you need to have following
 - Add images to the section's asset folder. Consider creating a folder for your page when using several images.
 - Although the FlyByWire Documentation Team will take care of navigation it might still be of interest how the navigation is done. This is well explained on the [mkdocs-awesome-pages-plugin's README on their Github](https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin#Features){target=new}
 
+!!! tip "Embedding YouTube Videos"
+    We have included the plugin `mkdocs-video` to streamline adding YouTube embeds into documentation. This removes the necessity to inline `<iframe>` information within 
+    documentation pages. 
+
+    The plugin uses the markdown image syntax with a custom marker defined in mkdocs.yml: `video-embed`.
+
+    ```md title="Sample YouTube Embed Code"
+    ![video-embed](https://www.youtube.com/embed/3i1FaGKOwII)
+    ```
+
 #### Tips to Work Effectively with `mkdocs` (Change, Previews, etc.)
 
 - Have your editor and browser preview side-by-side on your screen.

--- a/docs/fbw-a32nx/faq.md
+++ b/docs/fbw-a32nx/faq.md
@@ -62,7 +62,7 @@
 ??? info "Q: Which lights should I turn on during taxi/takeoff/flight?"
     There are many fantastic tutorials online which demonstrate the proper use of lighting on the A320neo, take a look at this video from 320 Sim Pilot:
 
-    [Airbus Lights: What you didn't (need to) know! With a Real Airbus Pilot in Flight Simulator](https://www.youtube.com/watch?v=L9XUHepoFDg){target=new}
+    ![video-embed](https://www.youtube.com/embed/L9XUHepoFDg)
 
 ??? info "Q: Is the Hold function implemented yet?"
     Yes - the Hold function is available in the MCDU. 

--- a/docs/fbw-a32nx/feature-guides/nw-tiller.md
+++ b/docs/fbw-a32nx/feature-guides/nw-tiller.md
@@ -147,9 +147,10 @@ Modifying steering animation so it shows our internal system state will mask tho
 
 ### 320 Sim Pilot Video
 
-<iframe width="790" height="450" src="https://www.youtube-nocookie.com/embed/2gWx0EblS30" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+![video-embed](https://www.youtube-nocookie.com/embed/2gWx0EblS30)
+
 
 ### Easyjetsimpilot
 
-<iframe width="790" height="450" src="https://www.youtube-nocookie.com/embed/JM6WrwJJjIo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+![video-embed](https://www.youtube-nocookie.com/embed/JM6WrwJJjIo)
 

--- a/docs/pilots-corner/advanced-guides/data-management.md
+++ b/docs/pilots-corner/advanced-guides/data-management.md
@@ -127,4 +127,4 @@ Alternatively you can use the `MCDU DATA A/C STATUS` page to delete all stored w
 
 ### 320 Sim Pilot Video
 
-<iframe width="790" height="447" src="https://www.youtube-nocookie.com/embed/qDM8Ijp--3o" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+![video-embed](https://www.youtube-nocookie.com/embed/qDM8Ijp--3o)

--- a/docs/pilots-corner/advanced-guides/flight-planning/fixinfo.md
+++ b/docs/pilots-corner/advanced-guides/flight-planning/fixinfo.md
@@ -143,5 +143,5 @@ To visualize these points we can use the fix info page to define a 2NM distance 
 
 ## 320 Sim Pilot Video
 
-<iframe width="790" height="447" src="https://www.youtube-nocookie.com/embed/dHZZ2ukxU9Y" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+![video-embed](https://www.youtube-nocookie.com/embed/dHZZ2ukxU9Y)
 

--- a/docs/release-notes/v070.md
+++ b/docs/release-notes/v070.md
@@ -80,7 +80,7 @@ Major steps have been taken to bring an accurate hydraulics system to the A32NX.
 
 For a great overview of this implementation check out 320 Sim Pilot's video:
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/7uV27k8FsNQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+![video-embed](https://www.youtube-nocookie.com/embed/7uV27k8FsNQ)
 
 ### ADIRS System
 
@@ -88,7 +88,7 @@ We have created an advanced ADIRS implementation that allows for separated ADIRU
 
 See our Developer Series video for more information:
 
-<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/5YCc_tafGgs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+![video-embed](https://www.youtube-nocookie.com/embed/5YCc_tafGgs)
 
 ### Electrical System
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,8 @@ plugins:
   - git-revision-date-localized:
       type: date
   - external-markdown
+  - mkdocs-video:
+      mark: "video-embed"
   - redirects:
       redirect_maps:
         # Folder: /start/

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects
 mkdocs-exclude-search
 mkdocs-embed-external-markdown
+mkdocs-video
 mike


### PR DESCRIPTION
## Summary
Utilizes a new plugin: mkdocs-video

Simplifies adding youtube embeds to documentation without having to inline `<iframe>` into the page's text.

Uses the markdown image syntax with a specific name (marker): `video-embed`

```md
![video-embed](youtube embed link here)
```

Can also serve videos hosted on the repo if we so choose.

- This PR also refactors all the old iframes into the new format utilizing the above plugin.
- Added supporting documentation on how to utilize feature in documentation.md (for docs website contribution)

### Location
- mkdocs.yml
- requirements.txt
- other locations within /docs due to refactor
- docs/dev-corner/development-projects/documentation.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
