### PR TITLE
docs(Simbridge): install/upgrade failure troubleshooting (special case)

### DIFF
--- a/docs/simbridge/installation.md
+++ b/docs/simbridge/installation.md
@@ -18,7 +18,7 @@ When you attempt to install an addon or different addon version (for example, sw
 
 Select `Yes` to install SimBridge along with your chosen addon/version.
 
-#### Seperate Install
+#### Separate Install
 
 If you select `No` in the [Addon Install](#addon-install) or would like to separately install SimBridge, then you can install SimBridge by selecting the SimBridge tab.
 

--- a/docs/simbridge/terrain.md
+++ b/docs/simbridge/terrain.md
@@ -10,7 +10,7 @@ The Terrain Awareness and Warning Systems (TAWS) is a system used to alert the f
     SimBridge *must* be [running](autostart.md) in order for the Terrain Display to function
 
 # Terrain Database
-The aforementioned database has a worldwide coverage and is defined accoreding to a standardized Earth Model, dividing the surface into grid sets. Several optimisations have been made to the database to deal with size constraints within the aircraft.
+The aforementioned database has a worldwide coverage and is defined accoreding to a standardized Earth Model, dividing the surface into grid sets. Several optimizations have been made to the database to deal with size constraints within the aircraft.
 
 - En-route
     - 3.0NM resolution

--- a/docs/simbridge/troubleshooting.md
+++ b/docs/simbridge/troubleshooting.md
@@ -129,3 +129,9 @@ The log file is stored in a file in this folder, formatted by date:
 <YOUR_COMMUNITY_FOLDER>\flybywire-externaltools-simbridge\resources\logs
 ```
 Please send us the latest logfile to the support channel on discord or on github issues if you're facing issues using the SimBridge's features.
+
+## Installation and Upgrade
+
+Sometimes the installation or the upgrade of Simbridge will fail with an Error during the [Installation](installation.md). This happens when Simbridge is still running in the background, even though the Installer indicates it isn't.
+
+Use the Windows Task Manager to stop the Simbridge process as described in the [Stopping Simbridge](autostart.md#stopping-simbridge) documentation and then run the installation or upgrade again.


### PR DESCRIPTION
## Summary
A user has encountered an issue where the Installer will show an Error when trying to upgrade simbridge where simbridge was still running in a bad state in the background, but the health API was no longer responding (CONNECTION_REFUSED in the installer debug log).

This made the installer think that the install could work, but when it tried, it was unable to remove the existing simbridge folder because it was in use. 

This change explains a way around this exceptional situation. 

Also corrected two minor spelling errors while looking at docs. 

Error from the installer debug log as reference:
```
renderer.js:14 Download failed, see exception below
(anonymous) @ renderer.js:14
renderer.js:14 Error: EPERM: operation not permitted, unlink 'D:\Program Files\SteamLibrary\steamapps\common\MicrosoftFlightSimulator\Community\flybywire-externaltools-simbridge\fbw-simbridge.exe'
    at Object.unlinkSync (node:fs:1708)
    at g (renderer.js:14)
    at u (renderer.js:14)
    at renderer.js:14
    at Array.forEach (<anonymous>)
    at renderer.js:14
    at f (renderer.js:14)
    at g (renderer.js:14)
    at Object.u [as removeSync] (renderer.js:14)
    at Function.removeTargetForAddon (renderer.js:14)
(anonymous) @ renderer.js:14
localhost:8380/health:1 Failed to load resource: net::ERR_CONNECTION_REFUSED
localhost:8380/health:1 Failed to load resource: net::ERR_CONNECTION_REFUSED
```

### Location
Install troubleshooting added to 
https://docs.flybywiresim.com/simbridge/troubleshooting/
Spelling corrections:
https://docs.flybywiresim.com/simbridge/installation/#seperate-install
https://docs.flybywiresim.com/simbridge/terrain/

Discord username (if different from GitHub): 
straks (straks#7240)
