### PR TITLE
docs(nd): add internal link to vertical guidance symbols + correct navigation title

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/flight-deck/front/nd.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/front/nd.md
@@ -31,6 +31,7 @@ The weather radar image can be displayed in all modes except PLAN.
 !!! info "Future Update"
     A more in depth description of the Navigation Display is currently being developed and will be available in the near future.
 
+    Documentation on the various [vertical guidance symobology](../../../advanced-guides/flight-guidance/vertical-guidance/nd-symbols.md) is now available.
 
 ## Usage
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/front/nd.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/front/nd.md
@@ -29,9 +29,9 @@ The weather radar image can be displayed in all modes except PLAN.
 
 <!-- TODO: UPDATE -->
 !!! info "Future Update"
-    A more in depth description of the Navigation Display is currently being developed and will be available in the near future.
+    A more in depth description of the Navigation Display is currently being developed and will be available in the near future. Listed below will be interim updates until we have fully completed the documentation.
 
-    Documentation on the various [vertical guidance symobology](../../../advanced-guides/flight-guidance/vertical-guidance/nd-symbols.md) is now available.
+    - Various [vertical guidance symbology](../../../advanced-guides/flight-guidance/vertical-guidance/nd-symbols.md) as seen on the ND is now available.
 
 ## Usage
 

--- a/docs/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/.pages
+++ b/docs/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/.pages
@@ -9,7 +9,7 @@ nav:
     - Selected Vertical Modes: selected-modes.md
     - Managed Vertical Modes: managed-modes.md
     - Speed/Mach Control: speed-control.md
-    - Navigation Display Symbols: nd-symbols.md
+    - Vertical Guidance Symbols: nd-symbols.md
     - Primary Flight Display Indications: pfd-indications.md
     - Example Managed Flight: example.md
     - ...


### PR DESCRIPTION
## Summary
As requested a server member -- added extra copy to the briefing page on nd.md to link towards vertical guidance symbology page.

The vertical guidance symbology page navigation was also updated in the `.pages` file to ensure the correct social card image is generated. See Images:

**Previous**
![image](https://user-images.githubusercontent.com/1619968/202852722-a08ff6fb-93fb-426c-968a-a39e9be4bb54.png)

**Now**
![image](https://user-images.githubusercontent.com/1619968/202852713-6a9198e7-80bb-4b84-a189-9a2a56aefd35.png)


### Location
- docs/pilots-corner/a32nx-briefing/flight-deck/front/nd.md
- docs/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/nd-symbols.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
 Valastiri#8902
