### PR TITLE
docs: Fix documentation to reflect proper parameter usage of MCDU

### DIFF
--- a/docs/simbridge/remote-displays/remote-mcdu.md
+++ b/docs/simbridge/remote-displays/remote-mcdu.md
@@ -39,17 +39,17 @@ You can hold the CLR key for >1.5sec to clear all of the scratchpad's content as
 Changes done in the MCDU Web Interface will be reflected immediately in the cockpit and vice versa. Any change in the cockpit will be immediately shown in the MCDU Web Interface.
 
 !!! info "Notice"
-    You can combine several slash commands to get combined effects. For example `/fullscreen/sound` will enable sound *and* fullscreen modes.
+    You can combine several display options, described below, to get combined effects. For example `?fullscreen&sound` will enable sound *and* fullscreen modes.
 
 ### Fullscreen Display
 
 If you only want the MCDU display to be shown then tap on the top-most part of the MCDU display. To return to the full MCDU view tap anywhere on the display.
 
-If you want to start with only the MCDU display visible then add `/fullscreen` to the url.
+If you want to start with only the MCDU display visible then add `?fullscreen` to the url.
 
 ### Sound
 
-You can enable click sounds when pressing buttons on the MCDU by adding `/sound` to the url.
+You can enable click sounds when pressing buttons on the MCDU by adding `?sound` to the url.
 
 ### Day and Night Mode
 
@@ -59,7 +59,7 @@ It is possible to switch between a day and night mode MCDU visualization be clic
 
 If you are using MCDU hardware with a 4:3 display, you can use the 4:3 aspect ratio compatibility mode to improve the formatting so that the lines align better with your hardware.
 
-To use this mode, add `/43` to the url.
+To use this mode, add `?43` to the url.
 
 ## Compatible Browsers
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->
Fixes flybywiresim/a32nx#7379

## Summary
According to:

https://github.com/flybywiresim/simbridge/blob/9a4dce2b835176fc9c414bb5048e367f998e93c4/apps/mcdu/src/App.jsx#L15-L33 

The correct parameters to use fullscreen, sound and 4:3 mode are `?fullscreen`, `?sound` and `?43` instead of `/fullscreen`, `/sound` and `/43`. These are GET query parameters instead of URI extensions.

### Location
[<!-- Please provide the original URL of the page modified or directory location here -->](https://docs.flybywiresim.com/simbridge/remote-displays/remote-mcdu/)

Discord username (if different from GitHub): straks ( straks#7240 )
