### PR TITLE
fix(briefing): Typo in fuel page

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/fuel.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/fuel.md
@@ -8,7 +8,7 @@
 
 ![FUEL Control Panel](../../../assets/a32nx-briefing/overhead-panel/Fuel-Panel.jpg "FUEL Control Panel")
 
-!!! note "API Documentation: [Fire Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#fuel-panel)"
+!!! note "API Documentation: [Fuel Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#fuel-panel)"
 
 ## Description
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
Fixes a small typo from "Fire" to "Fuel" as the 'button' links to fuel page.

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
/pilots-corner/a32nx-briefing/flight-deck/ovhd/fuel

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
Alepouna🌙#9824
