### PR TITLE
docs(beginner): update fuel information on init fuel pred

### DIFF
--- a/docs/pilots-corner/beginner-guide/preparing-mcdu.md
+++ b/docs/pilots-corner/beginner-guide/preparing-mcdu.md
@@ -390,6 +390,11 @@ Now we can add our fuel on board (FOB). The amount we input in this field can be
 
     Via the EFB - [Learn How](../../fbw-a32nx/feature-guides/flypados3/dispatch.md#fuel-page)
 
+    !!! warning "Planning Fuel"
+
+        If you are using the onboard *fuel planning* feature as a reference point before fueling the aircraft using the EFB, it is important to note that using the feature does not alter the 
+        actual fuel on board.
+
 ^^ECAM FOB^^
 
 Look at the upper ECAM and note the FOB indicated. Let's say that amount is `3091 KG`. When inputting the block fuel into the MCDU it is referenced in "Tons" and we should round to the closest decimal point.
@@ -405,14 +410,14 @@ We can choose to have the MCDU provide a recommended amount of fuel for the plan
 The `Block` field will be populated with a calculated fuel amount.
 
 * Press LSK3R again to confirm the fuel.
-* We should load this amount of fuel via the EFB or AOC option.
+* We should load this amount of fuel via the EFB.
 
 ^^SimBrief OFP^^
 
 We can use the planned block fuel stated on the OFP which in this case is `3091 KG`.
 
 * Using the keypad type in `3.1` and press LSK2R
-* We should load this amount of fuel via the EFB or AOC option.
+* We should load this amount of fuel via the EFB option.
 
 ![mcdu16](../assets/beginner-guide/mcdu/mcdu16.png){loading=lazy}
 

--- a/docs/pilots-corner/beginner-guide/preparing-mcdu.md
+++ b/docs/pilots-corner/beginner-guide/preparing-mcdu.md
@@ -390,10 +390,11 @@ Now we can add our fuel on board (FOB). The amount we input in this field can be
 
     Via the EFB - [Learn How](../../fbw-a32nx/feature-guides/flypados3/dispatch.md#fuel-page)
 
-    !!! warning "Planning Fuel"
+    !!! warning "Fuel Planning - MCDU"
 
-        If you are using the onboard *fuel planning* feature as a reference point before fueling the aircraft using the EFB, it is important to note that using the feature does not alter the 
-        actual fuel on board.
+        The *fuel planning* feature on the MCDU should only be used as a reference point bbefore fueling the aircraft using the EFB. 
+
+        Generating / using the vlue provided by this feature may not be accurate and does not actually load fuel into the aircraft.
 
 ^^ECAM FOB^^
 

--- a/docs/pilots-corner/beginner-guide/preparing-mcdu.md
+++ b/docs/pilots-corner/beginner-guide/preparing-mcdu.md
@@ -390,12 +390,6 @@ Now we can add our fuel on board (FOB). The amount we input in this field can be
 
     Via the EFB - [Learn How](../../fbw-a32nx/feature-guides/flypados3/dispatch.md#fuel-page)
 
-    !!! warning "Fuel Planning - MCDU"
-
-        The *fuel planning* feature on the MCDU should only be used as a reference point bbefore fueling the aircraft using the EFB. 
-
-        Generating / using the vlue provided by this feature may not be accurate and does not actually load fuel into the aircraft.
-
 ^^ECAM FOB^^
 
 Look at the upper ECAM and note the FOB indicated. Let's say that amount is `3091 KG`. When inputting the block fuel into the MCDU it is referenced in "Tons" and we should round to the closest decimal point.
@@ -403,6 +397,12 @@ Look at the upper ECAM and note the FOB indicated. Let's say that amount is `309
 * Using the keypad type in `3.1` and press LSK2R.
 
 ^^MCDU Planning^^
+
+!!! warning "A Note on Fuel Planning"
+
+    The *fuel planning* feature on the MCDU should only be used as a reference point before fueling the aircraft using the EFB. 
+
+    Generating / using the value provided by this feature may not be accurate and does not actually load fuel into the aircraft.
 
 We can choose to have the MCDU provide a recommended amount of fuel for the planned flight.
 


### PR DESCRIPTION
closes #718 

## Summary
As stated in the issue above -- removes references to AOC in the guides as it's no longer applicable to any of our versions. Cross-checked usage of AOC in the rest of our documentation when it pertains to fuel and did not find any mentions.

Also clarifies that fuel prediction is not 100% accurate + *does not* load fuel into the aircraft.

### Location
- docs/pilots-corner/beginner-guide/preparing-mcdu.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
