### PR TITLE
refactor(installation): download links point to github

### DIFF
--- a/docs/fbw-a32nx/installation.md
+++ b/docs/fbw-a32nx/installation.md
@@ -61,7 +61,7 @@ You can send us logs to our [Discord](https://discord.gg/flybywire){target=new} 
 
           Stable is our variant that has the least bugs and best performance. This version will not always be up to date but we gurantee its compatibility with each major patch from MSFS. 
 
-          [Download Stable](https://cdn.flybywiresim.com/addons/a32nx/stable/full.zip){ .md-button target=new}
+          [Download Stable](https://github.com/flybywiresim/a32nx/releases/download/assets/stable/A32NX-stable.zip){.md-button target=new}
 
           You can see the changelog on the releases page: [View Here](https://github.com/flybywiresim/a32nx/releases){target=new}
 
@@ -72,7 +72,7 @@ You can send us logs to our [Discord](https://discord.gg/flybywire){target=new} 
 
         It updates whenever something is added to the 'master' branch on GitHub. 
 
-         [Download Development](https://cdn.flybywiresim.com/addons/a32nx/master/full.zip){ .md-button target=new}
+         [Download Development](https://github.com/flybywiresim/a32nx/releases/download/assets/master/A32NX-master.zip){.md-button target=new}
          
          [**IMPORTANT:** View information on Autopilot / Fly-By-Wire here](feature-guides/autopilot-fbw.md)
 
@@ -80,13 +80,12 @@ You can send us logs to our [Discord](https://discord.gg/flybywire){target=new} 
 
         This version is similar to the development version, but contains custom systems early in the development phase - expect issues.
 
-        Currently the new upcoming update to the FlyByWire Custom Flight Management System (cFMS) is available in the Experimental version.
-
-        Please read [Experimental Version Support Page](support/exp.md) before using this version.
+        To see what features are being tested in our experimental version, please read [Experimental Version Support 
+        Page](support/exp.md) before using this version.
     
         It will be updated with the latest changes to the development version every week or so while new major features are tested (not guaranteed).
 
-        [Download Experimental](https://cdn.flybywiresim.com/addons/a32nx/experimental/full.zip){ .md-button target=new}
+        [Download Experimental](https://github.com/flybywiresim/a32nx/releases/download/assets/experimental/A32NX-experimental.zip){.md-button target=new}
 
         !!! danger "No Support for Experimental - use at own risk"
             Please do not seek support for the Experimental Version on Discord and only report issues if you have read this page and the reported and known issues.


### PR DESCRIPTION
## Summary
Standardizes version download links to the A32NX github releases. 

Also contains minor copy changes to the experimental blurb description.

### Location
- docs/fbw-a32nx/installation.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
