### PR TITLE
docs(simbrief): add admonition to clarify location of integration setting

### DIFF
--- a/docs/fbw-a32nx/feature-guides/flypados3/settings.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/settings.md
@@ -260,7 +260,10 @@ Settings for integrations with various data and information sources.
 
 Before you can use the A32NX simBrief Integration you need to provide your simBrief account details.
 
-- Simbrief Username/Pilot ID:
+!!! tip "Found in Settings -> ATSU/AOC"
+    If you have arrived at this section from the [SimBrief Integration](../simbrief.md) page please make note this setting is found on the EFB.
+
+- SimBrief Username/Pilot ID:
     - Enter your simBrief username or Pilot ID.
 
         ![simBrief Account field](../../assets/flypados3/simbrief-account-field.png "simBrief Account field")
@@ -269,7 +272,7 @@ Before you can use the A32NX simBrief Integration you need to provide your simBr
 
         ![simBrief Account Field Error](../../assets/flypados3/simbrief-account-field-error.png "simBrief Account Field Error")
 
-To get your simBrief username or Pilot ID you can go to your simBrief Account settings and open "Simbrief Data".
+To get your simBrief username or Pilot ID you can go to your simBrief Account settings and open "SimBrief Data".
 
 ![simBrief Account Data](../../assets/flypados3/simbrief-account-data.png "simBrief Account Data")
 


### PR DESCRIPTION
## Summary
When users are internally linked from the simbrief integration page to the flyPadOS settings page to input their username -- there have been people that do not understand they have transitioned pages and/or notice the table of contents.

This makes the information and "jump" to new page a little more reader friendly.

<img width="868" alt="Screenshot 2022-12-20 at 7 21 58 PM" src="https://user-images.githubusercontent.com/1619968/208715823-227c70be-29d2-494f-b551-5e3ce0b010d0.png">


### Location
- docs/fbw-a32nx/feature-guides/flypados3/settings.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
