### PR TITLE
feat: coroute documentation

### DIFF
--- a/docs/fbw-a32nx/support/exp.md
+++ b/docs/fbw-a32nx/support/exp.md
@@ -53,6 +53,7 @@ The following are features in testing that require the use of SimBridge:
 - Remote MCDU (Web MCDU) 
     - [Setup and Configuration Guide](../../simbridge/remote-displays/configuration.md)
     - [Usage Guide](../../simbridge/remote-displays/remote-mcdu.md)
+- [Company Routes](#company-routes)
 
 !!! tip "SimBridge Information"
     - Learn about SimBridge and further status of various features please - [Read Here](../../simbridge/index.md).
@@ -68,7 +69,7 @@ of honeywell and do not have map-data above 83° north or below 84° south.
 You can read more about the "PEAKS DISPLAY" in this technical guide from Honeywell - [Read Here](https://skybrary.aero/sites/default/files/bookshelf/3364.pdf){target=new}
 
 !!! tip "Configuration"
-    - [Terrain Usage Guide](../../simbridge/terrain.md)
+    [Terrain Usage Guide](../../simbridge/terrain.md){.md-button}
 
 !!! warning "Reporting Bugs / Strange Behaviors"
     When reporting a bug or strange behavior that we need the GPS position or at least a reference to an airport/VOR/NDB with a distance and direction. 
@@ -76,6 +77,13 @@ You can read more about the "PEAKS DISPLAY" in this technical guide from Honeywe
     This will help us iron out the feature and identify issues faster. For more information on where to report please see [How to Report Issues](#how-to-report-issues) below.
 
     Expect performance loss as we continue to optimise.
+
+#### Company Routes
+
+This feature allows you to save routes you regularly fly to your PC in the simBrief XML Datafiles format for repeated use.
+
+!!! tip "Configuration and Usage"
+    [Company Routes Guide](../../simbridge/coroute.md){.md-button}
 
 ### Pause at Top of Descent (TOD)
 

--- a/docs/fbw-a32nx/support/exp.md
+++ b/docs/fbw-a32nx/support/exp.md
@@ -15,6 +15,16 @@ Currently experimental is geared toward testing the initial version of VNAV with
 
 ## Implemented Features for Testing
 
+### RMP Navigation Tuning
+
+We are testing the ability for the radio management panel to tune navigational aids. See technical details in the respective [GitHub Pull Request #7241](https://github.
+com/flybywiresim/a32nx/pull/7241){target=new}.
+
+### Fine Tuning Engine Parameters
+
+We are further turning our engine primary parameters in regards to EGT and fuel flow in a two part implementation. See technical details in the respective 
+[GitHub Pull Request #7542](https://github.com/flybywiresim/a32nx/pull/7542){target=new}.
+
 ### Flight Warning System (FWS)
 
 We are testing the new FWS (Flight Warning System) which replaces the previous provisional system. 
@@ -33,17 +43,6 @@ not been touched, but will be eventually moved over to the new flight warning co
 
 The new Flight Warning Computers are also hooked into the electrical and failure system, so the alerts that are now 
 powered by the FWS truly won't work when both FWCs are unpowered or have failed.
-
-### Electronic Flight Control System (EFCS) 
-
-We are testing the initial flight control computers implementation. See [Pull Request #6913](https://github.com/flybywiresim/a32nx/pull/6913) on GitHub for a full description 
-of what is to be implemented and currently in testing.
-
-As a quick summary, the above PR will add the various EFCS computers to the A32NX to facilitate realistic data aquisition from the correct 
-sources (ADIRS, RAs, SFCCs, LGCIUs etc.) and compute their logics and laws from this data. Additionally, they will realistically communicate with each other via busses and discrete data.
-
-!!! warning ""
-    ECAM warnings are not perfectly accurate since we are missing our custom FWS.
 
 ### SimBridge
 
@@ -91,14 +90,6 @@ This feature allows you to save routes you regularly fly to your PC in the simBr
 - When enabled, flight will pause at the specified distance before TOD
 - If the TOD point shifts before your present position, or AP mode reverts in CRZ, this will pause the simulation.
 
-### Hydraulic Gear System
-
-- Custom gravity gear extension model
-
-For features that are already available in the Development Version - see our guide for usage and known issues.
-
-[Custom Hydraulics Guide](../feature-guides/custom-hydraulics.md){.md-button}
-
 ### Vertical Guidance
 
 - Speed and altitude predictions in the flight plan page, including magenta or amber asterisks.
@@ -133,9 +124,21 @@ For features that are already available in the Development Version - see our gui
 
 ---
 
+## Released Into Development Version
+
+Features in testing that have been released into Development but not Stable will be listed here. This list will be pruned with every Stable release.
+
+- Electronic Flight Control System (EFCS)
+- Hydraulic Gear System - [Guide Here](../feature-guides/custom-hydraulics.md)
+
+---
+
 ## Known Issues
 
 ### EFCS
+
+!!! info ""
+    We are keeping these known issues here until dedicated EFCS information is available.
 
 - Improve direct and alternate law: Direct law is not scaled down based on Flaps/Slats configuration, thus can be very sensitive at high speeds, Alternate law still uses TAS for 
 the C* law, this is incorrect and will result in issues if no ADR is available.

--- a/docs/simbridge/.pages
+++ b/docs/simbridge/.pages
@@ -12,5 +12,5 @@ nav:
     - Autostart: autostart.md
     - Remote Displays: remote-displays
     - Terrain Display: terrain.md
-    # - Company Routes: coroute.md
+    - Company Routes: coroute.md
     # - PDF Viewer: pdf-viewer.md

--- a/docs/simbridge/coroute.md
+++ b/docs/simbridge/coroute.md
@@ -1,6 +1,12 @@
 # Company Routes
 Stored Company Routes allow you to save routes you regularly fly to your PC. It uses simBrief XML Datafiles format so you can easily use your simBrief planning to create a stored company route.
 
+!!! danger "Experimental-Only"
+    This feature is only available on Experimental. Since this feature is currently in testing, please expect issues and report them in the 
+    appropriate channel on Discord. 
+
+    See the [Experimental Support Guide](../fbw-a32nx/support/exp.md).
+
 !!! warning Notice
     To allow the aircraft to access local files you need to SimBridge running. See [Autostart](autostart.md) documentation on how to start it. 
 

--- a/docs/simbridge/coroute.md
+++ b/docs/simbridge/coroute.md
@@ -14,7 +14,21 @@ Stored Company Routes allow you to save routes you regularly fly to your PC. It 
 - Save the simBrief XML Datafile to the coroutes folder in the [resources folder](installation.md#resources-folder).
 - Rename the simBrief XML Datafile to any name with maximal 9 characters. E.g. the airport's IATA codes `STRCPH1.xml`.
 
-#### Entering a Company Route Name 
+### How Use a Saved Company Route
+
+There are two methods available:
+
+- [Entering the Company Route Name](#entering-the-company-route-name)
+- [Entering a FROM/TO Pair](#entering-a-fromto-pair)
+
+!!! warning "Important Note"
+     When utilizing a company route please be aware of the following:
+
+    - A Stored Company Route does not include the flight number, cost index or cruise level.
+    - Also, SID/STAR and APPR or any other flight specific data (pax, cargo, etc.) are not part of a stored company route.
+    - You can now complete the flight plan setup by entering the missing data manually.
+
+#### Entering the Company Route Name 
 - Start a flight at the appropriate departure airport and follow the standard setup procedure.
 - When setting up the flight management system in the MCDU you can directly head to the INIT A page.
 - Enter the name of your company route into the `CO RTE` field.
@@ -22,9 +36,7 @@ Stored Company Routes allow you to save routes you regularly fly to your PC. It 
     ![MCDU INIT A Loading CoRoute](assets/mcdu-init-a-load.png){loading=lazy}
 
 - This populates FROM/TO and also the basic flight plan. 
-- A Stored Company Route does not include the flight number, cost index or cruise level.
-- Also, SID/STAR and APPR or any other flight specific data (pax, cargo, etc.) are not part of a stored company route.
-- You can now complete the flight plan setup by entering the missing data manually.
+
 
 #### Entering a FROM/TO Pair
 - **Alternatively** you can enter the FROM/TO pair of routes you have stored which will bring up the co-route selection page.
@@ -35,6 +47,3 @@ Stored Company Routes allow you to save routes you regularly fly to your PC. It 
 - You can navigate between the routes with the horizontal slew keys.
 - For long routes you can scroll the page by using the vertical slew keys.
 - You can choose and insert a route by pressing the LSK 6L next to `INSERT*`
-- A Stored Company Route does not include the flight number, cost index or cruise level.
-- Also, SID/STAR and APPR or any other flight specific data (pax, cargo, etc.) are not part of a stored company route.
-- You can now complete the flight plan setup by entering the missing data manually.

--- a/docs/simbridge/coroute.md
+++ b/docs/simbridge/coroute.md
@@ -6,7 +6,7 @@ Stored Company Routes allow you to save routes you regularly fly to your PC. It 
 
 ### Generating a Stored Company Route Using simBrief
 
-- Generate a flight plan using simBrief .
+- Generate a flight plan using simBrief.
 - Download the `XML Datafile' from simBrief.
 
     ![simBrief Datafile Download](assets/simbridge/simbrief-datafile-download.png){loading=lazy}

--- a/docs/simbridge/coroute.md
+++ b/docs/simbridge/coroute.md
@@ -22,11 +22,12 @@ There are two methods available:
 - [Entering a FROM/TO Pair](#entering-a-fromto-pair)
 
 !!! warning "Important Note"
-     When utilizing a company route please be aware of the following:
+     When utilizing a stored company route please be aware of the following data that is not included:
 
-    - A Stored Company Route does not include the flight number, cost index or cruise level.
-    - Also, SID/STAR and APPR or any other flight specific data (pax, cargo, etc.) are not part of a stored company route.
-    - You can now complete the flight plan setup by entering the missing data manually.
+    - <span style= "color:red;">Does not include</span> the flight number, cost index or cruise level.
+    - <span style= "color:red;">Does not include</span> SID/STAR and APPR or any other flight specific data (pax, cargo, etc.).
+    
+    You can complete the flight plan setup by entering the missing data manually.
 
 #### Entering the Company Route Name 
 - Start a flight at the appropriate departure airport and follow the standard setup procedure.

--- a/docs/simbridge/index.md
+++ b/docs/simbridge/index.md
@@ -28,12 +28,12 @@ require fewer extra steps before launching into your flights.
     
     This page will keep you updated with the status and any further documentation for these services.
 
-|                                      Feature                                       |                                         Status                                          |
-|:----------------------------------------------------------------------------------:|:---------------------------------------------------------------------------------------:|
-|                           [Terrain Display](terrain.md)                            |                 In [Experimental](../fbw-a32nx/support/exp.md) Version                  |
-|               [MCDU Remote Display](remote-displays/remote-mcdu.md)                | In [Development](../fbw-a32nx/fbw-versions.md#development-version-recommended) Version  |
-|                               Company Route Support                                |                                Built - Not Yet Migrated                                 |
-| [flyPad Local Charts](../fbw-a32nx/feature-guides/flypados3/charts.md#local-files) | In [Development](../fbw-a32nx/fbw-versions.md#development-version-recommended) Version  |
-|                                  Remote Displays                                   |                                    Work in Progress                                     |
+|                                      Feature                                       |                                         Status                                         |
+|:----------------------------------------------------------------------------------:|:--------------------------------------------------------------------------------------:|
+|                           [Terrain Display](terrain.md)                            |                 In [Experimental](../fbw-a32nx/support/exp.md) Version                 |
+|               [MCDU Remote Display](remote-displays/remote-mcdu.md)                | In [Development](../fbw-a32nx/fbw-versions.md#development-version-recommended) Version |
+|                        [Company Routes Support](coroute.md)                        |                 In [Experimental](../fbw-a32nx/support/exp.md) Version                 |
+| [flyPad Local Charts](../fbw-a32nx/feature-guides/flypados3/charts.md#local-files) | In [Development](../fbw-a32nx/fbw-versions.md#development-version-recommended) Version |
+|                                  Remote Displays                                   |                                    Work in Progress                                    |
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,7 +46,6 @@ plugins:
       - pilots-corner/advanced-guides/flight-guidance/autopilot.md
       - pilots-corner/advanced-guides/flight-guidance/lnav.md
       - pilots-corner/advanced-guides/flight-guidance/vnav.md
-      - simbridge/coroute.md
       - simbridge/pdf-viewer.md
   awesome-pages: {}
   tags: {}


### PR DESCRIPTION

## Summary
Supports A32NX PR:

- https://github.com/flybywiresim/a32nx/pull/6411

Some changes were mde to the coroute.md page for readability and pointing out certain information to the end-user.

Updates to the SimBridge index page and experimental support page. Also removes config exclusions for the following pages:

- Terrain
- Coroute

### Location
- docs/simbridge/coroute.md
- docs/simbridge/index.md
- docs/fbw-a32nx/support/exp.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
