### PR TITLE
refactor: Changed location of a32nx flight deck API page

### DIFF
--- a/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -3,10 +3,10 @@ hide:
     - navigation
 ---
 
-# Flight Deck A32NX API
+# A32NX Flight Deck API
 
-[A320neo Pilot Briefing](index.md){ .md-button }
-[Clickable Flight Deck](flight-deck/index.md){ .md-button }
+[A320neo Pilot Briefing](../../pilots-corner/a32nx-briefing/index.md){ .md-button }
+[Clickable Flight Deck](../../pilots-corner/a32nx-briefing/flight-deck/index.md){ .md-button }
 
 !!! note ""
     The below table might lag behind the current developments of the A32NX. It is
@@ -29,7 +29,7 @@ Find the complete list of Custom Event and Custom LVARS of the A32NX:
 
 ### ELEC Panel
 
-Flight Deck:  [ELEC Panel](flight-deck/ovhd/elec.md)
+Flight Deck:  [ELEC Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/elec.md)
 
 | Function    | API Usage                                 | Values   | Read/Write | Type             | Remark                                     |
 |:------------|:------------------------------------------|:---------|:-----------|:-----------------|:-------------------------------------------|
@@ -75,7 +75,7 @@ Flight Deck:  [ELEC Panel](flight-deck/ovhd/elec.md)
 
 ### External Lights Panel
 
-Flight Deck:  [EXT LT Panel](flight-deck/ovhd/ext-lt.md)
+Flight Deck:  [EXT LT Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/ext-lt.md)
 
 | Function     | API Usage             | Values   | Read/Write | Type             | Remark                                                             |
 |:-------------|:----------------------|:---------|:-----------|:-----------------|:-------------------------------------------------------------------|
@@ -160,7 +160,7 @@ Flight Deck:  [EXT LT Panel](flight-deck/ovhd/ext-lt.md)
 
 ### Interior Lights Panel
 
-Flight Deck: [INT LT Panel](flight-deck/ovhd/int-lt.md)
+Flight Deck: [INT LT Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/int-lt.md)
 
 | Function               | API Usage              | Values | Read/Write | Type             | Remark               |
 |:-----------------------|:-----------------------|:-------|:-----------|:-----------------|:---------------------|
@@ -175,7 +175,7 @@ Flight Deck: [INT LT Panel](flight-deck/ovhd/int-lt.md)
 
 ### Signs Panel
 
-Flight Deck: [Signs Panel](flight-deck/ovhd/signs.md)
+Flight Deck: [Signs Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/signs.md)
 
 | Function     | API Usage                                    | Values   | Read/Write | Type             | Remark              |
 |:-------------|:---------------------------------------------|:---------|:-----------|:-----------------|:--------------------|
@@ -188,7 +188,7 @@ Flight Deck: [Signs Panel](flight-deck/ovhd/signs.md)
 
 ### ADIRS Panel
 
-Flight Deck: [ADIRS Panel](flight-deck/ovhd/adirs.md)
+Flight Deck: [ADIRS Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs.md)
 
 !!! note "The below table shows the API for ADIR 1. Replace `1` with `2` or `3` for the other ADIRS."
 
@@ -208,7 +208,7 @@ Flight Deck: [ADIRS Panel](flight-deck/ovhd/adirs.md)
 
 ### APU Panel
 
-Flight Deck: [APU Panel](flight-deck/ovhd/apu.md)
+Flight Deck: [APU Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/apu.md)
 
 | Function  | API Usage                             | Values   | Read/Write | Type        | Remark |
 |:----------|:--------------------------------------|:---------|:-----------|:------------|:-------|
@@ -222,7 +222,7 @@ Flight Deck: [APU Panel](flight-deck/ovhd/apu.md)
 
 ### RCDR Panel
 
-Flight Deck: [RCDR Panel](flight-deck/ovhd/voice-recorder.md)
+Flight Deck: [RCDR Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/voice-recorder.md)
 
 | Function  | API Usage                    | Values   | Read/Write | Type        | Remark |
 |:----------|:-----------------------------|:---------|:-----------|:------------|:-------|
@@ -234,7 +234,7 @@ Flight Deck: [RCDR Panel](flight-deck/ovhd/voice-recorder.md)
 
 ### Oxygen Panel
 
-Flight Deck: [Oxygen Panel](flight-deck/ovhd/oxygen.md)
+Flight Deck: [Oxygen Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/oxygen.md)
 
 | Function    | API Usage                       | Values   | Read/Write | Type        | Remark |
 |:------------|:--------------------------------|:---------|:-----------|:------------|:-------|
@@ -246,7 +246,7 @@ Flight Deck: [Oxygen Panel](flight-deck/ovhd/oxygen.md)
 
 ### Fire Panel
 
-Flight Deck: [Fire Panel](flight-deck/ovhd/fire.md)
+Flight Deck: [Fire Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/fire.md)
 
 !!! note "The below table shows the API for ENG 1. Replace `1` with `2`for ENG 2."
 
@@ -272,7 +272,7 @@ Flight Deck: [Fire Panel](flight-deck/ovhd/fire.md)
 
 ### Fuel Panel
 
