### PR TITLE
build: bump mkdocs-material -> 8.5.2

### DIFF
--- a/docs/dev-corner/development-projects/documentation.md
+++ b/docs/dev-corner/development-projects/documentation.md
@@ -31,8 +31,13 @@ To participate in the FlyByWire Documentation Project you need to have following
     - MkDocs ([MkDocs](https://www.mkdocs.org/){target=new})
     - mkdocs-awesome-pages-plugin
     - mkdocs-git-revision-date-localized-plugin
-    - mkdocs-material
     - mkdocs-redirects
+    - mkdocs-exclude-search
+    - mkdocs-embed-external-markdown
+    - mkdocs-video
+    - mike
+    - pillow
+    - cairosvg
 - Install with this single line command:
 
     ```title="Run In Terminal"
@@ -40,7 +45,7 @@ To participate in the FlyByWire Documentation Project you need to have following
     ```
 !!! info "Pillow + Cairo Dependency"
     As part of the new social card feature released with `mkdocs-material 8.5.0` [Pillow](https://pillow.readthedocs.io/) and [Cairo Graphics](https://www.cairographics.org/) 
-    dependencies were added. If you encounter any issues with these python packages:
+    dependencies were added. We bundle this as part of our `requirements.txt` to ensure the dependeices are installed when attempting to test [social cards locally](#social-cards-feature). If you encounter any issues with these python packages:
 
     - Install [GTK+](https://www.gtk.org/docs/installations/windows/) for Windows.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==8.5.0
+mkdocs-material==8.5.2
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ mkdocs-exclude-search
 mkdocs-embed-external-markdown
 mkdocs-video
 mike
+pillow
+cairosvg


### PR DESCRIPTION
## Summary
Fixes two important regressions:
- Fixed overly large headlines in search results (8.5.0 regression)
- Navigation sections appear as clickable (8.5.0 regression)

Additionally, mkdocs-material removed pillow + cariosvg as native extensions to the platform (prevents the requirement of additional packages for projects that don't use the social cards feature). This PR explicitly adds these into `requirements.txt`.

Documentation on docs project updated. 

### Location
- requirements.txt
- docs/dev-corner/development-projects/documentation.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
