### PR TITLE
docs: Remove duplicate inop warning on cargo vent ovhd

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/cargo-vent.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/cargo-vent.md
@@ -28,9 +28,6 @@ The switch controls the aft isolation valves and the extraction fan.
 !!! attention ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
-!!! attention ""
-    Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
-
 ---
 
 [Back to Flight Deck](../index.md){ .md-button }


### PR DESCRIPTION
## Summary
- Remove duplicate inop warning on cargo vent overhead panel page

### Location
https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/flight-deck/ovhd/cargo-vent/

Discord username (if different from GitHub): `jakuski#9191`
