### PR TITLE
docs: Adding extra clarification on the simbrief import in BG

### DIFF
--- a/docs/fbw-a32nx/feature-guides/simbrief.md
+++ b/docs/fbw-a32nx/feature-guides/simbrief.md
@@ -84,7 +84,7 @@ This will prepare the MCDU to input the flight plan.
 #### Initialize Flight Plan
 
 !!! warning "IMPORTANT"
-    Do not select an arrival airport on the MSFS world menu or flight planner. Doing this "initializes" the `FROM/TO` field when loading into your flight removing the INIT REQ. option from the `INIT A` page.
+    Do not select an arrival airport on the MSFS world menu or flight planner. Doing this "initializes" the `FROM/TO` field when loading into your flight removing the `INIT REQ.` option from the `INIT A` page.
 
 Head over to the `INIT A` page.
 

--- a/docs/pilots-corner/beginner-guide/preflight.md
+++ b/docs/pilots-corner/beginner-guide/preflight.md
@@ -27,6 +27,9 @@ You can choose to use other software/websites to plan your route but when using 
 
 If you wish to expedite the process of inputting your flight plan on the MCDU we have incorporated a simBrief import function on the MCDU. Our EFB can also display your generated OFP within MSFS.
 
+!!! warning "IMPORTANT"
+    If you plan to import the flight plan from Simbrief, do not select an arrival airport on the MSFS world menu or flight planner. Doing this "initializes" the `FROM/TO` field when loading into your flight removing the `INIT REQ.` option from the `INIT A` page.
+
 [SimBrief A32NX Features](../../fbw-a32nx/feature-guides/simbrief.md){.md-button}
 
 ### Manual Flight Planning


### PR DESCRIPTION
## Summary

Users who start using the Beginners guide might already plan or load into the plane from the World Map using a arrival airport before understanding or realizing that they should not do so if they intent to import from Simbrief.

This adds a warning early in the process, in the hopes to avoid this.

### Location
https://docs.flybywiresim.com/pilots-corner/beginner-guide/preflight/#flight-plan-import

Discord username (if different from GitHub): straks#7240
