### PR TITLE
docs: fix typo under takeoff/climb/cruise

### DIFF
--- a/docs/pilots-corner/beginner-guide/takeoff-climb-cruise.md
+++ b/docs/pilots-corner/beginner-guide/takeoff-climb-cruise.md
@@ -412,7 +412,7 @@ Here are some **typical activities** which might happen during cruise mostly on 
   Dial heading knob to the desired heading and pull knob for Selected Heading Mode. The aircraft will automatically change course to the new heading. If you want the aircraft to follow the planned route again you can push the knob for Managed Heading Mode.
 
 - **Direct course to a waypoint (DIR TO)** <br/>
-  ATC regularly instructs us to go "direct to (waypoint) XYZ". Use the ECAM DIR page to select the waypoint from the plight plan's list of waypoints. In rare cases it is a waypoint not in the current flight plan then you can enter a new waypoint in the MCDU and put it into the upper left entry field. Select DIRECT* on the rght bottom to execute the change.
+  ATC regularly instructs us to go "direct to (waypoint) XYZ". Use the ECAM DIR page to select the waypoint from the flight plan's list of waypoints. In rare cases it is a waypoint not in the current flight plan then you can enter a new waypoint in the MCDU and put it into the upper left entry field. Select DIRECT* on the rght bottom to execute the change.
 
     ![ECAM direct to](../assets/beginner-guide/takeoff-climb-cruise/Dir-to.png "ECAM direct to"){ loading=lazy }
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
Fix typo from `plight` to `flight` for **Direct course to a waypoint (DIR TO)** under Takeoff/Climb/Cruise page

### Location
https://docs.flybywiresim.com/pilots-corner/beginner-guide/takeoff-climb-cruise/

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
jakuski#9191