-Flight Deck: [Fuel Panel](flight-deck/ovhd/fuel.md)
+Flight Deck: [Fuel Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/fuel.md)
 
 !!! note "The below table shows the API for PUMP 1. Replace `1` with `2..6` for the other pumps."
     L1=2, L2=5. C1=1, C2=4, R1=3, R2=6
@@ -290,7 +290,7 @@ Flight Deck: [Fuel Panel](flight-deck/ovhd/fuel.md)
 
 ### Air Condition Panel
 
-Flight Deck: [AC Panel](flight-deck/ovhd/ac.md)
+Flight Deck: [AC Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/ac.md)
 
 | Function       | API Usage                                                 | Values   | Read/Write | Type        | Remark       |
 |:---------------|:----------------------------------------------------------|:---------|:-----------|:------------|:-------------|
@@ -337,7 +337,7 @@ Flight Deck: [AC Panel](flight-deck/ovhd/ac.md)
 
 ### Anti Ice Panel
 
-Flight Deck: [Anti Ice Panel](flight-deck/ovhd/anti-ice.md)
+Flight Deck: [Anti Ice Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/anti-ice.md)
 
 | Function          | API Usage                                            | Values   | Read/Write | Type             | Remark                  |
 |:------------------|:-----------------------------------------------------|:---------|:-----------|:-----------------|:------------------------|
@@ -358,7 +358,7 @@ Flight Deck: [Anti Ice Panel](flight-deck/ovhd/anti-ice.md)
 
 ### Calls Panel
 
-Flight Deck: [Calls Panel](flight-deck/ovhd/calls.md)
+Flight Deck: [Calls Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/calls.md)
 
 | Function | API Usage                | Values   | Read/Write | Type        | Remark |
 |:---------|:-------------------------|:---------|:-----------|:------------|:-------|
@@ -375,7 +375,7 @@ Flight Deck: [Calls Panel](flight-deck/ovhd/calls.md)
 
 ### Wiper Panel
 
-Flight Deck: [Wiper Panel](flight-deck/ovhd/wipers.md)
+Flight Deck: [Wiper Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/wipers.md)
 
 | Function     | API Usage                            | Values   | Read/Write | Type        | Remark                                 |
 |:-------------|:-------------------------------------|:---------|:-----------|:------------|:---------------------------------------|
@@ -394,7 +394,7 @@ Flight Deck: [Wiper Panel](flight-deck/ovhd/wipers.md)
 
 ### Lighting Knobs
 
-Flight Deck: [Glareshield Lighting Knobs](flight-deck/glareshield/light-knobs.md)
+Flight Deck: [Glareshield Lighting Knobs](../../pilots-corner/a32nx-briefing/flight-deck/glareshield/light-knobs.md)
 
 | Function                    | API Usage              | Values | Read/Write | Type     | Remark |
 |:----------------------------|:-----------------------|:-------|:-----------|:---------|:-------|
