### PR TITLE
docs: Refactored documentation for flight planning with the A32NX

### DIFF
--- a/docs/fbw-a32nx/feature-guides/cFMS.md
+++ b/docs/fbw-a32nx/feature-guides/cFMS.md
@@ -80,108 +80,11 @@ We have introduced new features to the custom flight management system as part o
 - Fuel calculations might be incorrect.
 - Route on VFR map will not match up with what is shown on the ND.
 
-## Special Notes
+## MSFS Flight Planning
 
-Our custom FMS provides better accuracy and features over the default offering in MSFS which results in issues syncing the flight plan from the MCDU back into the simulator.
-Flight plans with complex routing may have significant issues if synced backwards or loaded externally through MSFS's simplified flight planning.
+Please see our [Flight Planning in MSFS Guide](flight-planning.md) for more information.
 
-This will always be problematic unless Asobo improves the built-in flight planner. Other aircraft with complex flight planning capabilities also have this limitation.
-
-The options below allow you to use to utilize the built-in MSFS ATC and VFR Map:
-
-- [Sync the MCDU flight plan to MSFS ATC](#sync-the-mcdu-flight-plan-to-msfs-atc) -> After pressing "Fly"
-- [Load the same flight plan in the World Planner and the MCDU](#load-the-same-flight-plan-in-the-world-planner-and-the-mcdu) -> Before pressing "Fly"
-
-When using either method will allow for the following:
-
-- **IFR clearance access through the MSFS ATC**
-  - Although these methods allow you to use MSFS ATC with our custom FMS throughout the flight it does not fix the MSFS ATC system.
-    - Do not expect MSFS ATC to be aware of altitude constraints in SIDs and STARs.
-    - Do not expect MSFS ATC to provide descent clearance at the proper time.
-- **Usage of the VFR map**
-
-??? warning "Issues with VFR Map"
-    We'd like to stress that the VFR Map is not supported and we don't recommend using it - the A320neo is an IFR aircraft after all.
-
-    When flight plan sync is enabled you will often not see the proper sequence of waypoints or pathing between waypoints. 
-
-    **The VFR Map will attempt to you show you what the simulator's built-in flight planner produces**, which is not an accurate representation of the LNAV in our cFMS. In the future we may replicate a secondary route visualization (apart from the PLAN mode on the ND) feature in the EFB.
-
-!!! warning "Be Aware of the Following"
-    - In most cases our custom FMS may require you to select your SID or STAR manually. (This is similar to our simBrief import on the MCDU). We highly recommend you plan your entire route including arrival procedure and runway otherwise the default ATC may not perform adequately.
-    - If your `.pln` file contains VORs they may get shuffled around and lead to inaccurate flight plans following by MSFS ATC and inaccuracies on the VFR map.
-    - Although these methods allow you to use MSFS ATC with our custom FMS throughout the flight it does not fix the MSFS ATC system.
-        - Do not expect MSFS ATC to be aware of altitude constraints in SIDs and STARs.
-        - Do not expect MSFS ATC to provide descent clearance at the proper time.
-
-### Sync the MCDU flight plan to MSFS ATC
-
-If you choose to use our built-in simBrief import on the MCDU to bypass the world menu planner (as we recommend), we have provided a feature that helps sync the aircraft's
-flight plan back to the MSFS' built-in flight planner. This feature can be configured on the EFB and is set to `None` by default.
-
-Using this method MSFS ATC will most likely not detect your planned cruising flight level. You would need to request further climb once established on your initial cleared
-altitude after takeoff.
-
-!!! info "How to Turn on Flight Plan Sync"
-    Before performing an `INIT REQ.` in the MCDU `INIT A` page, or before manually inputting your flight plan, please follow the steps below if you would like to try and use the built-in ATC for your flight.
-
-    - Go to the EFB Settings and select Sim Options. [Location Here](flypados3/settings.md#sim-options).
-    - Switch the `Sync MSFS Flight Plan` setting to `Save`.
-    - Continue entering your flight plan or perform an `INIT REQ.`.
-
----
-
-### Load the same flight plan in the World Planner and the MCDU
-
-You can also use the same flight plan in both the MSFS World Planner and the MCDU to have MSFS ATC be aware of your flight plan. This can be done in two different ways:
-
-Both options are described in more detail below.
-
-**We recommend** the flyPad flight plan sync feature is set to `None` before attempting this. This would allow MSFS to follow your flight plan independently of our custom FMS.
-While the order you switch the sync feature to `None` may vary it is still important that the sync feature is set appropriately and done before you load any flight plan into
-the MCDU.
-
-??? info "Finding Flight Plan Sync Setting"
-    - Go to the EFB Settings and select Sim Options. [Location Here](flypados3/settings.md#sim-options).
-    - Switch the `Sync MSFS Flight Plan` setting to `None`.
-
-#### Importing a 3rd party flight plan
-
-You can attempt to load any saved `.pln` file from 3rd party flight planners (i.e. simBrief) into the world map flight planner. This would populate the world menu with the following:
-
-- FROM/TO
-- Routing
-- SID + STAR
-
-Follow these steps:
-
-1. Create a flight plan from simBrief or another 3rd party flight planner.
-    1. When using simBrief please ensure you generate an OFP for the same flight plan you will use for your flight.
-2. Download and save the fight plan for FS2020 in the `.pln` format to your PC.
-3. Load the `.pln` file in the MSFS world map.
-4. **Make sure** to select a starting gate and destination approach from the world map's drop down menus.
-5. Load your flight.
-6. Use our [built-in simBrief integration](simbrief.md) to populate the MCDU with your flight plan.
-   1. Reminder: This is done by using the `INIT REQ.` line on the `INIT A` MCDU page which will download the generated OFP from simBrief to provide an accurate flight plan with our custom FMS while having MSFS ATC support.
-
-#### Using the World Planner to generate a flight plan
-
-You can also use the World Planner to generate a flight plan and then enter that same flight plan manually in the `F-PLN` page in the MCDU.
-
-!!! warning "The flight plan will not be automatically loaded into the MCDU"
-    When using this method, the flight plan generated by the World Planner will **not** be loaded automatically into the MCDU. You will have to enter it manually!
-
-Follow these steps:
-
-1. In the World Planner, select a departure airport, a departure gate or runway and a destination airport.
-2. Select "IFR" (low or high altitude planning) from the planning dropdown.
-3. Select a Departure (SID), an Arrival (STAR) and an Approach.
-4. Take note of the route the World Planner generates for you. You need each individual waypoint noted down.
-5. Load your flight.
-6. In the `INIT A` page of the MCDU, enter the FROM/TO airports. An example is shown in our [Beginners Guide section on the `INIT A` page](../../pilots-corner/beginner-guide/preparing-mcdu.md#init-a).
-7. In the `F-PLN` page of the MCDU, enter your flight plan as it was generated by the World Planner, starting with the SID, the regular waypoints and finally the STAR. An example is shown in our [Beginners Guide section on the `Flight Plan`](../../pilots-corner/beginner-guide/preparing-mcdu.md#flight-plan).
-
-### WX/TER
+## WX/TER
 
 !!! info "Important Notice"
     - TCAS is now available in the Development version.
@@ -197,7 +100,7 @@ the lack of a native SDK API. We have posted about it on the MSFS forums, where 
 [Read more about weather and terrain API.](https://forums.flightsimulator.com/t/implement-weather-and-terrain-api-s-for-aircraft-developers-to-implement-accurate-radar-predictive-windshear-egpws-and-metar-wind-uplink/442016){target=new}
 **Please note again that terrain radar is being tested in our Experimental version.**
 
-### Flight Path Rendering
+## Flight Path Rendering
 
 In certain instances some legs may not render correctly with our current implementation and may look strange in PLAN mode or while en-route. In most cases the A32NX will attempt to fly the route and you won't experience any major issues.
 

--- a/docs/fbw-a32nx/feature-guides/flight-planning.md
+++ b/docs/fbw-a32nx/feature-guides/flight-planning.md
@@ -1,0 +1,100 @@
+# Flight Planning
+
+## Overview
+
+Flying an airliner is usually done using IFR (Instrument Flight Rules). This means that you will be flying with an IFR 
+flight plan. The IFR flight plan is usually created before the flight, and is then loaded into the aircraft's flight 
+management system (FMS). 
+
+See [MCDU F-PLN page](../../pilots-corner/a32nx-briefing/mcdu/f-pln.md) for more information on the aircraft's 
+flight planning in the Multipurpose Control and Display Unit (MCDU).
+
+There are various ways to load a flight plan into the aircraft. In real life pilots usually use an external data link 
+to load flight plans made for the flight by their company. Or they use the MCDU to enter a flight plan manually from 
+their flight briefing documents. 
+
+In the A32NX for Microsoft Flight Simulator, we have these options to load a flight plan:
+
+- [Entering a Flight Plan Manually](../../pilots-corner/beginner-guide/preparing-mcdu.md#--f---light-plan)
+- [Loading a Flight Plan from SimBrief](simbrief.md) (recommended)
+- Creating and Loading a Flight Plan from the MSFS World Map
+
+As Microsoft Flight Simulator uses a very simplified flight planning system, we have created our own custom FMS 
+(Flight Management System) which is used in the A32NX. It is much closer to the FMS in the real aircraft und 
+understands and represents real world flight plans much more accurately. 
+
+A custom FMS on the other hand results in issues syncing the flight plan from the aircraft back into the 
+simulator. Therefore, simulator-features as the MSFS ATC or the VFR Map will not always work as expected. Especially 
+flight plans with complex routing may have significant issues if saved backwards or loaded externally through 
+simulator's simplified flight planning.
+
+This is a general issue of all realistic and complex airliners in Microsoft Flight Simulator and unless the simulator's 
+built-in flight planner and ATC is significantly improved this will always cause problems with realistic airliners.
+
+## MSFS World Map Flight Planning, ATC, VFR Map
+
+Depending on how you want to use the A32NX in combination with the MSFS' World Map Planning, ATC and VFR Map, you 
+can choose between different methods to load a flight plan into the A32NX:
+
+- [Not Using MSFS World Map, MSFS ATC or MSFS VFR Map](#not-using-msfs-world-map-msfs-atc-or-msfs-vfr-map) (recommended)
+- [Loading a Flight Plan from the MSFS World Map](#using-the-msfs-world-map-flight-planner-to-create-and-load-a-flight-plan)
+- [Using MSFS World Map and MSFS ATC](#using-the-msfs-world-map-flight-planner-and-msfs-atc)
+- [Using a SimBrief Flight Plan and MSFS ATC](#importing-a-simbrief-flight-plan-and-using-msfs-atc)
+
+See [Setting `Sync MSFS Flight Plan`](flypados3/settings.md#sim-options) for more information.
+
+### Not Using MSFS World Map, MSFS ATC or MSFS VFR Map
+
+We recommend to use our built-in integration with [SimBrief](https://www.simbrief.com){target=_blank} for flight 
+planning. This will allow you to directly import flight plans from SimBrief into the MCDU.
+
+See our [SimBrief Integration Guide](simbrief.md) for more information.
+
+As long as MSFS ATC and VFR Map are not required, the aircraft's flight plan does not have to be synchronized back to 
+the MSFS flight planner (set `flyPad's Setting > Sim Options > Sync MSFS Flight Plan` to `None`).
+
+The MSFS ATC and VFR Map will not be aware of the flight plan at all and cannot be used.
+
+!!! note ""
+    This is the ideal setup for users who want to use the A32NX in combination with Online ATC services (Vatsim, Ivao, 
+    PilotEdge,...), 3rd party ATC add-ons or no ATC at all. 
+
+### Using the MSFS World Map Flight Planner to Create and Load a Flight Plan
+
+If you want to use the MSFS World Map Flight Planner to build and load a flight plan, you need to set the `Sync MSFS 
+Flight Plan` option in the `flyPad's Setting > Sim Options > Sync MSFS Flight Plan` to `Load Only`.
+
+This ensures the MSFS flight plan is loaded into the aircraft's flight plan when starting the flight.
+
+Any changes made to the flight plan in the MCDU will **not** be saved back to the MSFS flight plan. This means the MSFS
+ATC and VFR Map will **not** be aware of these changes.
+
+### Using the MSFS World Map Flight Planner and MSFS ATC
+
+If you are using the MSFS Flight Planner to build and load a flight plan, and you also want to use the MSFS ATC even
+after making changes to the aircraft's flight plan, you need to set the `flyPad's Setting > Sim Options > Sync MSFS 
+Flight Plan` option to `Save`.
+
+With this setting the aircraft will attempt to save any changes to the flight plan made in the MCDU back to the 
+simulator's flight plan. This will **not** always work as expected and may result in issues with the MSFS ATC. See 
+warning below.
+
+!!! warning "Synchronization Issues Expected"
+    The aircraft's custom Flight Management System provides better accuracy and features over the default
+    flight plan manager in Microsoft Flight simulator which results in issues syncing the flight plan from the
+    MCDU back into the simulator. Do not expect it to work properly in all cases.
+
+### Importing a SimBrief Flight Plan and Using MSFS ATC
+
+If you are using the aircraft's built-in SimBrief integration to import a flight plan, and you also want to use the
+MSFS ATC you need to set the `flyPad's Setting > Sim Options > Sync MSFS Flight Plan` option to `Save`.
+
+With this setting the aircraft attempts to save the loaded SimBrief flight plan and any subsequent changes to the
+flight plan made in the MCDU back to the simulator's flight plan. This will **not** always work as expected and may
+result in issues with the MSFS ATC. See warning below.
+
+!!! warning "Synchronization Issues Expected"
+    The aircraft's custom Flight Management System provides better accuracy and features over the default
+    flight plan manager in Microsoft Flight simulator which results in issues syncing the flight plan from the
+    MCDU back into the simulator. Do not expect it to work properly in all cases.
+

--- a/docs/fbw-a32nx/feature-guides/flight-planning.md
+++ b/docs/fbw-a32nx/feature-guides/flight-planning.md
@@ -17,21 +17,21 @@ In the A32NX for Microsoft Flight Simulator, we have these options to load a fli
 
 - [Entering a Flight Plan Manually](../../pilots-corner/beginner-guide/preparing-mcdu.md#--f---light-plan)
 - [Loading a Flight Plan from SimBrief](simbrief.md) (recommended)
-- Creating and Loading a Flight Plan from the MSFS World Map
+- [Creating and Loading a Flight Plan from the MSFS World Map](#msfs-world-map-flight-planning-atc-and-vfr-map)
 
 As Microsoft Flight Simulator uses a very simplified flight planning system, we have created our own custom FMS 
-(Flight Management System) which is used in the A32NX. It is much closer to the FMS in the real aircraft und 
+(Flight Management System) which is used in the A32NX. It is much closer to the FMS in the real aircraft and it
 understands and represents real world flight plans much more accurately. 
 
 A custom FMS on the other hand results in issues syncing the flight plan from the aircraft back into the 
 simulator. Therefore, simulator-features as the MSFS ATC or the VFR Map will not always work as expected. Especially 
 flight plans with complex routing may have significant issues if saved backwards or loaded externally through 
-simulator's simplified flight planning.
+the simulator's simplified flight planning.
 
 This is a general issue of all realistic and complex airliners in Microsoft Flight Simulator and unless the simulator's 
 built-in flight planner and ATC is significantly improved this will always cause problems with realistic airliners.
 
-## MSFS World Map Flight Planning, ATC, VFR Map
+## MSFS World Map Flight Planning, ATC and VFR Map
 
 Depending on how you want to use the A32NX in combination with the MSFS' World Map Planning, ATC and VFR Map, you 
 can choose between different methods to load a flight plan into the A32NX:
@@ -59,6 +59,11 @@ The MSFS ATC and VFR Map will not be aware of the flight plan at all and cannot 
     This is the ideal setup for users who want to use the A32NX in combination with Online ATC services (Vatsim, Ivao, 
     PilotEdge,...), 3rd party ATC add-ons or no ATC at all. 
 
+!!! warning "For SimBrief Import Do Not Set a Destination in the MSFS World Map"
+    If you plan to import a SimBrief flight plan please do **not** set a destination airport in the MSFS World Map 
+    as otherwise the aircraft will import the MSFS World Map flight plan, and it will not offer the "INIT REQUEST" 
+    option.  
+
 ### Using the MSFS World Map Flight Planner to Create and Load a Flight Plan
 
 If you want to use the MSFS World Map Flight Planner to build and load a flight plan, you need to set the `Sync MSFS 
@@ -77,7 +82,7 @@ Flight Plan` option to `Save`.
 
 With this setting the aircraft will attempt to save any changes to the flight plan made in the MCDU back to the 
 simulator's flight plan. This will **not** always work as expected and may result in issues with the MSFS ATC. See 
-warning below.
+the warning below for more information.
 
 !!! warning "Synchronization Issues Expected"
     The aircraft's custom Flight Management System provides better accuracy and features over the default
@@ -89,9 +94,11 @@ warning below.
 If you are using the aircraft's built-in SimBrief integration to import a flight plan, and you also want to use the
 MSFS ATC you need to set the `flyPad's Setting > Sim Options > Sync MSFS Flight Plan` option to `Save`.
 
+When importing a flight plan from SimBrief into the MCDU, do not select a destination airport and do not build a flight plan using the MSFS World Planner.
+
 With this setting the aircraft attempts to save the loaded SimBrief flight plan and any subsequent changes to the
 flight plan made in the MCDU back to the simulator's flight plan. This will **not** always work as expected and may
-result in issues with the MSFS ATC. See warning below.
+result in issues with the MSFS ATC. See the warning below for more information.
 
 !!! warning "Synchronization Issues Expected"
     The aircraft's custom Flight Management System provides better accuracy and features over the default

--- a/docs/fbw-a32nx/feature-guides/flight-planning.md
+++ b/docs/fbw-a32nx/feature-guides/flight-planning.md
@@ -15,9 +15,10 @@ their flight briefing documents.
 
 In the A32NX for Microsoft Flight Simulator, we have these options to load a flight plan:
 
-- [Entering a Flight Plan Manually](../../pilots-corner/beginner-guide/preparing-mcdu.md#--f---light-plan)
-- [Loading a Flight Plan from SimBrief](simbrief.md) (recommended)
-- [Creating and Loading a Flight Plan from the MSFS World Map](#msfs-world-map-flight-planning-atc-and-vfr-map)
+!!! tip ""
+    - [Entering a Flight Plan Manually](../../pilots-corner/beginner-guide/preparing-mcdu.md#--f---light-plan)
+    - [Loading a Flight Plan from SimBrief](simbrief.md) (recommended)
+    - [Creating and Loading a Flight Plan from the MSFS World Map](#msfs-world-map-flight-planning-atc-and-vfr-map)
 
 As Microsoft Flight Simulator uses a very simplified flight planning system, we have created our own custom FMS 
 (Flight Management System) which is used in the A32NX. It is much closer to the FMS in the real aircraft and it
@@ -28,22 +29,28 @@ simulator. Therefore, simulator-features as the MSFS ATC or the VFR Map will not
 flight plans with complex routing may have significant issues if saved backwards or loaded externally through 
 the simulator's simplified flight planning.
 
-This is a general issue of all realistic and complex airliners in Microsoft Flight Simulator and unless the simulator's 
-built-in flight planner and ATC is significantly improved this will always cause problems with realistic airliners.
+This is a general issue for all realistic and complex airliners in Microsoft Flight Simulator and unless the 
+simulator's built-in flight planner and ATC is significantly improved this will always cause problems with realistic 
+airliners.
 
 ## MSFS World Map Flight Planning, ATC and VFR Map
 
 Depending on how you want to use the A32NX in combination with the MSFS' World Map Planning, ATC and VFR Map, you 
 can choose between different methods to load a flight plan into the A32NX:
 
-- [Not Using MSFS World Map, MSFS ATC or MSFS VFR Map](#not-using-msfs-world-map-msfs-atc-or-msfs-vfr-map) (recommended)
-- [Loading a Flight Plan from the MSFS World Map](#using-the-msfs-world-map-flight-planner-to-create-and-load-a-flight-plan)
-- [Using MSFS World Map and MSFS ATC](#using-the-msfs-world-map-flight-planner-and-msfs-atc)
-- [Using a SimBrief Flight Plan and MSFS ATC](#importing-a-simbrief-flight-plan-and-using-msfs-atc)
+!!! tip ""
+    - [Not Using MSFS World Map, MSFS ATC or MSFS VFR Map](#not-using-msfs-world-map-msfs-atc-or-msfs-vfr-map) (recommended)
+    - [Loading a Flight Plan from the MSFS World Map](#using-the-msfs-world-map-flight-planner-to-create-and-load-a-flight-plan)
+    - [Using MSFS World Map and MSFS ATC](#using-the-msfs-world-map-flight-planner-and-msfs-atc)
+    - [Using a SimBrief Flight Plan and MSFS ATC](#importing-a-simbrief-flight-plan-and-using-msfs-atc)
 
 See [Setting `Sync MSFS Flight Plan`](flypados3/settings.md#sim-options) for more information.
 
 ### Not Using MSFS World Map, MSFS ATC or MSFS VFR Map
+
+!!! note ""
+    This is the ideal setup for users who want to use the A32NX in combination with Online ATC services (Vatsim, Ivao, 
+    PilotEdge,...), 3rd party ATC add-ons or no ATC at all. 
 
 We recommend to use our built-in integration with [SimBrief](https://www.simbrief.com){target=_blank} for flight 
 planning. This will allow you to directly import flight plans from SimBrief into the MCDU.
@@ -55,16 +62,17 @@ the MSFS flight planner (set `flyPad's Setting > Sim Options > Sync MSFS Flight 
 
 The MSFS ATC and VFR Map will not be aware of the flight plan at all and cannot be used.
 
-!!! note ""
-    This is the ideal setup for users who want to use the A32NX in combination with Online ATC services (Vatsim, Ivao, 
-    PilotEdge,...), 3rd party ATC add-ons or no ATC at all. 
-
 !!! warning "For SimBrief Import Do Not Set a Destination in the MSFS World Map"
     If you plan to import a SimBrief flight plan please do **not** set a destination airport in the MSFS World Map 
     as otherwise the aircraft will import the MSFS World Map flight plan, and it will not offer the "INIT REQUEST" 
     option.  
 
 ### Using the MSFS World Map Flight Planner to Create and Load a Flight Plan
+
+!!! note ""
+    This is the ideal setup for users who do not use Online ATC nor the MSFS ATC service and want to use the 
+    simplified flight planning of the MSFS World Map. Please do expect some issues especially for procedures (SID, 
+    STAR, APPR). 
 
 If you want to use the MSFS World Map Flight Planner to build and load a flight plan, you need to set the `Sync MSFS 
 Flight Plan` option in the `flyPad's Setting > Sim Options > Sync MSFS Flight Plan` to `Load Only`.
@@ -75,6 +83,11 @@ Any changes made to the flight plan in the MCDU will **not** be saved back to th
 ATC and VFR Map will **not** be aware of these changes.
 
 ### Using the MSFS World Map Flight Planner and MSFS ATC
+
+!!! note ""
+    This is the ideal setup for users who want to use the simplified flight planning of the MSFS World Map and the 
+    MSFS ATC service (in spite of the known issues with MSFS ATC). 
+    Please do expect issues especially for procedures (SID, STAR, APPR) and MSFS ATC instructions. 
 
 If you are using the MSFS Flight Planner to build and load a flight plan, and you also want to use the MSFS ATC even
 after making changes to the aircraft's flight plan, you need to set the `flyPad's Setting > Sim Options > Sync MSFS 
@@ -90,6 +103,11 @@ the warning below for more information.
     MCDU back into the simulator. Do not expect it to work properly in all cases.
 
 ### Importing a SimBrief Flight Plan and Using MSFS ATC
+
+!!! note ""
+    This is the ideal setup for users who want to use the advanced flight planning of SimBrief 
+    but still use the MSFS ATC service (in spite of the known issues with MSFS ATC).
+    Please do expect issues especially for procedures (SID, STAR, APPR) and MSFS ATC instructions.
 
 If you are using the aircraft's built-in SimBrief integration to import a flight plan, and you also want to use the
 MSFS ATC you need to set the `flyPad's Setting > Sim Options > Sync MSFS Flight Plan` option to `Save`.

--- a/docs/fbw-a32nx/feature-guides/flypados3/settings.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/settings.md
@@ -111,7 +111,7 @@ Settings for simulation aspects of the A32NX aircraft.
         - Save: 
             - The simulator's flight plan set in the World Map will be loaded once when starting the flight. Any 
               subsequent changes to the flight plan in the aircraft will be synchronized back to the simulator if 
-              possible. See warning below.
+              possible. See the warning below for more information.
    
         !!! note "There is No synchronization from the sim's flight plan to the aircraft after initial load."
 

--- a/docs/fbw-a32nx/feature-guides/flypados3/settings.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/settings.md
@@ -98,15 +98,27 @@ Settings for simulation aspects of the A32NX aircraft.
 - Default Baro:
     - User can set which baro setting is wanted as a default: inHg, hPA or Auto (depends on the airport where 
       the aircraft spawned).
+     
 - Sync MSFS Flight Plan:
     - User can set if and how the flight plan synchronization between the simulator and the aircraft should work.
     - The options are:
-        - None: No synchronization.
-        - Load Only: Only once when loading the flight.
-        - Save: Synchronization with every change in the aircraft
+        - None: 
+            - The simulator's flight plan will not be loaded and changes to the aircraft's flight plan will not be 
+              saved back to the sim's flight plan. 
+        - Load Only: 
+            - The simulator's flight plan set in the World Map will be loaded once when starting the flight. 
+              Any subsequent changes to the flight plan in the aircraft will not be synchronized back to the simulator.
+        - Save: 
+            - The simulator's flight plan set in the World Map will be loaded once when starting the flight. Any 
+              subsequent changes to the flight plan in the aircraft will be synchronized back to the simulator if 
+              possible. See warning below.
+   
+        !!! note "There is No synchronization from the sim's flight plan to the aircraft after initial load."
 
         !!! warning "Synchronization Issues Expected"
-            The aircraft's custom Flight Management System provides better accuracy and features over the default flight plan manager in Microsoft Flight simulator which results in issues syncing the flight plan from the MCDU back into the simulator. Do not expect it to work properly in all cases.
+            The aircraft's custom Flight Management System provides better accuracy and features over the default 
+            flight plan manager in Microsoft Flight simulator which results in issues syncing the flight plan from the 
+            MCDU back into the simulator. Do not expect it to work properly in all cases.
 
 - Enable SimBridge Connection
     - Auto:


### PR DESCRIPTION
## Summary
Re-writing parts of the cFMS and MSFS Synch documentation to make it clearer to users how to load flight plans into the A32NX and use MSFS World Map, ATC and VFR. 

### Location
Feature Guides 

Discord username (if different from GitHub): Cdr_Maverick#6475
