### PR TITLE
docs: Clarification of retracting landing lights

### DIFF
--- a/docs/pilots-corner/beginner-guide/takeoff-climb-cruise.md
+++ b/docs/pilots-corner/beginner-guide/takeoff-climb-cruise.md
@@ -379,7 +379,7 @@ Typically, the climb to the flight plan's cruise level (e.g., FL210) happens in 
     See also [Protections](../advanced-guides/protections/overview.md).
 
 **Passing 10,000ft**<br/>
-Turn off landing lights and when the aircraft is stable (weather, no turn, etc.) you can turn off the seatbelt signs. The aircraft will now accelerate to CLB speed (defined in `MCDU PERF CLB` page).
+Turn off and retract the landing lights and when the aircraft is stable (weather, no turn, etc.) you can turn off the seatbelt signs. The aircraft will now accelerate to CLB speed (defined in `MCDU PERF CLB` page).
 
 **Repeat the climb process above until cruise level (e.g. FL240) is reached.**
 


### PR DESCRIPTION
This is trivial, close if it is nit-picking (no hard feelings), but there was a question about it, so I thought: Why not correct it?

## Summary
A small fix to clarify that landing lights should be retracted.

### Location
https://docs.flybywiresim.com/pilots-corner/beginner-guide/takeoff-climb-cruise/#2-takeoff

Discord username (if different from GitHub):
straks (straks#7240)