### PR TITLE
fix: various header configuration and typos in simbridge directory

### DIFF
--- a/docs/simbridge/autostart.md
+++ b/docs/simbridge/autostart.md
@@ -4,7 +4,6 @@
 
 Autostart is a feature provided by the FlyByWire Installer that allows SimBridge to be autostarted upon Windows start. SimBridge will live in the systems tray similar to Navigraph Simlink. 
 
-
 ### Configuration
 
 Upon installation of SimBridge you will be prompted to enable autostart, You can choose to enable or disable autostart. 
@@ -20,22 +19,21 @@ If you choose to not enable autostart you can open SimBridge via the installer. 
 If this is not your preference or it fails to start you can also open the tool by opening the `fbw-simbridge.exe` found in the folder, `flybywire-externaltools-simbridge`, in the [community folder](../fbw-a32nx/installation.md#Troubleshooting).
 ![simbridge executable location](assets/simbridge/exec_location.png)
 
-# Stopping SimBridge
+## Stopping SimBridge
 There's several avenues to stop SimBridge to provide flexibility to you as the user, this also includes stopping SimBridge from a remote device.
 
-## Installer
+### Installer
 - The simplest way is via the installer and selecting the stop button on the SimBridge page.
 
-## Tray Icon
+### Tray Icon
 - By right-clicking the tray icon in your systems tray and selecting `Exit`, you can also stop SimBridge.
 
     ![quit simbridge](assets/simbridge/tray_stop.png){loading=lazy}
 
-## API Endpoint
+### API Endpoint
 - You can stop SimBridge by calling the health endpoint via http://{[host machine IP](troubleshooting.md#network-configuration)}:{[selected port](configuration.md#server-settings)}/health/kill
 - For example `https://192.168.1.21:8380/health/kill`
 
-
-## Task Manager
+### Task Manager
 - If you encounter issues when closing SimBridge normally, you can kill the `fbw-simbridge.exe` process in Task Manager.
 ![task manager stop](assets/simbridge/simbridge_stop_tm.png){loading=lazy}

--- a/docs/simbridge/index.md
+++ b/docs/simbridge/index.md
@@ -23,12 +23,12 @@ require fewer extra steps before launching into your flights.
     
     This page will keep you updated with the status and any further documentation for these services.
 
-|                        Feature                        |            Status             |
-|:-----------------------------------------------------:|:-----------------------------:|
-|               [Terrain Display](terrain.md)      | In [Experimental](../fbw-a32nx/support/exp.md)  |
-| [MCDU Remote Display](remote-displays/remote-mcdu.md) | In [Experimental](../fbw-a32nx/support/exp.md)  |
-|              Company Route Support                        |   Built - Not Yet Migrated    |
-|                   EFB Local Charts                    |   Built - Not Yet Migrated    |
-|                    Remote Displays                    | Work in Progress |
+|                        Feature                        |                     Status                     |
+|:-----------------------------------------------------:|:----------------------------------------------:|
+|             [Terrain Display](terrain.md)             | In [Experimental](../fbw-a32nx/support/exp.md) |
+| [MCDU Remote Display](remote-displays/remote-mcdu.md) | In [Experimental](../fbw-a32nx/support/exp.md) |
+|                 Company Route Support                 |            Built - Not Yet Migrated            |
+|                   EFB Local Charts                    |            Built - Not Yet Migrated            |
+|                    Remote Displays                    |                Work in Progress                |
 
 

--- a/docs/simbridge/installation.md
+++ b/docs/simbridge/installation.md
@@ -12,8 +12,6 @@ Please follow the information on this page to install the FlyByWire SimBridge to
 
 When you attempt to install an addon or different addon version (for example, switching from Development to Experimental) you will be prompted to install SimBridge
 
-
-
 ![SimBridge install prompt](assets/simbridge/installer_prompt.png "Prompt to install SimBridge when installing an addon that requires it"){loading=lazy}
 
 Select `Yes` to install SimBridge along with your chosen addon/version.
@@ -83,8 +81,6 @@ It is located in:
 ### Troubleshooting
 
 See [find the community folder](../fbw-a32nx/installation.md#Troubleshooting)
-
-
 
 ## Resources Folder
 The resources folder is used for storing various files required by SimBridge to provide it's functionality. 

--- a/docs/simbridge/terrain.md
+++ b/docs/simbridge/terrain.md
@@ -9,7 +9,7 @@ The Terrain Awareness and Warning Systems (TAWS) is a system used to alert the f
 !!! warning "Note"
     SimBridge *must* be [running](autostart.md) in order for the Terrain Display to function
 
-# Terrain Database
+## Terrain Database
 The aforementioned database has a worldwide coverage and is defined accoreding to a standardized Earth Model, dividing the surface into grid sets. Several optimizations have been made to the database to deal with size constraints within the aircraft.
 
 - En-route

--- a/docs/simbridge/terrain.md
+++ b/docs/simbridge/terrain.md
@@ -4,13 +4,14 @@
 !!! danger "Experimental-Only"
     This feature is only available on [experimental](../fbw-a32nx/support/exp.md), as this feature is currently in testing, expect performance loss as we continue to optimise.
 
-The Terrain Awareness and Warning Systems (TAWS) is a system used to alert the flight crew in a timely manner of hazardous situations ahead of the airport to avoid Controlled Flight Into Terrain (CFIT). A part of TAWS is to overlay the approach terrain on the [ND](../pilots-corner/a32nx-briefing/flight-deck/front/nd.md), refered to as Terrain Awareness and Display (TAD), for the awareness of the crew. this display is derived from a database and subsequently can be out of date which can lead to TAWS making false positives and general nuisances to the crew.
+The Terrain Awareness and Warning Systems (TAWS) is a system used to alert the flight crew in a timely manner of hazardous situations ahead of the airport to avoid Controlled 
+Flight Into Terrain (CFIT). A part of TAWS is to overlay the approach terrain on the [ND](../pilots-corner/a32nx-briefing/flight-deck/front/nd.md), referred to as Terrain Awareness and Display (TAD), for the awareness of the crew. This display is derived from a database and subsequently can be out of date which can lead to TAWS making false positives and general nuisances to the crew.
 
 !!! warning "Note"
     SimBridge *must* be [running](autostart.md) in order for the Terrain Display to function
 
 ## Terrain Database
-The aforementioned database has a worldwide coverage and is defined accoreding to a standardized Earth Model, dividing the surface into grid sets. Several optimizations have been made to the database to deal with size constraints within the aircraft.
+The aforementioned database has a worldwide coverage and is defined according to a standardized Earth Model, dividing the surface into grid sets. Several optimizations have been made to the database to deal with size constraints within the aircraft.
 
 - En-route
     - 3.0NM resolution
@@ -24,7 +25,7 @@ The aforementioned database has a worldwide coverage and is defined accoreding t
 The Terrain Display can be enabled on either the `left` or `right` [Navigation Display](../pilots-corner/a32nx-briefing/flight-deck/front/nd.md). To enable the display, push the `TERR ON ND` [pushbutton](../pilots-corner/a32nx-briefing/flight-deck/front/nd.md#terr-on-nd-pushbutton) and the display will begin to overlay the terrain ahead of the aircraft in a sweeping motion.
 
 ## Usage
-The display contains different several details and understanding these details will allow you to effectively use the display as-well as understanding it's faults. If the aircraft is descending more than 1,0000 ft/min then the display provides a 30 second advance display for better projection.
+The display contains different several details and understanding these details will allow you to effectively use the display as-well as understanding it's faults. If the aircraft is descending more than 1,000 ft/min then the display provides a 30 second advance display for better projection.
 
 ### Modes
 The TAWS provides two different modes of terrain display on the ND.

--- a/docs/simbridge/troubleshooting.md
+++ b/docs/simbridge/troubleshooting.md
@@ -1,4 +1,5 @@
 # Troubleshooting
+
 ## Main Window
 By default SimBridge's main window starts hidden to the systems tray, to view it select `Show/Hide` on the systems tray icon.
 ![main window](assets/simbridge/simbridge_window.png){loading=lazy}


### PR DESCRIPTION
## Summary
As noted in our docs channel the SimBridge directory had multiple instances of H1 elements breaking the table of contents navigation.

Includes typo fixes.

### Location
- simbridge/

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
