### PR TITLE
fix: taxiing typo

### DIFF
--- a/docs/fbw-a32nx/feature-guides/nw-tiller.md
+++ b/docs/fbw-a32nx/feature-guides/nw-tiller.md
@@ -97,7 +97,7 @@ If you use externally configured controls using SPAD.neXt, FSUIPC or Axis and Oh
 
 ### Pedal Disconnect Button
 
-The tiller handwheel has a button to disconnect any input from the rudder pedals to the nose wheel. This button is commonly used when performing rudder checks while taxing so there is no unexpected nosewheel movement.
+The tiller handwheel has a button to disconnect any input from the rudder pedals to the nose wheel. This button is commonly used when performing rudder checks while taxiing so there is no unexpected nosewheel movement.
 
 Again Microsoft Flight Simulator does not support this directly so we again reused an existing option to map a key or button to this.
 

--- a/docs/pilots-corner/beginner-guide/after-landing.md
+++ b/docs/pilots-corner/beginner-guide/after-landing.md
@@ -39,7 +39,7 @@ This guide will cover these phases:
 - ATC has been informed that we vacated the runway.
 
 !!!info "Simulation vs. Real Life"
-    In real life the A320 will have two pilots who can actually do things in parallel. Talking to ATC, taxing the aircraft and do the after landing tasks.
+    In real life the A320 will have two pilots who can actually do things in parallel. Talking to ATC, taxiing the aircraft and do the after landing tasks.
 
     In the simulation we are typically alone so it is absolutely ok to stop once we have fully vacated the runway and do these things one after the other.
 

--- a/docs/pilots-corner/beginner-guide/landing.md
+++ b/docs/pilots-corner/beginner-guide/landing.md
@@ -295,7 +295,7 @@ We can now safely stop the aircraft and do our "After Landing" checklist.
 If ATC did not already contact us on the ground we would contact them now to let them now we have vacated the runway. They will give us taxi instructions so we can continue taxiing to our gate once we have completed the after landing tasks.
 
 !!!info "After landing tasks in simulation"
-    In real life the A320 will have two pilots which can actually do things in parallel. Talking to ATC, taxing the aircraft and do the after landing tasks. In the simulation we are typically alone so it is absolutely ok to stop once we have fully vacated the runway and do these things one after the other. Talking to ATC and getting taxi instruction, do the after landing tasks and checklist, taxiing to gate.
+    In real life the A320 will have two pilots which can actually do things in parallel. Talking to ATC, taxiing the aircraft and do the after landing tasks. In the simulation we are typically alone so it is absolutely ok to stop once we have fully vacated the runway and do these things one after the other. Talking to ATC and getting taxi instruction, do the after landing tasks and checklist, taxiing to gate.
 
 This concludes *Vacate Runway*
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->

Based on a report from Sweaty Cam in Discord.
See https://en.wikipedia.org/wiki/Taxiing

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
- https://docs.flybywiresim.com/pilots-corner/beginner-guide/after-landing/
- https://docs.flybywiresim.com/pilots-corner/beginner-guide/landing/
- https://docs.flybywiresim.com/fbw-a32nx/feature-guides/nw-tiller/#using-keyboard-or-controller-buttons

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