@@ -408,7 +408,7 @@ Flight Deck: [Glareshield Lighting Knobs](flight-deck/glareshield/light-knobs.md
 
 ### EFIS Control Panel
 
-Flight Deck: [EFIS Control Panel](flight-deck/glareshield/efis_control.md)
+Flight Deck: [EFIS Control Panel](../../pilots-corner/a32nx-briefing/flight-deck/glareshield/efis_control.md)
 
 | Function     | API Usage                        | Values           | Read/Write | Type             | Remark                                            |
 |:-------------|:---------------------------------|:-----------------|:-----------|:-----------------|:--------------------------------------------------|
@@ -443,7 +443,7 @@ Flight Deck: [EFIS Control Panel](flight-deck/glareshield/efis_control.md)
 
 ### FCU Panel
 
-Flight Deck: [FCU Panel](flight-deck/glareshield/fcu.md)
+Flight Deck: [FCU Panel](../../pilots-corner/a32nx-briefing/flight-deck/glareshield/fcu.md)
 
 | Function          | API Usage                           | Values               | Read/Write | Type             | Remark                                                                   |
 |:------------------|:------------------------------------|:---------------------|:-----------|:-----------------|:-------------------------------------------------------------------------|
@@ -538,7 +538,7 @@ Flight Deck: [FCU Panel](flight-deck/glareshield/fcu.md)
 
 ### Warning Panel
 
-Flight Deck: [Warning Panel](flight-deck/glareshield/warning.md)
+Flight Deck: [Warning Panel](../../pilots-corner/a32nx-briefing/flight-deck/glareshield/warning.md)
 
 | Function            | API Usage                        | Values   | Read/Write | Type                     | Remark |
 |:--------------------|:---------------------------------|:---------|:-----------|:-------------------------|:-------|
@@ -560,7 +560,7 @@ Flight Deck: [Warning Panel](flight-deck/glareshield/warning.md)
 
 ### Instrument Lighting Control Panel
 
-Flight Deck: [ILCP Panel](flight-deck/front/ilcp.md)
+Flight Deck: [ILCP Panel](../../pilots-corner/a32nx-briefing/flight-deck/front/ilcp.md)
 
 | Function            | API Usage              | Values      | Read/Write | Type     | Remark |
 |:--------------------|:-----------------------|:------------|:-----------|:---------|:-------|
@@ -590,7 +590,7 @@ Flight Deck: [ILCP Panel](flight-deck/front/ilcp.md)
 
 ### Autobrake, Gear Lever and Gear Annunciation
 
-Flight Deck: [Autobrake and Gear Panel](flight-deck/front/autobrake-gear.md)
+Flight Deck: [Autobrake and Gear Panel](../../pilots-corner/a32nx-briefing/flight-deck/front/autobrake-gear.md)
 
 | Function              | API Usage                       | Values   | Read/Write | Type             | Remark                             |
 |:----------------------|:--------------------------------|:---------|:-----------|:-----------------|:-----------------------------------|
@@ -622,7 +622,7 @@ Flight Deck: [Autobrake and Gear Panel](flight-deck/front/autobrake-gear.md)
 
 ### ISIS
 
-Flight Deck: [ISIS Panel](flight-deck/front/isis.md)
+Flight Deck: [ISIS Panel](../../pilots-corner/a32nx-briefing/flight-deck/front/isis.md)
 
 | Function   | API Usage             | Values | Read/Write | Type        | Remark                                      |
 |:-----------|:----------------------|:-------|:-----------|:------------|:--------------------------------------------|
@@ -630,7 +630,7 @@ Flight Deck: [ISIS Panel](flight-deck/front/isis.md)
 
 ### Clock
 
-Flight Deck: [Chrono Panel](flight-deck/front/clock.md)
+Flight Deck: [Chrono Panel](../../pilots-corner/a32nx-briefing/flight-deck/front/clock.md)
 
 | Function            | API Usage                    | Values                | Read/Write | Type        | Remark                       |
 |:--------------------|:-----------------------------|:----------------------|:-----------|:------------|:-----------------------------|
@@ -640,7 +640,7 @@ Flight Deck: [Chrono Panel](flight-deck/front/clock.md)
 
 ### TERR ON ND
 
-Flight Deck: [ND Panel](flight-deck/front/nd.md)
+Flight Deck: [ND Panel](../../pilots-corner/a32nx-briefing/flight-deck/front/nd.md)
 
 | Function       | API Usage                | Values   | Read/Write | Type        | Remark                         |
 |:---------------|:-------------------------|:---------|:-----------|:------------|:-------------------------------|
@@ -649,7 +649,7 @@ Flight Deck: [ND Panel](flight-deck/front/nd.md)
 
 ### DCDU
 
-Flight Deck: [DCDU Panel](flight-deck/front/dcdu.md)
+Flight Deck: [DCDU Panel](../../pilots-corner/a32nx-briefing/flight-deck/front/dcdu.md)
 
 note "The below table shows the API for left DCDU. Replace `L` with `R` for the right DCDU."
 
@@ -661,7 +661,7 @@ note "The below table shows the API for left DCDU. Replace `L` with `R` for the 
 
 ### MCDU Panel
 
-Flight Deck: [MCDU Panel](flight-deck/pedestal/mcdu.md)
+Flight Deck: [MCDU Panel](../../pilots-corner/a32nx-briefing/flight-deck/pedestal/mcdu.md)
 
 !!! note "The below table shows the API for left MCDU. Replace `L` with `R` for the right MCDU."
 
@@ -671,7 +671,7 @@ Flight Deck: [MCDU Panel](flight-deck/pedestal/mcdu.md)
 
 ### Switching Panel
 
-Flight Deck: [Switching Panel](flight-deck/pedestal/switching.md)
+Flight Deck: [Switching Panel](../../pilots-corner/a32nx-briefing/flight-deck/pedestal/switching.md)
 
 | Function    | API Usage                        | Values | Read/Write | Type        | Remark                |
 |:------------|:---------------------------------|:-------|:-----------|:------------|:----------------------|
@@ -685,7 +685,7 @@ Flight Deck: [Switching Panel](flight-deck/pedestal/switching.md)
 
 ### ECAM Control Panel
 
-Flight Deck: [ECAM Control Panel](flight-deck/pedestal/ecam-control.md)
+Flight Deck: [ECAM Control Panel](../../pilots-corner/a32nx-briefing/flight-deck/pedestal/ecam-control.md)
 
 | Function              | API Usage                        | Values   | Read/Write | Type        | Remark                                                                     |
 |:----------------------|:---------------------------------|:---------|:-----------|:------------|:---------------------------------------------------------------------------|
@@ -732,7 +732,7 @@ A32NX_ECAM_SD_CURRENT_PAGE_INDEX:
 
 ### Thrust Lever and Trim Wheel
 
-Flight Deck: [Thrust Lever Panel](flight-deck/pedestal/thrust-pitch-trim.md)
+Flight Deck: [Thrust Lever Panel](../../pilots-corner/a32nx-briefing/flight-deck/pedestal/thrust-pitch-trim.md)
 
 | Function              | API Usage                   | Values        | Read/Write | Type             | Remark  |
 |:----------------------|:----------------------------|:--------------|:-----------|:-----------------|:--------|
@@ -745,7 +745,7 @@ Flight Deck: [Thrust Lever Panel](flight-deck/pedestal/thrust-pitch-trim.md)
 
 ### RMP
 
-Flight Deck: [RMP Panel](flight-deck/pedestal/rmp.md)
+Flight Deck: [RMP Panel](../../pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md)
 
 !!! note "The below table shows the API for RMP 1. Replace `1` with `2` or `3` for the other RMPs."
 
@@ -769,7 +769,7 @@ Flight Deck: [RMP Panel](flight-deck/pedestal/rmp.md)
 
 ### Lighting Pedestal Captain Side Panel
 
-Flight Deck: [Lighting Pedestal Cpt. Side Panel](flight-deck/pedestal/lighting-capt.md)
+Flight Deck: [Lighting Pedestal Cpt. Side Panel](../../pilots-corner/a32nx-briefing/flight-deck/pedestal/lighting-capt.md)
 
 | Function      | API Usage              | Values | Read/Write | Type     | Remark       |
 |:--------------|:-----------------------|:-------|:-----------|:---------|:-------------|
@@ -781,7 +781,7 @@ Flight Deck: [Lighting Pedestal Cpt. Side Panel](flight-deck/pedestal/lighting-c
 
 ### WX Radar
 
-Flight Deck: [WX Radar Panel](flight-deck/pedestal/radar.md)
+Flight Deck: [WX Radar Panel](../../pilots-corner/a32nx-briefing/flight-deck/pedestal/radar.md)
 
 | Function   | API Usage                       | Values   | Read/Write | Type        | Remark                      |
 |:-----------|:--------------------------------|:---------|:-----------|:------------|:----------------------------|
@@ -802,7 +802,7 @@ Flight Deck: [WX Radar Panel](flight-deck/pedestal/radar.md)
 
 ### ATC-TCAS
 
-Flight Deck: [ATC-TCAS Panel](flight-deck/pedestal/atc-tcas.md)
+Flight Deck: [ATC-TCAS Panel](../../pilots-corner/a32nx-briefing/flight-deck/pedestal/atc-tcas.md)
 
 | Function     | API Usage                          | Values      | Read/Write | Type             | Remark                      |
 |:-------------|:-----------------------------------|:------------|:-----------|:-----------------|:----------------------------|
@@ -822,7 +822,7 @@ Flight Deck: [ATC-TCAS Panel](flight-deck/pedestal/atc-tcas.md)
 
 ### ENG Panel
 
-Flight Deck: [ENG Panel](flight-deck/pedestal/engine.md)
+Flight Deck: [ENG Panel](../../pilots-corner/a32nx-briefing/flight-deck/pedestal/engine.md)
 
 | Function       | API Usage                      | Values     | Read/Write | Type       | Remark                 |
 |:---------------|:-------------------------------|:-----------|:-----------|:-----------|:-----------------------|
@@ -840,7 +840,7 @@ Flight Deck: [ENG Panel](flight-deck/pedestal/engine.md)
 
 ### Speed Brake
 
-Flight Deck: [Speed Brake Panel](flight-deck/pedestal/speedbrake.md)
+Flight Deck: [Speed Brake Panel](../../pilots-corner/a32nx-briefing/flight-deck/pedestal/speedbrake.md)
 
 | Function         | API Usage                      | Values   | Read/Write | Type             | Remark                           |
 |:-----------------|:-------------------------------|:---------|:-----------|:-----------------|:---------------------------------|
@@ -853,7 +853,7 @@ Flight Deck: [Speed Brake Panel](flight-deck/pedestal/speedbrake.md)
 
 ### Flaps
 
-Flight Deck: [Speed Brake Panel](flight-deck/pedestal/flaps.md)
+Flight Deck: [Speed Brake Panel](../../pilots-corner/a32nx-briefing/flight-deck/pedestal/flaps.md)
 
 | Function   | API Usage                  | Values   | Read/Write | Type             | Remark                        |
 |:-----------|:---------------------------|:---------|:-----------|:-----------------|:------------------------------|
@@ -874,7 +874,7 @@ Flight Deck: [Speed Brake Panel](flight-deck/pedestal/flaps.md)
 
 ### Parking Brake
 
-Flight Deck: [Parking Brake Panel](flight-deck/pedestal/parking-brake.md)
+Flight Deck: [Parking Brake Panel](../../pilots-corner/a32nx-briefing/flight-deck/pedestal/parking-brake.md)
 
 | Function      | API Usage                  | Values   | Read/Write | Type        | Remark |
 |:--------------|:---------------------------|:---------|:-----------|:------------|:-------|
@@ -882,7 +882,7 @@ Flight Deck: [Parking Brake Panel](flight-deck/pedestal/parking-brake.md)
 
 ### Rudder Trim
 
-Flight Deck: [Rudder Trim Panel](flight-deck/pedestal/rudder-trim.md)
+Flight Deck: [Rudder Trim Panel](../../pilots-corner/a32nx-briefing/flight-deck/pedestal/rudder-trim.md)
 
 | Function | API Usage         | Values        | Read/Write | Type             | Remark                                                                         |
 |:---------|:------------------|:--------------|:-----------|:-----------------|:-------------------------------------------------------------------------------|
@@ -895,7 +895,7 @@ Flight Deck: [Rudder Trim Panel](flight-deck/pedestal/rudder-trim.md)
 
 ### Cockpit Door
 
-Flight Deck: [Cockpit Door Panel](flight-deck/pedestal/cockpit-door.md)
+Flight Deck: [Cockpit Door Panel](../../pilots-corner/a32nx-briefing/flight-deck/pedestal/cockpit-door.md)
 
 | Function     | API Usage                 | Values   | Read/Write | Type        | Remark |
 |:-------------|:--------------------------|:---------|:-----------|:------------|:-------|
@@ -918,7 +918,7 @@ Flight Deck: [Cockpit Door Panel](flight-deck/pedestal/cockpit-door.md)
 
 ## Tiller
 
-See [Nose Wheel and Tiller Operation](../../fbw-a32nx/feature-guides/nw-tiller.md)
+See [Nose Wheel and Tiller Operation](../feature-guides/nw-tiller.md)
 
 ## Rudder Pedals
 

--- a/docs/fbw-a32nx/a32nx-api/hardware.md
+++ b/docs/fbw-a32nx/a32nx-api/hardware.md
@@ -14,7 +14,7 @@ Find the complete SPAD documentation for these controllers in this single file: 
 
 This profile is maintained by Cdr_Maverick#6475.
 
-To build your own profile you can use our Flight-Deck API Documentation: [Flight-Deck API](../../pilots-corner/a32nx-briefing/a32nx_api.md)
+To build your own profile you can use our Flight-Deck API Documentation: [Flight-Deck API](a32nx-flightdeck-api.md)
 
 ### Logitech Switch Panel
 

--- a/docs/fbw-a32nx/a32nx-api/index.md
+++ b/docs/fbw-a32nx/a32nx-api/index.md
@@ -44,7 +44,7 @@ The mentioned software solutions would then enable the user to map a hardware la
 
 The FlyByWire A32NX also requires specific variables to control its advanced features. The documentation for these variables and events can be found here:
 
-Flight-Deck Documentation: [Flight-Deck API](../../pilots-corner/a32nx-briefing/a32nx_api.md)
+Flight-Deck Documentation: [Flight-Deck API](a32nx-flightdeck-api.md)
 
 Developer Documentation: [A32NX API Documentation](lvars-events.md)
 

--- a/docs/fbw-a32nx/a32nx-api/lvars-events.md
+++ b/docs/fbw-a32nx/a32nx-api/lvars-events.md
@@ -1,6 +1,6 @@
-# FlyByWire A32NX API
+# A32NX Developer API
 
-Flight-Deck API Documentation: [Flight-Deck API](../../pilots-corner/a32nx-briefing/a32nx_api.md)
+Flight-Deck API Documentation: [Flight-Deck API](a32nx-flightdeck-api.md)
 
 In addition to the above documentation all custom variables and custom events are documented by our developers on our project's github: [:fontawesome-brands-github:{: .github } -  **Docs section on Github**](https://github.com/flybywiresim/a32nx/tree/master/docs){target=new}
 

--- a/docs/pilots-corner/a32nx-briefing/.pages
+++ b/docs/pilots-corner/a32nx-briefing/.pages
@@ -2,6 +2,5 @@ title: A320neo Pilot Briefing
 nav:
   - Overview: index.md
   - Flight Deck: flight-deck
-  - a32nx_api.md
   - ecam
   - pfd

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/front/autobrake-gear.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/front/autobrake-gear.md
@@ -8,7 +8,7 @@
 
 ![Autobrake and gear indicators, Brake Fan and A/SKID](../../../assets/a32nx-briefing/front/Autobrake-gear.jpg "Autobrake and gear indicators, Brake Fan and A/SKID")
 
-!!! note "API Documentation: [Autobrake and Gear API](../../a32nx_api.md#autobrake-gear-lever-and-gear-annunciation)"
+!!! note "API Documentation: [Autobrake and Gear API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#autobrake-gear-lever-and-gear-annunciation)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/front/dcdu.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/front/dcdu.md
@@ -8,7 +8,7 @@
 
 ![Datalink Ctl and Display Unit](../../../assets/a32nx-briefing/front/DCDU.png "Datalink Ctl and Display Unit")
 
-!!! note "API Documentation: [DCDU Panel API](../../a32nx_api.md#dcdu)"
+!!! note "API Documentation: [DCDU Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#dcdu)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/front/ilcp.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/front/ilcp.md
@@ -8,7 +8,7 @@
 
 ![Instrument Lighting Control Panel](../../../assets/a32nx-briefing/front/ilcp.jpg "Instrument Lighting Control Panel")
 
-!!! note "API Documentation: [ILCP Panel API](../../a32nx_api.md#instrument-lighting-control-panel)"
+!!! note "API Documentation: [ILCP Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#instrument-lighting-control-panel)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/front/isis.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/front/isis.md
@@ -8,7 +8,7 @@
 
 ![Integrated Standby Instrument System](../../../assets/a32nx-briefing/front/ISIS.jpg "Integrated Standby Instrument System")
 
-!!! note "API Documentation: [ISIS Panel](../../a32nx_api.md#isis)"
+!!! note "API Documentation: [ISIS Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#isis)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/front/nd.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/front/nd.md
@@ -8,7 +8,7 @@
 
 ![Navigation Display](../../../assets/a32nx-briefing/front/nd.jpg "Navigation Display")
 
-!!! note "API Documentation: [ND Panel](../../a32nx_api.md#terr-on-nd)"
+!!! note "API Documentation: [ND Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#terr-on-nd)"
 
 ---
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/efis_control.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/efis_control.md
@@ -8,7 +8,7 @@
 
 ![EFIS Control](../../../assets/a32nx-briefing/glareshield/EFIS-Control.jpg "EFIS Control")
 
-!!! note "API Documentation: [EFIS Control Panel](../../a32nx_api.md#efis-control-panel)"
+!!! note "API Documentation: [EFIS Control Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#efis-control-panel)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/fcu.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/fcu.md
@@ -8,7 +8,7 @@
 
 ![Flight Control Unit (FCU)](../../../assets/a32nx-briefing/glareshield/FCU.jpg "Flight Control Unit (FCU)")
 
-!!! note "API Documentation: [FCU Panel](../../a32nx_api.md#fcu-panel)"
+!!! note "API Documentation: [FCU Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#fcu-panel)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/light-knobs.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/light-knobs.md
@@ -8,7 +8,7 @@
 
 ![Lighting Knob](../../../assets/a32nx-briefing/glareshield/Lighting-Knob.jpg "Lighting Knob")
 
-!!! note "API Documentation: [Lighting Knobs API](../../a32nx_api.md#lighting-knobs)"
+!!! note "API Documentation: [Lighting Knobs API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#lighting-knobs)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/warning.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/warning.md
@@ -8,7 +8,7 @@
 
 ![Outer Glareshield Panel](../../../assets/a32nx-briefing/glareshield/warning-panel.png "Outer Glareshield Panel")
 
-!!! note "API Documentation: [Warning Panel](../../a32nx_api.md#warning-panel)"
+!!! note "API Documentation: [Warning Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#warning-panel)"
 
 ## Usage
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/ac.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/ac.md
@@ -8,7 +8,7 @@
 
 ![Air Conditioning Panel](../../../assets/a32nx-briefing/overhead-panel/AC-Panel.jpg "Air Conditioning Panel"){loading=lazy}
 
-!!! note "API Documentation: [AC Panel API](../../a32nx_api.md#air-condition-panel)"
+!!! note "API Documentation: [AC Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#air-condition-panel)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs.md
@@ -8,7 +8,7 @@
 
 ![ADIRS Panel](../../../assets/a32nx-briefing/overhead-panel/ADIRS.jpg "ADIRS Panel")
 
-!!! note "API Documentation: [ADIRS Panel API](../../a32nx_api.md#adirs-panel)"
+!!! note "API Documentation: [ADIRS Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#adirs-panel)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/anti-ice.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/anti-ice.md
@@ -8,7 +8,7 @@
 
 ![Anti Ice Panel](../../../assets/a32nx-briefing/overhead-panel/Anti-Ice-Panel.jpg "Anti Ice Panel")
 
-!!! note "API Documentation: [Anti Ice Panel API](../../a32nx_api.md#anti-ice-panel)"
+!!! note "API Documentation: [Anti Ice Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#anti-ice-panel)"
 
 ---
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/apu.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/apu.md
@@ -8,7 +8,7 @@
 
 ![APU Panel](../../../assets/a32nx-briefing/overhead-panel/Apu-Panel.jpg "APU Panel")
 
-!!! note "API Documentation: [APU Panel API](../../a32nx_api.md#apu-panel)"
+!!! note "API Documentation: [APU Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#apu-panel)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/calls.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/calls.md
@@ -8,7 +8,7 @@
 
 ![Calls Panel](../../../assets/a32nx-briefing/overhead-panel/Calls-Panel.jpg "Calls Panel")
 
-!!! note "API Documentation: [Calls Panel](../../a32nx_api.md#calls-panel)"
+!!! note "API Documentation: [Calls Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#calls-panel)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/elec.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/elec.md
@@ -8,7 +8,7 @@
 
 ![Overhead Electrical Panel](../../../assets/a32nx-briefing/overhead-panel/ELEC-Panel.jpg "Overhead Electrical Panel"){loading=lazy}
 
-!!! note "API Documentation: [ELEC Panel API](../../a32nx_api.md#elec-panel)"
+!!! note "API Documentation: [ELEC Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#elec-panel)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/ext-lt.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/ext-lt.md
@@ -8,7 +8,7 @@
 
 ![Exterior Lighting](../../../assets/a32nx-briefing/overhead-panel/Exterior-Lighting-Panel.jpg "Exterior Lighting")
 
-!!! note "API Documentation: [EXT LT Panel API](../../a32nx_api.md#external-lights-panel)"
+!!! note "API Documentation: [EXT LT Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#external-lights-panel)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/fire.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/fire.md
@@ -8,7 +8,7 @@
 
 ![Fire Control Panel](../../../assets/a32nx-briefing/overhead-panel/Fire-Control-Panel.jpg "Fire Control Panel")
 
-!!! note "API Documentation: [Fire Panel API](../../a32nx_api.md#fire-panel)"
+!!! note "API Documentation: [Fire Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#fire-panel)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/fuel.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/fuel.md
@@ -8,7 +8,7 @@
 
 ![FUEL Control Panel](../../../assets/a32nx-briefing/overhead-panel/Fuel-Panel.jpg "FUEL Control Panel")
 
-!!! note "API Documentation: [Fire Panel API](../../a32nx_api.md#fuel-panel)"
+!!! note "API Documentation: [Fire Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#fuel-panel)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/int-lt.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/int-lt.md
@@ -9,7 +9,7 @@
 
 ![Internal Lights Panel](../../../assets/a32nx-briefing/overhead-panel/Int-lt-Panel.jpg "Internal Lights Panel")
 
-!!! note "API Documentation: [INT LT Panel API](../../a32nx_api.md#interior-lights-panel)"
+!!! note "API Documentation: [INT LT Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#interior-lights-panel)"
 
 ## Usage
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/oxygen.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/oxygen.md
@@ -8,7 +8,7 @@
 
 ![Oxygen Panel](../../../assets/a32nx-briefing/overhead-panel/Oxygen.jpg "Oxygen Panel")
 
-!!! note "API Documentation: [Oxygen Panel API](../../a32nx_api.md#oxygen-panel)"
+!!! note "API Documentation: [Oxygen Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#oxygen-panel)"
 
 ## Usage
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/signs.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/signs.md
@@ -8,7 +8,7 @@
 
 ![SIGNS Panel](../../../assets/a32nx-briefing/overhead-panel/Signs-Panel.jpg "SIGNS Panel")
 
-!!! note "API Documentation: [Signs Panel API](../../a32nx_api.md#signs-panel)"
+!!! note "API Documentation: [Signs Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#signs-panel)"
 
 ## Usage
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/voice-recorder.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/voice-recorder.md
@@ -8,7 +8,7 @@
 
 ![Voice Recorder Panel](../../../assets/a32nx-briefing/overhead-panel/Recorder.jpg "Voice Recorder Panel")
 
-!!! note "API Documentation: [RCDR Panel API](../../a32nx_api.md#rcdr-panel)"
+!!! note "API Documentation: [RCDR Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#rcdr-panel)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/wipers.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/wipers.md
@@ -9,7 +9,7 @@
 
 ![Wipers Panel - Left](../../../assets/a32nx-briefing/overhead-panel/Wipers-Left.jpg "Wipers Panel - Left")
 
-!!! note "API Documentation: [Wiper Panel](../../a32nx_api.md#wiper-panel)"
+!!! note "API Documentation: [Wiper Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#wiper-panel)"
 
 ## DESCRIPTION
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/atc-tcas.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/atc-tcas.md
@@ -8,7 +8,7 @@
 
 ![ATC-TCAS Panel](../../../assets/a32nx-briefing/pedestal/ATC-TCAS.jpg "ATC-TCAS Panel")
 
-!!! note "API Documentation: [ATC TCAS Panel](../../a32nx_api.md#atc-tcas)"
+!!! note "API Documentation: [ATC TCAS Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#atc-tcas)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/cockpit-door.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/cockpit-door.md
@@ -8,7 +8,7 @@
 
 ![Cockpit Door Panel](../../../assets/a32nx-briefing/pedestal/Cockpit-Door-Panel.jpg "Cockpit Door Panel")
 
-!!! note "API Documentation: [Cockpit Door Panel](../../a32nx_api.md#cockpit-door)"
+!!! note "API Documentation: [Cockpit Door Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#cockpit-door)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/console.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/console.md
@@ -8,7 +8,7 @@
 
 ![Console Sidestick and Tiller](../../../assets/a32nx-briefing/console/lateral-console.png)
 
-!!! note "API Documentation: [Sidestick](../../a32nx_api.md#side-stick)"
+!!! note "API Documentation: [Sidestick](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#side-stick)"
 
 ## Sidesticks
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/ecam-control.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/ecam-control.md
@@ -8,7 +8,7 @@
 
 ![ECAM Control Panel](../../../assets/a32nx-briefing/pedestal/ECAM-Control-Panel.jpg "ECAM Control Panel")
 
-!!! note "API Documentation: [ECAM Control Panel API](../../a32nx_api.md#ecam-control-panel)"
+!!! note "API Documentation: [ECAM Control Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#ecam-control-panel)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/engine.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/engine.md
@@ -8,7 +8,7 @@
 
 ![Engine Panel](../../../assets/a32nx-briefing/pedestal/Engine-Panel.jpg "Engine Panel")
 
-!!! note "API Documentation: [Engine Panel](../../a32nx_api.md#eng-panel)"
+!!! note "API Documentation: [Engine Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#eng-panel)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/lighting-capt.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/lighting-capt.md
@@ -8,7 +8,7 @@
 
 ![Pedestal Lighting Knobs](../../../assets/a32nx-briefing/pedestal/Pedestal-lighting.jpg "Pedestal Lighting Knobs")
 
-!!! note "API Documentation: [Lighting Pedestal Cpt. Side Panel API](../../a32nx_api.md#lighting-pedestal-captain-side-panel)"
+!!! note "API Documentation: [Lighting Pedestal Cpt. Side Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#lighting-pedestal-captain-side-panel)"
 
 ## Usage
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/mcdu.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/mcdu.md
@@ -8,7 +8,7 @@
 
 ![Multipurpose Control and Display Unit](../../../assets/a32nx-briefing/pedestal/mcdu.jpg "Multipurpose Control and Display Unit")
 
-!!! note "API Documentation: [MCDU Panel API](../../a32nx_api.md#mcdu)"
+!!! note "API Documentation: [MCDU Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#mcdu)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/parking-brake.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/parking-brake.md
@@ -8,7 +8,7 @@
 
 ![Parking Brake Panel](../../../assets/a32nx-briefing/pedestal/Parking-Brake-Panel.jpg "Parking Brake Panel")
 
-!!! note "API Documentation: [Parking Brake Panel](../../a32nx_api.md#parking-brake)"
+!!! note "API Documentation: [Parking Brake Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#parking-brake)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/radar.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/radar.md
@@ -8,7 +8,7 @@
 
 ![WX Radar Panel](../../../assets/a32nx-briefing/pedestal/WX-radar-Panel.jpg "WX Radar Panel")
 
-!!! note "API Documentation: [Radar Panel](../../a32nx_api.md#wx-radar)"
+!!! note "API Documentation: [Radar Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#wx-radar)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
@@ -8,7 +8,7 @@
 
 ![Radio Management Panel](../../../assets/a32nx-briefing/pedestal/RMP.jpg "Radio Management Panel")
 
-!!! note "API Documentation: [RMP Panel](../../a32nx_api.md#rmp)"
+!!! note "API Documentation: [RMP Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#rmp)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rudder-trim.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rudder-trim.md
@@ -8,7 +8,7 @@
 
 ![Rudder Trim Panel](../../../assets/a32nx-briefing/pedestal/Rudder-trim-Panel.jpg "Rudder Trim Panel")
 
-!!! note "API Documentation: [Rudder Trim Panel](../../a32nx_api.md#rudder-trim)"
+!!! note "API Documentation: [Rudder Trim Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#rudder-trim)"
 
 ## Usage
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/speedbrake.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/speedbrake.md
@@ -8,7 +8,7 @@
 
 ![Speed Brake Panel](../../../assets/a32nx-briefing/pedestal/Speed-brake-panel.jpg "Speed Brake Panel")
 
-!!! note "API Documentation: [Speed Brake Panel](../../a32nx_api.md#speed-brake)"
+!!! note "API Documentation: [Speed Brake Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#speed-brake)"
 
 ## Usage
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/switching.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/switching.md
@@ -8,7 +8,7 @@
 
 ![Switching Panel](../../../assets/a32nx-briefing/pedestal/Switching-Panel.jpg "Switching Panel")
 
-!!! note "API Documentation: [Switching Panel](../../a32nx_api.md#switching-panel)"
+!!! note "API Documentation: [Switching Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#switching-panel)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/thrust-pitch-trim.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/thrust-pitch-trim.md
@@ -10,7 +10,7 @@
 
 ![A/THR Instinctive Disconnect Push Button](../../../assets/a32nx-briefing/pedestal/thrustlevel-athr-disconnect.jpg)
 
-!!! note "API Documentation: [Thrust Lever Panel](../../a32nx_api.md#isis)"
+!!! note "API Documentation: [Thrust Lever Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#isis)"
 
 ## Description
 

--- a/docs/pilots-corner/a32nx-briefing/index.md
+++ b/docs/pilots-corner/a32nx-briefing/index.md
@@ -22,7 +22,7 @@ but are omitted in this briefing.
 | Quick Links                           |
 | :-----                                |
 | [Flight-Deck](flight-deck/index.md)   |
-| [Flight-Deck A32NX API](a32nx_api.md) |
+| [Flight-Deck A32NX API](../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md) |
 | [ECAM](ecam/index.md)                 |
 | [PFD](pfd/index.md)                   |
 <!--- [ND](nd/index.md)-->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,7 +78,7 @@ plugins:
         # Fix Info
         'fbw-a32nx/feature-guides/fixinfo.md': 'pilots-corner/advanced-guides/flight-planning/fixinfo.md'
         # A32NX API
-        '/pilots-corner/a32nx-briefing/a32nx_api.md': '/fbw-a32nx/a32nx-flightdeck-api/a32nx-api.md'
+        'pilots-corner/a32nx-briefing/a32nx_api.md': 'fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md'
 
         # additional redirects:
         'fbw-a32nx/feature-guides/throttle-calibration.md': 'fbw-a32nx/feature-guides/flypados3/throttle-calibration.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,8 @@ plugins:
         'fbw-a32nx/feature-guides/afloor.md': 'pilots-corner/advanced-guides/protections/afloor.md'
         # Fix Info
         'fbw-a32nx/feature-guides/fixinfo.md': 'pilots-corner/advanced-guides/flight-planning/fixinfo.md'
+        # A32NX API
+        '/pilots-corner/a32nx-briefing/a32nx_api.md': '/fbw-a32nx/a32nx-flightdeck-api/a32nx-api.md'
 
         # additional redirects:
         'fbw-a32nx/feature-guides/throttle-calibration.md': 'fbw-a32nx/feature-guides/flypados3/throttle-calibration.md'


### PR DESCRIPTION
## Summary
Moved Flight Deck API page to A32NX section as it never really belonged in Pilot's Corner. 

### Location


Discord username (if different from GitHub): Cdr_Maverick#6475
