### PR TITLE
docs(audio): add audio showcase

### DIFF
--- a/docs/fbw-a32nx/feature-guides/audio.md
+++ b/docs/fbw-a32nx/feature-guides/audio.md
@@ -8,6 +8,8 @@ These settings can be found on the EFB:
 
 For information on the other settings available on the EFB visit our [flyPad Settings](flypados3/settings.md) page.
 
+![video-embed](https://www.youtube-nocookie.com/embed/3i1FaGKOwII)
+
 ## Passenger Simulation
 
 !!! important "Cockpit Door"


### PR DESCRIPTION

## Summary
Adds audio showcase video the the page useing the new video embed feature.

### Location
- docs/fbw-a32nx/feature-guides/audio.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
