### PR TITLE
docs(simbridge): coroutes moved to development

### DIFF
--- a/docs/fbw-a32nx/support/exp.md
+++ b/docs/fbw-a32nx/support/exp.md
@@ -49,10 +49,10 @@ powered by the FWS truly won't work when both FWCs are unpowered or have failed.
 The following are features in testing that require the use of SimBridge:
 
 - [Terrain Display](#terrain-display)
-- Remote MCDU (Web MCDU) 
+- Remote MCDU (Web MCDU) - **Now Available on the Development Version**
     - [Setup and Configuration Guide](../../simbridge/remote-displays/configuration.md)
     - [Usage Guide](../../simbridge/remote-displays/remote-mcdu.md)
-- [Company Routes](#company-routes)
+- [Company Routes](#company-routes) - **Now Available on the Development Version**
 
 !!! tip "SimBridge Information"
     - Learn about SimBridge and further status of various features please - [Read Here](../../simbridge/index.md).
@@ -80,6 +80,8 @@ You can read more about the "PEAKS DISPLAY" in this technical guide from Honeywe
 #### Company Routes
 
 This feature allows you to save routes you regularly fly to your PC in the simBrief XML Datafiles format for repeated use.
+
+**Available on the Development Version.**
 
 !!! tip "Configuration and Usage"
     [Company Routes Guide](../../simbridge/coroute.md){.md-button}

--- a/docs/simbridge/coroute.md
+++ b/docs/simbridge/coroute.md
@@ -1,12 +1,6 @@
 # Company Routes
 Stored Company Routes allow you to save routes you regularly fly to your PC. It uses simBrief XML Datafiles format so you can easily use your simBrief planning to create a stored company route.
 
-!!! danger "Experimental-Only"
-    This feature is only available on Experimental. Since this feature is currently in testing, please expect issues and report them in the 
-    appropriate channel on Discord. 
-
-    See the [Experimental Support Guide](../fbw-a32nx/support/exp.md).
-
 !!! warning Notice
     To allow the aircraft to access local files you need to SimBridge running. See [Autostart](autostart.md) documentation on how to start it. 
 

--- a/docs/simbridge/index.md
+++ b/docs/simbridge/index.md
@@ -21,6 +21,9 @@ require fewer extra steps before launching into your flights.
 
 !!! warning "Important Notes"
     Please keep SimBridge updated at all times regardless of the version of aircraft you are currently flying!
+
+    !!! tip ""
+        Reminder: Any feature available in Development will also be available in Experimental.
     
     ---
 
@@ -28,12 +31,12 @@ require fewer extra steps before launching into your flights.
     
     This page will keep you updated with the status and any further documentation for these services.
 
-|                                      Feature                                       |                                         Status                                         |
-|:----------------------------------------------------------------------------------:|:--------------------------------------------------------------------------------------:|
-|                           [Terrain Display](terrain.md)                            |                 In [Experimental](../fbw-a32nx/support/exp.md) Version                 |
-|               [MCDU Remote Display](remote-displays/remote-mcdu.md)                | In [Development](../fbw-a32nx/fbw-versions.md#development-version-recommended) Version |
-|                        [Company Routes Support](coroute.md)                        |                 In [Experimental](../fbw-a32nx/support/exp.md) Version                 |
-| [flyPad Local Charts](../fbw-a32nx/feature-guides/flypados3/charts.md#local-files) | In [Development](../fbw-a32nx/fbw-versions.md#development-version-recommended) Version |
-|                                  Remote Displays                                   |                                    Work in Progress                                    |
+|                                      Feature                                       |                                         Status                                          |
+|:----------------------------------------------------------------------------------:|:---------------------------------------------------------------------------------------:|
+|                           [Terrain Display](terrain.md)                            |                 In [Experimental](../fbw-a32nx/support/exp.md) Version                  |
+|               [MCDU Remote Display](remote-displays/remote-mcdu.md)                | In [Development](../fbw-a32nx/fbw-versions.md#development-version-recommended) Version  |
+|                        [Company Routes Support](coroute.md)                        | In [Development](../fbw-a32nx/fbw-versions.md#development-version-recommended) Version  |
+| [flyPad Local Charts](../fbw-a32nx/feature-guides/flypados3/charts.md#local-files) | In [Development](../fbw-a32nx/fbw-versions.md#development-version-recommended) Version  |
+|                                  Remote Displays                                   |                                    Work in Progress                                     |
 
 

--- a/docs/simbridge/index.md
+++ b/docs/simbridge/index.md
@@ -23,7 +23,7 @@ require fewer extra steps before launching into your flights.
     Please keep SimBridge updated at all times regardless of the version of aircraft you are currently flying!
 
     !!! tip ""
-        Reminder: Any feature available in Development will also be available in Experimental.
+        Reminder: Any feature available in the Development version will also be available in the Experimental version.
     
     ---
 


### PR DESCRIPTION
## Summary
Supports the release of SimBridge's Co-Routes feature in development updating relevant documentation and internal links.

EXP page updated.

Minor TODO: Ask Lucky if anything needs to be updated on the page for Co-Routes

### Location
- docs/simbridge/index.md
- docs/fbw-a32nx/support/exp.md
- docs/simbridge/coroute.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
