### PR TITLE
fix(briefing): Duplicate INOP label in wipers page

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/wipers.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/wipers.md
@@ -34,9 +34,6 @@ Each windshield is provided with two-speed electric wipers that are controlled b
 !!! attention ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
-    !!! attention ""
-        Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
-
 ---
 
 [Back to Flight Deck](../index.md){ .md-button }


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->
Fixes #697 

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
Removes a duplicate INOP label 

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
/pilots-corner/a32nx-briefing/flight-deck/ovhd/wipers

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
Alepouna🌙#9824