### PR TITLE
docs(development-corner): add scenery dev tips

### DIFF
--- a/docs/dev-corner/.pages
+++ b/docs/dev-corner/.pages
@@ -7,4 +7,5 @@ title: Development Corner
 nav:
     - Overview: index.md
     - Texture Changes: texture-changes.md
+    - Scenery Developers: scenery-developers.md
     - ...

--- a/docs/dev-corner/index.md
+++ b/docs/dev-corner/index.md
@@ -12,5 +12,6 @@ This section of the FlyByWire Documentation is dedicated to the development aspe
 | :----                                       |
 | [Development Guide](dev-guide/index.md)     |
 | [Texture Changes](texture-changes.md)       |
+| [Scenery Developers](scenery-developers.md) |
 | [FlyByWire Projects](development-projects/) |
 

--- a/docs/dev-corner/scenery-developers.md
+++ b/docs/dev-corner/scenery-developers.md
@@ -1,0 +1,9 @@
+# Tips for Scenery Developers
+
+## Navigation Data
+
+In general it's best to stay away from navigation data in scenery packages, as the default navdata from NavBlue is kept up-to-date each cycle, and third-party solutions like Navigraph can provide good service when their data isn't overriden.
+
+## ILS Auto-Tuning
+
+The A32NX relies on the navigation data from MSFS to link ILS to runways. This depends on runway definitions in the scenery. To ensure full functionality in FlyByWire aircraft (and other MSFS avionics), make sure your `<Runway />` definitions have an [`<IlsReference />`](https://docs.flightsimulator.com/html/Content_Configuration/Environment/Airports_And_Facilities/Runway_Definition_Properties.htm#h8) linking them to the runway-aligned localiser specified in the official AIP.


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->

Some scenery devs are omitting ILS information from their runways, which limits the data available to us, especially post-SU10 where we would miss out on some newly available data at these airports e.g. glideslope slope.

### Location
<!-- Please provide the original URL of the page modified or directory location here -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
