### PR TITLE
docs: minor corrections/fixes in various documentation

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/ext-lt.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/ext-lt.md
@@ -39,7 +39,7 @@ Turns on and off the three synchronized strobe lights, one on each wing tip and 
 - OFF:
     - Strobe light are off.
 
-Strobes are turned on at the latest when airborne. Usually shortly before the take of roll.
+Strobes are turned on at the latest when airborne. Usually shortly before the takeoff roll.
 
 ![STROBE and NAV](../../../assets/a32nx-briefing/overhead-panel/lights/strobe-right.jpg "STROBE and NAV"){loading=lazy}
 

--- a/docs/pilots-corner/advanced-guides/flight-guidance/autoland.md
+++ b/docs/pilots-corner/advanced-guides/flight-guidance/autoland.md
@@ -161,7 +161,7 @@ See [Beginner Guide Preparation and Checklist for Landing](../../beginner-guide/
 - At 10ft: callout "Retard" commands the PF to set the throttle levers to idle.
 - At touchdown:
     - FMA shows ROLL OUT - autopilot keeps aircraft on center line.
-    - PM sets both thrust levers to reverse thrust (idle or up to max as appropriate).
+    - PF sets both thrust levers to reverse thrust (idle or up to max as appropriate).
     - PM checks and calls out: "touchdown", "spoilers", "reversers", "auto brake", "decel".
 - At 70kts: PM announces "70kts" and PF will set the throttle to reverse idle if reverse max was used. 
 - Before 20kts: the PF manually brakes to deactivate the autobrake.


### PR DESCRIPTION

## Summary
Couple minor corrections and spelling errors that have been pending on Discord.

- Correct use of PF for autoland throttle action
- Correct spelling of takeoff roll in exterior lighting page

### Location
- docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/ext-lt.md
- docs/pilots-corner/advanced-guides/flight-guidance/autoland.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
