### PR TITLE
feat: add EFCS to exp.md

### DIFF
--- a/docs/fbw-a32nx/support/exp.md
+++ b/docs/fbw-a32nx/support/exp.md
@@ -23,6 +23,9 @@ of what is to be implemented and currently in testing.
 As a quick summary, the above PR will add the various EFCS computers to the A32NX to facilitate realistic data aquisition from the correct 
 sources (ADIRS, RAs, SFCCs, LGCIUs etc.) and compute their logics and laws from this data. Additionally, they will realistically communicate with each other via busses and discrete data.
 
+!!! warning ""
+    ECAM warnings are not perfectly accurate since we are missing our custom FWS.
+
 ### SimBridge
 
 The following are features in testing that require the use of SimBridge:

--- a/docs/fbw-a32nx/support/exp.md
+++ b/docs/fbw-a32nx/support/exp.md
@@ -15,6 +15,14 @@ Currently experimental is geared toward testing the initial version of VNAV with
 
 ## Implemented Features for Testing
 
+### Electronic Flight Control System (EFCS) 
+
+We are testing the initial flight control computers implementation. See [Pull Request #6913](https://github.com/flybywiresim/a32nx/pull/6913) on GitHub for a full description 
+of what is to be implemented and currently in testing.
+
+As a quick summary, the above PR will add the various EFCS computers to the A32NX to facilitate realistic data aquisition from the correct 
+sources (ADIRS, RAs, SFCCs, LGCIUs etc.) and compute their logics and laws from this data. Additionally, they will realistically communicate with each other via busses and discrete data.
+
 ### SimBridge
 
 The following are features in testing that require the use of SimBridge:
@@ -96,6 +104,15 @@ For features that are already available in the Development Version - see our gui
 ---
 
 ## Known Issues
+
+### EFCS
+
+- Improve direct and alternate law: Direct law is not scaled down based on Flaps/Slats configuration, thus can be very sensitive at high speeds, Alternate law still uses TAS for 
+the C* law, this is incorrect and will result in issues if no ADR is available.
+- V_stall warn AoAs need to be tuned, currently they are just the same as alpha_prot.
+- In some situations, AP might not be available in alternate law even though it should be. This is due to how the AP commands are currently executed, which requires the normal 
+  laws to be active (IRL this is different). Will take some time to fix this, not planned currently.
+- The electrical bus connections are not quite correct yet, the ELAC/SEC 2s have rather complex logic for power supply switching, which is not done yet.
 
 ### Pause at TOD Issues
 

--- a/docs/fbw-a32nx/support/exp.md
+++ b/docs/fbw-a32nx/support/exp.md
@@ -152,7 +152,7 @@ the C* law, this is incorrect and will result in issues if no ADR is available.
 
     At this time please only report issues via our Discord channel threads:
 
-    [cFMS LNAV+VNAV Issue Reports [NO SUPPORT]](https://discord.com/channels/738864299392630914/926586416820011098){target=new .md-button}
+[//]: # (    [cFMS LNAV+VNAV Issue Reports [NO SUPPORT]]&#40;https://discord.com/channels/738864299392630914/926586416820011098&#41;{target=new .md-button})
 
     [flyPadOS3 Experimental - Issue Reports [NO SUPPORT]](https://discord.com/channels/738864299392630914/926586416820011098){target=new .md-button}
 


### PR DESCRIPTION

## Summary
Adds EFCS information to experimental page for support ops and end user awareness.

Includes issues and links outbound to A32NX PR:
- https://github.com/flybywiresim/a32nx/pull/6913

### Location
- docs/fbw-a32nx/support/exp.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
