### PR TITLE
docs: Update for Presets lists

### DIFF
--- a/docs/fbw-a32nx/feature-guides/flypados3/presets.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/presets.md
@@ -185,56 +185,130 @@ complete the setup manually or simply click another preset (or the same) to be l
 
 ### Aircraft States Overview
 
-| State              | System                      |
-|--------------------|-----------------------------|
-| Cold & Dark        | All Systems Off             |
-|                    |                             |
-| Turnaround         | BAT 1+2 On                  |
-|                    | EXT PWR On                  |
-|                    | APU Master On               |
-|                    | APU Start On                |
-|                    | AC BUS Avail Check          |
-|                    | Nav & Logo Lt On            |
-|                    | ADIRS 1,2,3 Nav             |
-|                    | GND CTL On                  |
-|                    | Crew Oxy On                 |
-|                    | NO SMOKING Auto             |
-|                    | EMER EXT Lt Arm             |
-|                    | APU Avail Check             |
-|                    | APU Bleed On                |
-|                    |                             |
-| Ready for Pushback | EXT PWR Off                 |
-|                    | FUEL PUMP 1-6 On            |
-|                    | PWS Auto                    |
-|                    | Transponder On              |
-|                    | ATC ALT RPTG On             |
-|                    | TCAS TRAFFIC ABV            |
-|                    | COCKPIT DOOR LCK            |
-|                    | Strobe Auto                 |
-|                    | Beacon On                   |
-|                    | SEAT BELTS On               |
-|                    | ADIRS 1,2,3 Await Alignment |
-|                    |                             |
-| Ready for Taxi     | ENG MODE SEL START          |
-|                    | ENG 2 ON                    |
-|                    | ENG 2 Avail Check           |
-|                    | ENG 1 ON                    |
-|                    | ENG 1 Avail Check           |
-|                    | ENG MODE SEL NORM           |
-|                    | APU Bleed Off               |
-|                    | APU Master Off              |
-|                    | Autobrake Max               |
-|                    | Spoiler Arm                 |
-|                    | Rudder Trim Reset           |
-|                    | Flaps 1                     |
-|                    | NOSE Lt Taxi                |
-|                    | RWY TURN OFF Light L&R On   |
-|                    |                             |
-| Ready for Takeoff  | WX Radar On                 |
-|                    | WX Radar Mode               |
-|                    | TCAS Switch TA/RA           |
-|                    | NOSE Light Takeoff          |
-|                    | Landing Light L&R On        |
+| State          | System                         |                           |
+|----------------|--------------------------------|---------------------------|
+| Cold & Dark    | All Systems Off                |                           |
+|                |                                |                           |
+| TURNAROUND_ON  | BAT1 On                        |                           |
+|                | BAT2 On                        |                           |
+|                | EXT PWR On                     |                           |
+|                | APU Fire Test On               | Only if EXT PWR not avail |
+|                | APU Fire Test Off              | Only if EXT PWR not avail |
+|                | APU Master On                  | Only if EXT PWR not avail |
+|                | APU Start On                   | Only if EXT PWR not avail |
+|                | Waiting on AC BUS Availability |                           |
+|                | Nav & Logo Lt On               |                           |
+|                | ADIRS 1 Nav                    |                           |
+|                | ADIRS 2 Nav                    |                           |
+|                | ADIRS 3 Nav                    |                           |
+|                | GND CTL On                     |                           |
+|                | Crew Oxy On                    |                           |
+|                | NO SMOKING Auto                |                           |
+|                | EMER EXT Lt Arm                |                           |
+|                | Waiting on FWC Initialization  |                           |
+|                | Waiting...                     |                           |
+|                | APU Fire Test On               |                           |
+|                | APU Fire Test Off              |                           |
+|                | APU Master On                  |                           |
+|                | APU Start On                   |                           |
+|                | Waiting on APU Availability    |                           |
+|                | APU Bleed On                   |                           |
+|                |                                |                           |
+| PUSHBACK_ON    | ENG 1 Fire Test On             |                           |
+|                | ENG 1 Fire Test Off            |                           |
+|                | ENG 2 Fire Test On             |                           |
+|                | ENG 2 Fire Test Off            |                           |
+|                | EXT PWR Off                    |                           |
+|                | FUEL PUMP 2 On                 |                           |
+|                | FUEL PUMP 5 On                 |                           |
+|                | FUEL PUMP 1 On                 |                           |
+|                | FUEL PUMP 4 On                 |                           |
+|                | FUEL PUMP 3 On                 |                           |
+|                | FUEL PUMP 6 On                 |                           |
+|                | PWS Auto                       |                           |
+|                | Transponder On                 |                           |
+|                | ATC ALT RPTG On                |                           |
+|                | TCAS TRAFFIC ABV               |                           |
+|                | COCKPIT DOOR LCK               |                           |
+|                | Strobe Auto                    |                           |
+|                | Beacon On                      |                           |
+|                | SEAT BELTS On                  |                           |
+|                | Await ADIRS 1 Alignment        |                           |
+|                | Await ADIRS 2 Alignment        |                           |
+|                | Await ADIRS 3 Alignment        |                           |
+|                |                                |                           |
+| TAXI_ON        | ENG MODE SEL START             |                           |
+|                | ENG 2 ON                       |                           |
+|                | Await ENG 2 AVAIL              |                           |
+|                | ENG 1 ON                       |                           |
+|                | Await ENG 1 AVAIL              |                           |
+|                | ENG MODE SEL NORM              |                           |
+|                | APU Bleed Off                  |                           |
+|                | APU Master Off                 |                           |
+|                | Autobrake Max                  |                           |
+|                | Spoiler Arm                    |                           |
+|                | Rudder Trim Reset              |                           |
+|                | Flaps 1                        |                           |
+|                | NOSE Lt Taxi                   |                           |
+|                | RWY TURN OFF Lt L On           |                           |
+|                | RWY TURN OFF Lt R On           |                           |
+|                |                                |                           |
+| TAKEOFF_ON     | WX Radar On                    |                           |
+|                | WX Radar Mode                  |                           |
+|                | TCAS Switch TA/RA              |                           |
+|                | NOSE Lt Takeoff                |                           |
+|                | LL Lt L On                     |                           |
+|                | LL Lt R On                     |                           |
+|                |                                |                           |
+| TAKEOFF_OFF    | LL Lt L Off                    |                           |
+|                | LL Lt R Off                    |                           |
+|                | NOSE Lt Takeoff                |                           |
+|                | TCAS Switch TA/RA              |                           |
+|                | WX Radar Off                   |                           |
+|                | WX Radar Mode                  |                           |
+|                |                                |                           |
+| TAXI_OFF       | NOSE Lt Taxi                   |                           |
+|                | RWY TURN OFF Lt L Off          |                           |
+|                | RWY TURN OFF Lt R Off          |                           |
+|                | Autobrake Off                  |                           |
+|                | Spoiler Disarm                 |                           |
+|                | Rudder Trim Reset              |                           |
+|                | Flaps 0                        |                           |
+|                | ENG 1 Off                      |                           |
+|                | ENG 2 Off                      |                           |
+|                | ENG 1 N1 <3%                   |                           |
+|                | ENG 2 N1 <3%                   |                           |
+|                |                                |                           |
+| PUSHBACK_OFF   | Strobe Off                     |                           |
+|                | Beacon Off                     |                           |
+|                | SEAT BELTS Off                 |                           |
+|                | PWS Off                        |                           |
+|                | Transponder Off                |                           |
+|                | ATC ALT RPTG Off               |                           |
+|                | TCAS TRAFFIC ABV               |                           |
+|                | COCKPIT DOOR OP                |                           |
+|                | FUEL PUMP 2 Off                |                           |
+|                | FUEL PUMP 5 Off                |                           |
+|                | FUEL PUMP 1 Off                |                           |
+|                | FUEL PUMP 4 Off                |                           |
+|                | FUEL PUMP 3 Off                |                           |
+|                | FUEL PUMP 6 Off                |                           |
+|                |                                |                           |
+| TURNAROUND_OFF | NO SMOKING Off                 |                           |
+|                | EMER EXT Lt Off                |                           |
+|                | Crew Oxy Off                   |                           |
+|                | GND CTL Off                    |                           |
+|                | ADIRS 3 Off                    |                           |
+|                | ADIRS 2 Off                    |                           |
+|                | ADIRS 1 Off                    |                           |
+|                | Nav & Logo Lt Off              |                           |
+|                | APU Bleed Off                  |                           |
+|                | APU Master Off                 |                           |
+|                | EXT PWR Off                    |                           |
+|                | BAT2 Off                       |                           |
+|                | BAT1 Off                       |                           |
+|                | AC BUS Off Check               |                           |
+
 
 ## Quick Help
 


### PR DESCRIPTION
## Summary
Updates the presets state list 
See https://github.com/flybywiresim/a32nx/pull/7497

### Location
https://docs-git-fork-frankkopp-preset-list-flybywire.vercel.app/fbw-a32nx/feature-guides/flypados3/presets/#aircraft-states-overview

Discord username (if different from GitHub): Cdr_Maverick#6475
