### PR TITLE
fix(briefing): Typo URL in thrust-pitch-trim page

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/thrust-pitch-trim.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/thrust-pitch-trim.md
@@ -10,7 +10,7 @@
 
 ![A/THR Instinctive Disconnect Push Button](../../../assets/a32nx-briefing/pedestal/thrustlevel-athr-disconnect.jpg)
 
-!!! note "API Documentation: [Thrust Lever Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#isis)"
+!!! note "API Documentation: [Thrust Lever Panel](../../../../fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md#thrust-lever-and-trim-wheel)"
 
 ## Description
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
Fixes URL that goes to wrong API section

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
/pilots-corner/a32nx-briefing/flight-deck/pedestal/thrust-pitch-trim

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
Alepouna🌙#9824
