### PR TITLE
build: bump mkdocs-material -> 8.5.6

### DIFF
--- a/docs/stylesheets/admonitions.css
+++ b/docs/stylesheets/admonitions.css
@@ -83,3 +83,6 @@
     -webkit-mask-size: contain;
     mask-size: contain;
 }
+.md-typeset :is(.note)>:is(.admonition-title,summary):after {
+    color: #00E0FE;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,6 @@ theme:
 plugins:
   search:
     lang: en
-  tags: {}
   exclude-search:
     exclude:
       - pilots-corner/advanced-guides/flight-planning/fplan.md
@@ -50,6 +49,7 @@ plugins:
       - simbridge/coroute.md
       - simbridge/pdf-viewer.md
   awesome-pages: {}
+  tags: {}
   git-revision-date-localized:
     type: date
   external-markdown: {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==8.5.2
+mkdocs-material==8.5.6
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
- Updates mkdocs base to 1.4 (compatibility with future plugin changes/updates)
- Includes upstream changes to modernized admonitions

Local fixes:
- Config for `tags {}` moved below awesome-pages to remove build error/warning
- Add arrow styling to the `??? note` admonition that had old FBW colors.

### Admonition Changes
Sample title only admonition:
![image](https://user-images.githubusercontent.com/1619968/193528962-ee042cf8-8b40-4f59-b2eb-7eea4b5964aa.png)

Sample no title admonition:
![image](https://user-images.githubusercontent.com/1619968/193528843-4a3c0366-7f29-48fa-b436-76ec278c83f6.png)

Standard admonition:
![image](https://user-images.githubusercontent.com/1619968/193529024-3db46fc1-eca3-4e31-a3f6-3926e64a28c7.png)

### Location
- requirements.txt
- docs/stylesheets/admonitions.css
- mkdocs.yml

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
