### PR TITLE
refactor(config): update youtube social media link to new format

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -138,7 +138,7 @@ extra:
       link: https://www.twitch.tv/flybywiresimulations
       name: FlyByWire Simulations on Twitch
     - icon: fontawesome/brands/youtube
-      link: https://youtube.com/flybywiresimulations
+      link: https://www.youtube.com/@FlyByWireSim
       name: FlyByWire Simulations on Youtube
 
 # Additional Markdown Extensions to use bundled icon sets


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
Youtube is changing the way to reach accounts/channels. This means the URL for the Youtube account has changed to: [youtube.com/@FlyByWireSim](https://www.youtube.com/@FlyByWireSim) (the old one still works as well).

Thanks @pdellaert :P Copied your bot PR description. 

### Location
- mkdocs.yml

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
