### PR TITLE
build: bump mkdocs-material -> 8.5.10

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Manrope:wght@300;400;500;600&display=swap');
 
 /*Primary Thematic Colors*/
-:root {
+:root > * {
   --md-primary-fg-color:        #00E0FE;
   --md-primary-fg-color--dark:  hsl(216,32%,17%);
   --md-primary-fg-color--light: #00E0FE;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==8.5.6
+mkdocs-material==8.5.10
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary
Latest fixes from upstream. No major breakages were observed in local testing. Most notable patch:

- Deprecated additional admonition qualifiers to reduce size of CSS

### Location
- requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
