### PR TITLE
fix(typo a32nx-api): Fix THROTTLE 2 API shown as Throttle 1

### DIFF
--- a/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -758,7 +758,7 @@ Flight Deck: [Thrust Lever Panel](../../pilots-corner/a32nx-briefing/flight-deck
 |:----------------------|:----------------------------|:--------------|:-----------|:-----------------|:--------|
 | Throttle 1 Axis       | THROTTLE1_AXIS_SET_EX1      | -16383..16384 | -          | MSFS EVENT       |         |
 |                       |                             |               |            |                  |         |
-| Throttle 1 Axis       | THROTTLE2_AXIS_SET_EX1      | -16383..16384 | -          | MSFS EVENT       |         |
+| Throttle 2 Axis       | THROTTLE2_AXIS_SET_EX1      | -16383..16384 | -          | MSFS EVENT       |         |
 |                       |                             |               |            |                  |         |
 | AUTO THRUST DISENGAGE | AUTO_THROTTLE_ARM           | -             | -          | SIMCONNECT EVENT | Toggles |
 |                       | A32NX_AUTOTHRUST_DISCONNECT | 0&#124;1      | R          | Custom LVAR      |         |

--- a/docs/fbw-a32nx/feature-guides/flypados3/index.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/index.md
@@ -8,8 +8,6 @@ description: A guide the flyPadOS 3 EFB used in the Development version of the A
 
 # flyPadOS 3 EFB
 
-!!! warning "flyPadOS 3 is only available in the Development version."
-
 <div style="position: relative;">
     <img src="/fbw-a32nx/assets/flypados3/flypad-dashboard-menu.png" style="width: 100%; height: auto;" loading="lazy">
     <a href="./dashboard/">   <div class="imagemap" style="position: absolute; left: 1.7%; top:  6.9%; width: 5.8%; height: 7.0%;"><span class="imagemapname">Dashboard</span></div></a>


### PR DESCRIPTION


## Summary
Fixes a typo in the API docs that show throttle 1 as throttle 2. 
![image](https://user-images.githubusercontent.com/98479040/211266377-fed62e66-727a-4a2e-9369-a058a9e3c20a.png)


### Location
/fbw-a32nx/a32nx-api/a32nx-flightdeck-api

Discord username (if different from GitHub): Alepouna🌙#9824
