### PR TITLE
docs(simbridge): clearly identify default port value remote mcdu

### DIFF
--- a/docs/simbridge/simbridge-feature-guides/remote-displays/remote-mcdu.md
+++ b/docs/simbridge/simbridge-feature-guides/remote-displays/remote-mcdu.md
@@ -15,12 +15,18 @@ It also allows you to use your real printer as a cockpit printer for the MCDU.
 
 ## Opening the MCDU Remote Display
 
-!!! warning Notice
-    SimBridge *must* be [running](../../install-configure/start-simbridge.md#autostart) in order to connect remotely.
+!!! warning "Important Requirements - **READ FIRST**"
+    Please note the following requirements before trying to use this feature:
 
-    See [Autostart](../../install-configure/start-simbridge#autostart) documentation on how to start it. 
+    - SimBridge *must* be [running](../../install-configure/start-simbridge.md#autostart) in order to connect remotely.
+    - See [Autostart](../../install-configure/start-simbridge#autostart) documentation on how to start it.
+    - Check [Troubleshooting](../../troubleshooting.md) if you are having issues.
 
-    Check [Troubleshooting](../../troubleshooting.md) if you are having issues.
+    !!! tip ""
+        The default port is: `8380`
+
+        This is valid for all options listed below. If you would like to change or confirm the port configuration of SimBridge see our [port configuration documentation](../..
+        /install-configure/configuration.md#server-settings). 
 
 ### Option 1: simbridge.local
 


### PR DESCRIPTION
## Summary
Provides clarity (within an admonition) before all listed options for starting remote MCDU explaining important requirements for using the feature. 

Default port is clearly identified within a **read first** warning admonition.

Quick example:

<img width="797" alt="Screenshot 2022-12-30 at 11 57 37 PM" src="https://user-images.githubusercontent.com/1619968/210111378-1353f6cf-f629-4b81-b9b7-0e0f3740996c.png">


### Location
- docs/simbridge/simbridge-feature-guides/remote-displays/remote-mcdu.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valasitir#8902
