### PR TITLE
refactor: correct elevation trim with pitch trim + navigation fixes

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/a32nx_api.md
+++ b/docs/pilots-corner/a32nx-briefing/a32nx_api.md
@@ -732,7 +732,7 @@ A32NX_ECAM_SD_CURRENT_PAGE_INDEX:
 
 ### Thrust Lever and Trim Wheel
 
-Flight Deck: [Thrust Lever Panel](flight-deck/pedestal/thrust-elev-trim.md)
+Flight Deck: [Thrust Lever Panel](flight-deck/pedestal/thrust-pitch-trim.md)
 
 | Function              | API Usage                   | Values        | Read/Write | Type             | Remark  |
 |:----------------------|:----------------------------|:--------------|:-----------|:-----------------|:--------|

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/index.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/index.md
@@ -121,7 +121,8 @@ hide:
     <a href="/pilots-corner/a32nx-briefing/flight-deck/pedestal/mcdu/"><div class="imagemap" style="position: absolute; left: 58.8%; top: 62.5%; width: 12.3%; height: 9.9%;"><span class="imagemapname">MCDU F.O.</span></div></a>
     <a href="/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp/"><div class="imagemap" style="position: absolute; left: 28.9%; top: 72.4%; width: 12.3%; height: 7.7%;"><span class="imagemapname">RMP and Audio Control Capt.</span></div></a>
     <a href="/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp/"><div class="imagemap" style="position: absolute; left: 58.8%; top: 72.4%; width: 12.3%; height: 7.7%;"><span class="imagemapname">RMP and Audio Control F.O.</span></div></a>
-    <a href="/pilots-corner/a32nx-briefing/flight-deck/pedestal/thrust-elev-trim/"><div class="imagemap" style="position: absolute; left: 41.2%; top: 70%; width: 17.6%; height: 11.7%;"><span class="imagemapname">Thrust Lever and Elevation Trim</span></div></a>
+    <a href="/pilots-corner/a32nx-briefing/flight-deck/pedestal/thrust-pitch-trim/"><div class="imagemap" style="position: absolute; left: 41.2%; top: 70%; width: 17.6%; 
+height: 11.7%;"><span class="imagemapname">Thrust Lever and Pitch Trim</span></div></a>
     <a href="/pilots-corner/a32nx-briefing/flight-deck/pedestal/engine/"><div class="imagemap" style="position: absolute; left: 45.5%; top: 81.7%; width: 8.9%; height: 3.3%;"><span class="imagemapname">Engine Panel</span></div></a>
     <a href="/pilots-corner/a32nx-briefing/flight-deck/pedestal/lighting-capt/"><div class="imagemap" style="position: absolute; left: 28.9%; top: 80.1%; width: 12.3%; height: 2.2%;"><span class="imagemapname">Lighting Capt.</span></div></a>
     <a href="/pilots-corner/a32nx-briefing/flight-deck/pedestal/radar/"><div class="imagemap" style="position: absolute; left: 28.9%; top: 82.3%; width: 12.3%; height: 2.8%;"><span class="imagemapname">Radar Panel</span></div></a>

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/thrust-pitch-trim.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/thrust-pitch-trim.md
@@ -1,4 +1,4 @@
-# Thrust Lever and Elevation Trim
+# Thrust Lever and Pitch Trim
 
 ---
 
@@ -6,7 +6,7 @@
 
 ---
 
-![Thrust Lever and Elevation Trim](../../../assets/a32nx-briefing/pedestal/Thrust-lever-elev-trim.jpg "Thrust Lever and Elevation Trim")
+![Thrust Lever and Pitch Trim](../../../assets/a32nx-briefing/pedestal/Thrust-lever-elev-trim.jpg "Thrust Lever and Pitch Trim")
 
 ![A/THR Instinctive Disconnect Push Button](../../../assets/a32nx-briefing/pedestal/thrustlevel-athr-disconnect.jpg)
 

--- a/docs/pilots-corner/beginner-guide/starting-the-aircraft.md
+++ b/docs/pilots-corner/beginner-guide/starting-the-aircraft.md
@@ -39,7 +39,7 @@ We begin by looking down at the [**bottom pedestal**](../a32nx-briefing/flight-d
 - [Weather Radar](../a32nx-briefing/flight-deck/pedestal/radar.md) is switched off
 - [Engine Masters 1 and 2](../a32nx-briefing/flight-deck/pedestal/engine.md) are in the `OFF` position
 - [Engine Mode](../a32nx-briefing/flight-deck/pedestal/engine.md) selector is set to `NORM`
-- [Thrust Levers](../a32nx-briefing/flight-deck/pedestal/thrust-elev-trim.md) are idle
+- [Thrust Levers](../a32nx-briefing/flight-deck/pedestal/thrust-pitch-trim.md) are idle
 
 We then direct our attention to the **main panel** and make sure the following is set:
 


### PR DESCRIPTION

## Summary
As requested by Donbikes to correct the mentions of elevation trim and replace with pitch trim.

Internal links and divmap text replaced to ensure no 404s and correct terminology.

### Location
- docs/pilots-corner/a32nx-briefing/flight-deck/index.md
- docs/pilots-corner/beginner-guide/starting-the-aircraft.md
- docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/thrust-pitch-trim.md
- docs/pilots-corner/a32nx-briefing/a32nx_api.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
