### PR TITLE
fix(audio): new "prepare for takeoff" sound event trigger

### DIFF
--- a/docs/fbw-a32nx/feature-guides/audio.md
+++ b/docs/fbw-a32nx/feature-guides/audio.md
@@ -43,7 +43,7 @@ If this setting is enabled the following crew announcements are played.
 | Boarding Completed + 30s                   | Captain makes a "Welcome on Board" announcement |     Captain      |
 | Beacon Light set to `ON`                   | "Arm Doors" Announcement                        | Flight Attendant |
 | "Arm Doors" Announcement + 30s             | Safety Demo                                     | On-Board System  |
-| Landing Lights set to `ON`                 | "Prepare for Takeoff" Announcement              |     Captain      |
+| TCAS mode switched to TA ONLY/TA RA        | "Prepare for Takeoff" Announcement              |     Captain      |
 | Enter **Cruise Phase** + 30s               | "Cruise" Announcement                           |     Captain      |
 | Enter **Descent Phase** + 30s              | "Descent" Announcement                          |     Captain      |
 | Gear Down + **Approach Phase** Active      | "Prepare for Landing" Announcement              |     Captain      |

--- a/docs/fbw-a32nx/feature-guides/audio.md
+++ b/docs/fbw-a32nx/feature-guides/audio.md
@@ -43,7 +43,7 @@ If this setting is enabled the following crew announcements are played.
 | Boarding Completed + 30s                   | Captain makes a "Welcome on Board" announcement |     Captain      |
 | Beacon Light set to `ON`                   | "Arm Doors" Announcement                        | Flight Attendant |
 | "Arm Doors" Announcement + 30s             | Safety Demo                                     | On-Board System  |
-| TCAS mode switched to TA ONLY/TA RA        | "Prepare for Takeoff" Announcement              |     Captain      |
+| TCAS mode switched to `TA` OR `TA/RA`      | "Prepare for Takeoff" Announcement              |     Captain      |
 | Enter **Cruise Phase** + 30s               | "Cruise" Announcement                           |     Captain      |
 | Enter **Descent Phase** + 30s              | "Descent" Announcement                          |     Captain      |
 | Gear Down + **Approach Phase** Active      | "Prepare for Landing" Announcement              |     Captain      |


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
Change for https://github.com/flybywiresim/a32nx/pull/7402 (FBW 320) to reflect new "Prepare for Takeoff" sound event trigger.

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/settings/?h=boarding#audio

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):2Cas#1022
