### PR TITLE
docs: Display "Incorrect Label" label below the image as done in other locations

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs.md
@@ -6,11 +6,11 @@
 
 ---
 
-![ADIRS Panel](../../../assets/a32nx-briefing/overhead-panel/ADIRS.jpg "ADIRS Panel")
-
-!!! info "Incorrect Label"
+!!! warning ""
 
     Please note, the ADIR 1, 2 and 3 labels are incorrect. They should state ADIR 1, 2 and 3.
+
+![ADIRS Panel](../../../assets/a32nx-briefing/overhead-panel/ADIRS.jpg "ADIRS Panel")
 
 !!! note "API Documentation: [ADIRS Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#adirs-panel)"
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs.md
@@ -8,7 +8,7 @@
 
 !!! warning ""
 
-    Please note, the ADIR 1, 2 and 3 labels are incorrect. They should state ADIR 1, 2 and 3.
+    Please note: Currently the ADIRS are labeled ADIR 1, 3 and 2 which is incorrect. They should be labeled ADIR 1, 2 and 3. This will be fixed in a future update.
 
 ![ADIRS Panel](../../../assets/a32nx-briefing/overhead-panel/ADIRS.jpg "ADIRS Panel")
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs.md
@@ -8,9 +8,9 @@
 
 ![ADIRS Panel](../../../assets/a32nx-briefing/overhead-panel/ADIRS.jpg "ADIRS Panel")
 
-!!!info "Incorrect Label"
+!!! info "Incorrect Label"
 
-    Please note, the ADIR 1, 2 and 3 labels are incorrect. They should state ADR 1, 2 and 3.
+    Please note, the ADIR 1, 2 and 3 labels are incorrect. They should state ADIR 1, 2 and 3.
 
 !!! note "API Documentation: [ADIRS Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#adirs-panel)"
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs.md
@@ -8,6 +8,10 @@
 
 ![ADIRS Panel](../../../assets/a32nx-briefing/overhead-panel/ADIRS.jpg "ADIRS Panel")
 
+!!!info "Incorrect Label"
+
+    Please note, the ADIR 1, 2 and 3 labels are incorrect. They should state ADR 1, 2 and 3.
+
 !!! note "API Documentation: [ADIRS Panel API](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#adirs-panel)"
 
 ## Description
@@ -41,10 +45,6 @@ Abnormal operation:
 - The heading data must be entered using the MCDU. This must be updated frequently, roughly every 10 minutes.
 
 - If the IR mode selector is set from NAV to ATT, or NAV to OFF during flight, NAV mode will be inoperable for the remainder of the flight.
-
-!!!info "Incorrect Label"
-
-    Please note, the ADIR 1, 2 and 3 labels are incorrect. They should state ADR 1, 2 and 3.
 
 ---
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
This PR moves the "Incorrect Label" label from the bottom of the page, to below the image for consisentcy purposes, as other locations (e.g. [Cargo Smoke panel](https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/flight-deck/ovhd/cargo-smoke/)) have this label exactly below the image.

![image](https://user-images.githubusercontent.com/98479040/208325077-f1d3fb64-aa38-4901-bcdc-661dc77436b0.png)
![image](https://user-images.githubusercontent.com/98479040/208325099-2c0b41d7-db2e-4527-bc07-2d588850c473.png)


- Potential issues: There are two labels back to back now (the API docs) however they are small enough, they should not be a problem 
- Alternative solution: Move the "Incorrect Label" to the bottom of the page in at least 'Cargo Smoke panel' page as mentioned above.

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
/pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
Alepouna🌙#9824