### PR TITLE
fix(a32nx-feature-guides): Remove "only in dev" warning from EFB page

### DIFF
--- a/docs/fbw-a32nx/feature-guides/flypados3/index.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/index.md
@@ -8,8 +8,6 @@ description: A guide the flyPadOS 3 EFB used in the Development version of the A
 
 # flyPadOS 3 EFB
 
-!!! warning "flyPadOS 3 is only available in the Development version."
-
 <div style="position: relative;">
     <img src="/fbw-a32nx/assets/flypados3/flypad-dashboard-menu.png" style="width: 100%; height: auto;" loading="lazy">
     <a href="./dashboard/">   <div class="imagemap" style="position: absolute; left: 1.7%; top:  6.9%; width: 5.8%; height: 7.0%;"><span class="imagemapname">Dashboard</span></div></a>


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
Removes the "flyPadOS 3 is only available in the Development version." warning as the EFB is available for all versions. 

### Location
/fbw-a32nx/feature-guides/flypados3/

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Alepouna🌙#9824
