### PR TITLE
refactor: broken external markdown links

### DIFF
--- a/docs/dev-corner/dev-guide/specific/flypad-translations.md
+++ b/docs/dev-corner/dev-guide/specific/flypad-translations.md
@@ -2,5 +2,4 @@
 
 This page is pulled externally from the A32NX repository and describes the processes involved with adding features to the EFB and sourcing translations.
 
-{{ external_markdown('https://raw.githubusercontent.com/flybywiresim/a32nx/master/src/instruments/src/EFB/Localization/README.md', '') }}
-
+{{ external_markdown('https://raw.githubusercontent.com/flybywiresim/a32nx/master/fbw-a32nx/src/systems/instruments/src/EFB/Localization/README.md', '') }}


### PR DESCRIPTION
fixes #723

## Summary
`mkdocs build` exit's if external markdown links 404. There is only one example of this currently. 

### Location
- docs/dev-corner/dev-guide/specific/flypad-translations.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
