### PR TITLE
docs: updated documentation with more details and clean up for flight plan sync

### DIFF
--- a/docs/fbw-a32nx/feature-guides/cFMS.md
+++ b/docs/fbw-a32nx/feature-guides/cFMS.md
@@ -133,7 +133,7 @@ altitude after takeoff.
 
 ### Load the same flight plan in the World Planner and the MCDU
 
-You can also use the same flight plan in both the MSFS World Planner and the MCDU to have the ATC be aware of your flight plan. This can be done in two different ways:
+You can also use the same flight plan in both the MSFS World Planner and the MCDU to have MSFS ATC be aware of your flight plan. This can be done in two different ways:
 
 Both options are described in more detail below.
 

--- a/docs/fbw-a32nx/feature-guides/cFMS.md
+++ b/docs/fbw-a32nx/feature-guides/cFMS.md
@@ -135,20 +135,6 @@ altitude after takeoff.
 
 You can also use the same flight plan in both the MSFS World Planner and the MCDU to have the ATC be aware of your flight plan. This can be done in two different ways:
 
-- [Custom Flight Management System](#custom-flight-management-system)
-  - [Features](#features)
-    - [Latest - Version 1.5](#latest---version-15)
-    - [Older Versions](#older-versions)
-  - [Guides and Information](#guides-and-information)
-  - [Known Issues](#known-issues)
-  - [Special Notes](#special-notes)
-    - [Sync the MCDU flight plan to MSFS ATC](#sync-the-mcdu-flight-plan-to-msfs-atc)
-    - [Load the same flight plan in the World Planner and the MCDU](#load-the-same-flight-plan-in-the-world-planner-and-the-mcdu)
-      - [Importing a 3rd party flight plan](#importing-a-3rd-party-flight-plan)
-      - [Using the World Planner to generate a flight plan](#using-the-world-planner-to-generate-a-flight-plan)
-    - [WX/TER](#wxter)
-    - [Flight Path Rendering](#flight-path-rendering)
-
 Both options are described in more detail below.
 
 **We recommend** the flyPad flight plan sync feature is set to `None` before attempting this. This would allow MSFS to follow your flight plan independently of our custom FMS.

--- a/docs/fbw-a32nx/feature-guides/cFMS.md
+++ b/docs/fbw-a32nx/feature-guides/cFMS.md
@@ -14,27 +14,27 @@ For guides on utilizing features included with our custom FMS see the [Guides an
 
 ## Features
 
-We will always list the latest updates in the following section. As we improve our custom flight management system older versions will be listed in a collapsible format in the [Older Versions](#older-versions) section. 
+We will always list the latest updates in the following section. As we improve our custom flight management system older versions will be listed in a collapsible format in the [Older Versions](#older-versions) section.
 
 ### Latest - Version 1.5
 
 We have introduced new features to the custom flight management system as part of a minor update. Please see the list below:
 
 - LNAV Updates
-    - Holding Patterns
-    - Turn direction constraints on non-TF legs
-    - Overfly restriction support
-    - ARINC424 Leg Types
-        - AF, CA, CI, CR, CF, DF, HF, HM, HA legs ([See List of Leg Types](../../pilots-corner/advanced-guides/flight-planning/leg-types.md))
-    - Turn Prediction Types
-        - Path capture
-        - Course capture
-        - Direct to fix turn
-        - Holding pattern entry turn
+  - Holding Patterns
+  - Turn direction constraints on non-TF legs
+  - Overfly restriction support
+  - ARINC424 Leg Types
+    - AF, CA, CI, CR, CF, DF, HF, HM, HA legs ([See List of Leg Types](../../pilots-corner/advanced-guides/flight-planning/leg-types.md))
+  - Turn Prediction Types
+    - Path capture
+    - Course capture
+    - Direct to fix turn
+    - Holding pattern entry turn
 - Navigation Display
-    - Removed flight plan loading from localStorage
-    - Corrected active waypoint ETA display
-    - Added `EfisVectors` systems with optimized transmit task queue + support for future display of OFFSET, SECONDARY, SECONDARY DASHED, MISSED APPROACH, ALTERNATE and EOSID flight paths.
+  - Removed flight plan loading from localStorage
+  - Corrected active waypoint ETA display
+  - Added `EfisVectors` systems with optimized transmit task queue + support for future display of OFFSET, SECONDARY, SECONDARY DASHED, MISSED APPROACH, ALTERNATE and EOSID flight paths.
 
 ### Older Versions
 
@@ -83,21 +83,21 @@ We have introduced new features to the custom flight management system as part o
 ## Special Notes
 
 Our custom FMS provides better accuracy and features over the default offering in MSFS which results in issues syncing the flight plan from the MCDU back into the simulator.
-Flight plans with complex routing may have significant issues if synced backwards or loaded externally through MSFS's simplified flight planning. 
+Flight plans with complex routing may have significant issues if synced backwards or loaded externally through MSFS's simplified flight planning.
 
 This will always be problematic unless Asobo improves the built-in flight planner. Other aircraft with complex flight planning capabilities also have this limitation.
 
 The options below allow you to use to utilize the built-in MSFS ATC and VFR Map:
 
-- [Sync MCDU to MSFS Flight Planning (World Map)](#sync-mcdu-to-msfs) -> After pressing "Fly"
-- [Load 3rd party files in the MSFS Flight Planner](#load-world-map-flight-plans) -> Before pressing "Fly"
+- [Sync the MCDU flight plan to MSFS ATC](#sync-the-mcdu-flight-plan-to-msfs-atc) -> After pressing "Fly"
+- [Load the same flight plan in the World Planner and the MCDU](#load-the-same-flight-plan-in-the-world-planner-and-the-mcdu) -> Before pressing "Fly"
 
 When using either method will allow for the following:
 
 - **IFR clearance access through the MSFS ATC**
-    - Although these methods allow you to use MSFS ATC with our custom FMS throughout the flight it does not fix the MSFS ATC system.
-        - Do not expect MSFS ATC to be aware of altitude constraints in SIDs and STARs.
-        - Do not expect MSFS ATC to provide descent clearance at the proper time.
+  - Although these methods allow you to use MSFS ATC with our custom FMS throughout the flight it does not fix the MSFS ATC system.
+    - Do not expect MSFS ATC to be aware of altitude constraints in SIDs and STARs.
+    - Do not expect MSFS ATC to provide descent clearance at the proper time.
 - **Usage of the VFR map**
 
 ??? warning "Issues with VFR Map"
@@ -107,52 +107,6 @@ When using either method will allow for the following:
 
     **The VFR Map will attempt to you show you what the simulator's built-in flight planner produces**, which is not an accurate representation of the LNAV in our cFMS. In the future we may replicate a secondary route visualization (apart from the PLAN mode on the ND) feature in the EFB.
 
-### Sync MCDU to MSFS
-
-If you choose to use our built-in simBrief import on the MCDU to bypass the world menu planner (as we recommend), we have provided a feature that helps sync the aircraft's 
-flight plan back to the MSFS' built-in flight planner. This feature can be configured on the EFB and is set to `None` by default.
-
-Using this method MSFS ATC will most likely not detect your planned cruising flight level. You would need to request further climb once established on your initial cleared 
-altitude after takeoff.
-
-!!! info "How to Turn on Flight Plan Sync"
-    Before performing an INIT REQ. or inputting your flight plan please follow the steps below if you would like to try and use the built-in ATC for your flight.
-
-    - Go to the EFB Settings and select Sim Options. [Location Here](flypados3/settings.md#sim-options).
-    - Switch the `Sync MSFS Flight Plan` setting to `Save`.
-    - Continue entering your flight plan or perform an INIT REQ.
-
----
-
-### Load World Map Flight Plans
-
-You can attempt to load any saved `.pln` file from 3rd party flight planners (i.e. simBrief) into the world map flight planner. This would populate the world menu with the following:
-
-- FROM/TO
-- Routing
-- SID + STAR
-
-#### Steps
-
-!!! danger "Follow each step carefully!"
-
-**We recommend** the flyPad flight plan sync feature is set to `None` before attempting this. This would allow MSFS to follow your flight plan independently of our custom FMS. 
-While the order you switch the sync feature to `None` may vary it is still important that the sync feature is set appropriately and done before you load any flight plan into 
-the MCDU.
-
-??? info "Finding Flight Plan Sync Setting"
-    - Go to the EFB Settings and select Sim Options. [Location Here](flypados3/settings.md#sim-options).
-    - Switch the `Sync MSFS Flight Plan` setting to `None`.
-
-1. Create a flight plan from simBrief or another 3rd party flight planner.
-     1. When using simBrief please ensure you generate an OFP for the same flight plan you will use for your flight. 
-2. Download and save the fight plan for FS2020 in the `.pln` format to your PC.
-3. Load the `.pln` file in the MSFS world map.
-4. **Make sure** to select a starting gate and destination approach from the world map's drop down menus.
-5. Load your flight.
-6. Use our [built-in simBrief integration](simbrief.md) to populate the MCDU with your flight plan.
-   1. Reminder: This is done by using the `INIT REQ.` line on `INIT A` to pull down from simBrief to have an accurate flight plan with our custom FMS while having MSFS ATC support. 
-   
 !!! warning "Be Aware of the Following"
     - In most cases our custom FMS may require you to select your SID or STAR manually. (This is similar to our simBrief import on the MCDU). We highly recommend you plan your entire route including arrival procedure and runway otherwise the default ATC may not perform adequately.
     - If your `.pln` file contains VORs they may get shuffled around and lead to inaccurate flight plans following by MSFS ATC and inaccuracies on the VFR map.
@@ -160,25 +114,105 @@ the MCDU.
         - Do not expect MSFS ATC to be aware of altitude constraints in SIDs and STARs.
         - Do not expect MSFS ATC to provide descent clearance at the proper time.
 
+### Sync the MCDU flight plan to MSFS ATC
+
+If you choose to use our built-in simBrief import on the MCDU to bypass the world menu planner (as we recommend), we have provided a feature that helps sync the aircraft's
+flight plan back to the MSFS' built-in flight planner. This feature can be configured on the EFB and is set to `None` by default.
+
+Using this method MSFS ATC will most likely not detect your planned cruising flight level. You would need to request further climb once established on your initial cleared
+altitude after takeoff.
+
+!!! info "How to Turn on Flight Plan Sync"
+    Before performing an `INIT REQ.` in the MCDU `INIT A` page, or before manually inputting your flight plan, please follow the steps below if you would like to try and use the built-in ATC for your flight.
+
+    - Go to the EFB Settings and select Sim Options. [Location Here](flypados3/settings.md#sim-options).
+    - Switch the `Sync MSFS Flight Plan` setting to `Save`.
+    - Continue entering your flight plan or perform an `INIT REQ.`.
+
+---
+
+### Load the same flight plan in the World Planner and the MCDU
+
+You can also use the same flight plan in both the MSFS World Planner and the MCDU to have the ATC be aware of your flight plan. This can be done in two different ways:
+
+- [Custom Flight Management System](#custom-flight-management-system)
+  - [Features](#features)
+    - [Latest - Version 1.5](#latest---version-15)
+    - [Older Versions](#older-versions)
+  - [Guides and Information](#guides-and-information)
+  - [Known Issues](#known-issues)
+  - [Special Notes](#special-notes)
+    - [Sync the MCDU flight plan to MSFS ATC](#sync-the-mcdu-flight-plan-to-msfs-atc)
+    - [Load the same flight plan in the World Planner and the MCDU](#load-the-same-flight-plan-in-the-world-planner-and-the-mcdu)
+      - [Importing a 3rd party flight plan](#importing-a-3rd-party-flight-plan)
+      - [Using the World Planner to generate a flight plan](#using-the-world-planner-to-generate-a-flight-plan)
+    - [WX/TER](#wxter)
+    - [Flight Path Rendering](#flight-path-rendering)
+
+Both options are described in more detail below.
+
+**We recommend** the flyPad flight plan sync feature is set to `None` before attempting this. This would allow MSFS to follow your flight plan independently of our custom FMS.
+While the order you switch the sync feature to `None` may vary it is still important that the sync feature is set appropriately and done before you load any flight plan into
+the MCDU.
+
+??? info "Finding Flight Plan Sync Setting"
+    - Go to the EFB Settings and select Sim Options. [Location Here](flypados3/settings.md#sim-options).
+    - Switch the `Sync MSFS Flight Plan` setting to `None`.
+
+#### Importing a 3rd party flight plan
+
+You can attempt to load any saved `.pln` file from 3rd party flight planners (i.e. simBrief) into the world map flight planner. This would populate the world menu with the following:
+
+- FROM/TO
+- Routing
+- SID + STAR
+
+Follow these steps:
+
+1. Create a flight plan from simBrief or another 3rd party flight planner.
+    1. When using simBrief please ensure you generate an OFP for the same flight plan you will use for your flight.
+2. Download and save the fight plan for FS2020 in the `.pln` format to your PC.
+3. Load the `.pln` file in the MSFS world map.
+4. **Make sure** to select a starting gate and destination approach from the world map's drop down menus.
+5. Load your flight.
+6. Use our [built-in simBrief integration](simbrief.md) to populate the MCDU with your flight plan.
+   1. Reminder: This is done by using the `INIT REQ.` line on the `INIT A` MCDU page which will download the generated OFP from simBrief to provide an accurate flight plan with our custom FMS while having MSFS ATC support.
+
+#### Using the World Planner to generate a flight plan
+
+You can also use the World Planner to generate a flight plan and then enter that same flight plan manually in the `F-PLN` page in the MCDU.
+
+!!! warning "The flight plan will not be automatically loaded into the MCDU"
+    When using this method, the flight plan generated by the World Planner will **not** be loaded automatically into the MCDU. You will have to enter it manually!
+
+Follow these steps:
+
+1. In the World Planner, select a departure airport, a departure gate or runway and a destination airport.
+2. Select "IFR" (low or high altitude planning) from the planning dropdown.
+3. Select a Departure (SID), an Arrival (STAR) and an Approach.
+4. Take note of the route the World Planner generates for you. You need each individual waypoint noted down.
+5. Load your flight.
+6. In the `INIT A` page of the MCDU, enter the FROM/TO airports. An example is shown in our [Beginners Guide section on the `INIT A` page](../../pilots-corner/beginner-guide/preparing-mcdu.md#init-a).
+7. In the `F-PLN` page of the MCDU, enter your flight plan as it was generated by the World Planner, starting with the SID, the regular waypoints and finally the STAR. An example is shown in our [Beginners Guide section on the `Flight Plan`](../../pilots-corner/beginner-guide/preparing-mcdu.md#flight-plan).
+
 ### WX/TER
 
 !!! info "Important Notice"
-    - TCAS is now available in the Development version. 
+    - TCAS is now available in the Development version.
     - Terrain Radar is being tested in the Experimental version via [SimBridge](../../index.md).
     - Please see our [CFMS NOTAM](https://flybywiresim.com/notams/cfms/) for further WX/TER information.
 
-It is important to note that the weather radar is not available yet with the latest version of our cFMS(v1.5). Our current focus is to deliver a more realistic flight planning 
+It is important to note that the weather radar is not available yet with the latest version of our cFMS(v1.5). Our current focus is to deliver a more realistic flight planning
 and navigation experience while maintaining performance and reliability. However, we are not satisfied with how the default code performs together with our custom systems.
 
-We believe the benefits that cFMS provides outweigh the temporary lack of WX functionality. Weather will still prove to be a challenge due to 
+We believe the benefits that cFMS provides outweigh the temporary lack of WX functionality. Weather will still prove to be a challenge due to
 the lack of a native SDK API. We have posted about it on the MSFS forums, where it currently sits at the top of the wishlist and Asobo are investigating how to best improve their API.
 
-[Read more about weather and terrain API.](https://forums.flightsimulator.
-com/t/implement-weather-and-terrain-api-s-for-aircraft-developers-to-implement-accurate-radar-predictive-windshear-egpws-and-metar-wind-uplink/442016){target=new} **Please 
-note again that terrain radar is being tested in our Experimental version.**
+[Read more about weather and terrain API.](https://forums.flightsimulator.com/t/implement-weather-and-terrain-api-s-for-aircraft-developers-to-implement-accurate-radar-predictive-windshear-egpws-and-metar-wind-uplink/442016){target=new}
+**Please note again that terrain radar is being tested in our Experimental version.**
 
 ### Flight Path Rendering
 
-In certain instances some legs may not render correctly with our current implementation and may look strange in PLAN mode or while enroute. In most cases the A32NX will attempt to fly the route and you won't experience any major issues.
+In certain instances some legs may not render correctly with our current implementation and may look strange in PLAN mode or while en-route. In most cases the A32NX will attempt to fly the route and you won't experience any major issues.
 
 Additionally, some flight plans may have extraneous waypoints that can lead to wrongly drawn flight paths. While this can be an edge case, going through your flight plan in `PLAN` mode you can find offending waypoints that need to be removed which will provide a much more reasonable drawn flight path.


### PR DESCRIPTION
## Summary

Updates and cleans up some documentation on the cFMS to include more details on the working methods to use the MSFS ATC. 

### Location
https://docs.flybywiresim.com/fbw-a32nx/feature-guides/cFMS/

Discord username (if different from GitHub):
straks#7240