### PR TITLE
chore: offline docs development support config + documentation

### DIFF
--- a/docs/dev-corner/development-projects/documentation.md
+++ b/docs/dev-corner/development-projects/documentation.md
@@ -90,6 +90,32 @@ feature.
     INFO     -  [12:05:30] Serving on http://127.0.0.1:8000/
     ```
   
+    !!! danger "Building the Project with No Internet Connection"
+        This project utilizes the `external-markdown` plugin which pulls MarkDown files from other repositories during the build for both production and development. This helps reference other 
+        important documentation externally without having to copy and paste it into this project.
+        
+        When working on a feature branch without an internet connection your development server may exit and fail to build resulting in:
+        
+        ```
+        Error! https://[hyperlink here] returned connection error
+        ```
+        
+        ---
+
+        In order to bypass this issue you can comment out the `external-markdown` plugin temporarily in `mkdocs.yml` found in the /root of this project. (Please ensure not to commit this change 
+        when creating a Pull Request.) See the example below:
+
+        ``` { .yaml .annotate title="mkdocs.yml example configured for offline builds" }
+        # Plugins
+        plugins:
+        search:
+          lang: en
+        # Comment out the plugin below if building docs without an internet connection.
+        # external-markdown: {} (1)
+        ```
+
+        1. For production or PR purposes please ensure that the above plugin reads `external-markdown: {}` (without the preceding `#`) before finalizing your PR.
+  
 !!! info "Faster Preview Server"
     You can opt to use a faster instance of the developer server by invoking the flag `--dirtyreload`. This just checks for any markdown that has changed since the HTML was rendered and will reconstruct any relevant pages only rather than rebuilding the entire website.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,8 @@ theme:
 plugins:
   search:
     lang: en
+  # Comment out the plugin below if building docs without an internet connection.
+  external-markdown: {}
   exclude-search:
     exclude:
       - pilots-corner/advanced-guides/flight-planning/fplan.md
@@ -49,7 +51,6 @@ plugins:
   tags: {}
   git-revision-date-localized:
     type: date
-  external-markdown: {}
   mkdocs-video:
     mark: "video-embed"
   redirects:


### PR DESCRIPTION
## Summary
Noted a small issue when building this project without an internet connection available. Builds exit and return with an error when trying to pull external markdown utilizing one of our plugins: `external-markdown` for mkdocs. 

Added a comment in the base config + updated the docs project documentation as well to provide info on how to build without an internet connection.

### Small Note

Utilized annotation in a code block (inline via `{ .annonate }`) just to try it out. Pretty neat feature if we want to do this globally for any important tidbits. The inline version is only for specific code blocks so no extra config / feat attached to this PR. Example below:

<img width="972" alt="image" src="https://user-images.githubusercontent.com/1619968/209213469-575c16d7-14bf-4506-a7b1-7936a7fd3ad7.png">


### Location
- docs/dev-corner/development-projects/documentation.md
- mkdocs.yml

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
