### PR TITLE
refactor: use correctly styled admonitions

### DIFF
--- a/archive/flypados2/dashboard.md
+++ b/archive/flypados2/dashboard.md
@@ -68,7 +68,7 @@ If you have [configured](settings.md) your simBrief account correctly, you can c
 
     Distance measurement tools.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### After loading of a simBrief flight plan

--- a/docs/dev-corner/dev-guide/setup-environment.md
+++ b/docs/dev-corner/dev-guide/setup-environment.md
@@ -94,7 +94,7 @@ If this works, you'll receive the response:
 
 Now you've compiled and symlinked your Github fork to your community folder, you should be able to load into the aircraft as normal.
 
-!!! attention ""
+!!! info ""
     Open MSFS and check everything is working with your compiled branch before progressing.
 
 ## Hello World Example

--- a/docs/dev-corner/qa-process.md
+++ b/docs/dev-corner/qa-process.md
@@ -29,7 +29,7 @@ conduct a few tests as described below without submitting any reports to GitHub!
 
 Send an application message and your test reports to the [Contact(s)](#contacts) at the bottom of this page via DM and the QA leaders will decide if you are eligible for a QA Trainee role (provided there are open positions).
 
-!!! attention ""
+!!! warning ""
     **Please do not submit reports to GitHub without having a QA Discord role.**
 
 ## What to Test
@@ -67,7 +67,7 @@ How to download the PR for QA
 
 5. Unzip the file and place the "flybywire-aircraft-a320-neo" folder into your Community.
 
-!!! attention "PR Builds only for FlyByWire QA Team"
+!!! info "PR Builds only for FlyByWire QA Team"
     The PR builds are only meant for QA testing and not for daily use. Outside of the FlyByWire QA Team we do not provide any support or answer any questions in regards to these builds.
 
 ## How to Test

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/front/autobrake-gear.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/front/autobrake-gear.md
@@ -45,7 +45,7 @@ An anti-skid and autobrake system is also provided.
 
 Lights up if the landing gear is not locked down when the aircraft is in the landing configuration, and a red warning appears on ECAM.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### A/SKID & N/W STRG

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/front/clock.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/front/clock.md
@@ -60,7 +60,7 @@ Note: When alternating between "RUN" and "STP" a cumulative elapsed time can be 
 
 Note: In order to select the date mode, the UTC selector must be set on "GPS" or "INT" position.
 
-!!! attention ""
+!!! info ""
     In the FlyByWire A32NX the Date Set button must be held to show date. It switches back to time when released.
 
 ---

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/front/ilcp.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/front/ilcp.md
@@ -23,7 +23,7 @@ These knobs are used to turn the displays (PFD, ND) on and off, and also adjust 
 - PFD
     - If the PFD is turned off (knob turned all the way counterclockwise) the PFD image is automatically displayed on the NDU, but the pilot may recover the ND by means of the PFD-ND XFR pushbutton.
 
-    !!! attention ""
+    !!! info ""
         Currently PFD/ND XFR is not available in the FBW A32NX for Microsoft Flight Simulator.
 
 - ND
@@ -33,7 +33,7 @@ These knobs are used to turn the displays (PFD, ND) on and off, and also adjust 
 
 Exchanges the PFD and the ND. If the PFDU fails, the PFD automatically transfers to the NDU.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 
@@ -48,7 +48,7 @@ Adjusts the volume of the loudspeaker for radio communication.
 
 Note: Does not control the loudness of aural alert and voice messages.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### Console/Floor Lt.

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/fcu.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/fcu.md
@@ -83,7 +83,7 @@ The flight crew uses these buttons to engage or disengage the autopilots. Lights
     - If disengaged with the takeover pushbutton on the sidestick, the warnings are temporary (&#8924;3s Master Warning, &#8924;9s ECAM message "AP OFF" (red), &#8924;1.5s Cavalry Charge audio).
     - If disengaged by a failure, or by pushing the pushbutton on the FCU, or from a force on the sidestick, the visual and audio warnings are continual (ECAM message "AUTO FLT AP OFF" in red).
 
-    !!! attention ""
+    !!! info ""
         Currently no continual warnings are implemented and also no ECAM message is displayed in the FBW A32NX for Microsoft Flight Simulator when the AP is disengaged.
 
 ### A/THR pushbutton

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/warning.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/warning.md
@@ -26,7 +26,7 @@
     - Both lights will flash if the pilots are attempting to move both sidesticks at the same time and neither pilot takes priority.
     - If a pilot who has taken priority by using the TAKEOVER pb and the other pilot's sidestick is in motion or not neutral, the light of the pilot who has taken priority illuminates. It will extinguish when the opposing sidestick returns to the neutral position.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### 2. CHRONO

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd-aft/circuit.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd-aft/circuit.md
@@ -23,7 +23,7 @@ Note: The CLR or the EMER CANCEL pushbutton can be used to clear the ECAM cautio
 
 The Overhead Aft Panel is usually not used during flight.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ## Rear Right Back Panel
@@ -32,7 +32,7 @@ There are further "Secondary Circuit Breakers" on the Rear Right Panel.
 
 ![Rear Right Back Panel](../../../assets/a32nx-briefing/overhead-aft-panel/Rear-Right-Back-Panel.jpg "Rear Right Back Panel"){loading=lazy}
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ---

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd-aft/cockpit-door.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd-aft/cockpit-door.md
@@ -10,7 +10,7 @@
 
 ## Description
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### Strikes' status lights

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd-aft/elt.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd-aft/elt.md
@@ -16,7 +16,7 @@ An audio alert starts and a distress signal is transmitted for search and rescue
 
 An additional handheld ELT is usually mounted in the cockpit wardrobe.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ---

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd-aft/fms-load.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd-aft/fms-load.md
@@ -21,7 +21,7 @@ The A320neo has the following software & databases:
 - PERF Database
 - Magnetic Variation Database (MAG VAR)
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ---

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd-aft/maintenance.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd-aft/maintenance.md
@@ -22,7 +22,7 @@ The maintenance crew uses this pushbutton to reset the control circuit, after th
 - ON: The PASSENGER SYS ON light goes off.
 - FAULT: when the door latch solenoids are energized for more than 30s this light comes on in white.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### SVCE INT OVRD
@@ -30,7 +30,7 @@ The maintenance crew uses this pushbutton to reset the control circuit, after th
 - Auto: Ground personnel can communicate with the flight crew by means of the service interphone jacks 10s after the aircraft has landed. The landing gear must be compressed.
 - ON: Communication is possible when the landing gear is not compressed. The ON light is white.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### AVIONICS COMP LT
@@ -38,7 +38,7 @@ The maintenance crew uses this pushbutton to reset the control circuit, after th
 - AUTO: avionic compartment lighting is automatically controlled by door opening.
 - ON: avionic compartment lighting is on.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### BLUE PUMP OVRD (guarded)
@@ -51,7 +51,7 @@ The maintenance crew uses this pushbutton to reset the control circuit, after th
 - OFF: The corresponding electrohydraulic valve closes and shuts off hydraulic supply to the primary flight controls.
 - ON: The corresponding electrohydraulic valve opens to go back to normal hydraulic supply.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### APU
@@ -68,7 +68,7 @@ The maintenance crew uses this pushbutton to reset the control circuit, after th
 
 - RESET PB: When pressed, resets the test circuit.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### ENG FADEC GND PWR
@@ -78,7 +78,7 @@ The maintenance crew uses this pushbutton to reset the control circuit, after th
     - The ENG FIRE pb-sw is not pressed,
     - The FADEC alternator does not supply the FADEC.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ---

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd-aft/pedestal-light.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd-aft/pedestal-light.md
@@ -22,10 +22,10 @@ Doing so takes away the third occupant's access to the acoustic equipment. AUDIO
 
 If set to CAPT 3 or F/O 3 the corresponding pilot uses his acoustic equipment and the third ACP.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ---

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/3rd-acp.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/3rd-acp.md
@@ -10,7 +10,7 @@
 
 ## Description
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ## Usage
@@ -19,7 +19,7 @@
 
 ![RMP Transmission Keys](../../../assets/a32nx-briefing/pedestal/RMP-transmission-keys.png)
 
-!!! attention ""
+!!! info ""
     Currently only the VHF1-3 channels are available in the FBW A32NX for Microsoft Flight Simulator.
 
 - Pressed:
@@ -39,7 +39,7 @@
 
 ![Reception Knobs](../../../assets/a32nx-briefing/pedestal/RMP-receiption-knobs-2.png "Reception Knobs")
 
-!!! attention ""
+!!! info ""
     Currently only the VHF2-3 channels are available for selection in the FBW A32NX for Microsoft Flight Simulator. VHF1 is always selected although not lit.
 
 These knobs are used to allow the flight crew to activate a channel for reception and to adjust volume.
@@ -51,35 +51,35 @@ These knobs are used to allow the flight crew to activate a channel for receptio
 
 Extinguishes CALL, MECH, and ATT lights.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### VOICE
 
 Inhibit the audio navigation signals (VOR, ADF) and filters out ident signals and turns on the green ON light.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### INT/RAD
 
 Press-to-talk switch for boom mike or oxygen mask mike.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### PA (Passenger Address)
 
 Passenger Address is used by the flight personnel to make passenger announcements through loudspeakers in the cabin.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 #### PA transmission key
 
 Pressed and held: To make an announcement a boom, mask or hand mike is used.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 #### PA reception knob
@@ -89,7 +89,7 @@ Pressed and held: To make an announcement a boom, mask or hand mike is used.
 - Pressed (knob in):
     - The PA system is disconnected. The white light goes out.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/ac.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/ac.md
@@ -59,7 +59,7 @@ The two air conditioning packs (PACK 1+2) operate automatically and independentl
 - OFF:
     - The RAM air inlet closes.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### ENG 1 and ENG 2 BLEED

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/cargo-smoke.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/cargo-smoke.md
@@ -29,7 +29,7 @@ When the system detects smoke in the compartment, a red light and an ECAM warnin
 
 Ignites the squib to discharge the extinguishing agent in the corresponding compartment (FWD or AFT).
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### DISCH light

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/cargo-vent.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/cargo-vent.md
@@ -25,7 +25,7 @@ The switch controls the aft isolation valves and the extraction fan.
 - FAULT Lt:
     - Amber light and ECAM caution when inlet or outlet valve is not in the selected position.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ---

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/emergency-electric.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/emergency-electric.md
@@ -10,7 +10,7 @@
 
 ## Usage
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### MAN ON (guarded)

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/eng-man.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/eng-man.md
@@ -10,12 +10,12 @@
 
 ## Usage
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### ENG MAN START
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - ON:
@@ -29,7 +29,7 @@
 
 ### ENG N1 MODE
 
-!!! attention ""
+!!! info ""
     These buttons do not exist in an A320neo with LEAP or PW1100 engines. They are exclusively for the CEO IAE V2500 engines. As these buttons are part of Asobo's Default A320 3D model they are still visible and can't be removed at this time.
 
     They are INOP in the FlyByWire A32NX. 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/ext-lt.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/ext-lt.md
@@ -78,7 +78,7 @@ NAV & LOGO are turned on when the aircraft is powered up (EXT PWR or APU or ENG)
 
 ![NAV & LOGO and STROBE](../../../assets/a32nx-briefing/overhead-panel/lights/tail-lights.jpg "NAV & LOGO and STROBE"){loading=lazy}
 
-!!! attention ""
+!!! info ""
     Currently the FlyByWire A32NX only has two settings for NAV & LOGO lights (2 or OFF / 1 is not available).
 
 ### RWY TURN OFF

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/fuel.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/fuel.md
@@ -51,7 +51,7 @@ Both engines can be fed from one side or both sides can feed only one engine.
 - FAULT:
     - Amber light and ECAM caution appear, when the left or right wing tank has less than 5000 kg (11000 lb) and center tank has more than 250 kg (550 lb).
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### CTR TK PUMP 1 + 2

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/int-lt.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/int-lt.md
@@ -21,7 +21,7 @@ Brightness for the integral lightning of the overhead panel.
 
 Integral lighting for the standby compass and the visual indicator.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### DOME

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/pa-cockpit-video.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/pa-cockpit-video.md
@@ -15,7 +15,7 @@
 
 Illuminates when the PA is activated from the cockpit or the cabin (cabin attendant ot prerecorded announcement).
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### Cockpit Door Video
@@ -23,7 +23,7 @@ Illuminates when the PA is activated from the cockpit or the cabin (cabin attend
 - OFF:
     - Manually turns off the power for the Cockpit Door Surveillance System.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ---

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/wipers.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/wipers.md
@@ -31,7 +31,7 @@ Each windshield is provided with two-speed electric wipers that are controlled b
 - When the button is pushed, the timer applies a measured quantity of rain repellent to the applicable windshield. To repeat the cycle, the push button must be pushed again.
 - This function is inhibited when the aircraft is on the ground and the engines are not running.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ---

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/atc-tcas.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/atc-tcas.md
@@ -56,7 +56,7 @@ The XPDR is capable of elementary surveillance (ELS) and enhanced surveillance (
 
 This switch selects XPDR 1 or 2.
 
-!!! attention ""
+!!! info ""
     Currently only 1 is available in the FBW A32NX for Microsoft Flight Simulator.
 
 ### ALT RPTG Switch

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/console.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/console.md
@@ -34,7 +34,7 @@ At all times, only one flight crewmember should fly the aircraft. However, if bo
 
 A flight crewmember can deactivate the other sidestick and take full control, by pressing and keeping pressed the sidestick pb. To deactivate the other sidestick, the flight crewmember must press their sidestick pb for 40s. The other sidestick is permanently deactivated, until any flight crewmember presses their sidestick pb. If both flight crew members press their sidestick pb, the last pilot to press gets the priority. If one sidestick was deactivated on ground, the CONFIG L(R) SIDESTICK FAULT alert is triggered at takeoff power application, or during the TO CONFIG test.
 
-!!! attention ""
+!!! info ""
     Sidestick priotity is currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ## Steering Handwheels (Tiller)

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/engine.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/engine.md
@@ -27,7 +27,7 @@ It contains Master Switches for each engine and also an Ignition Mode Switch for
 - CRANK:
     - The start valve opens, if the [ENG MAN START](../ovhd/eng-man.md) pushbutton switch is ON. Ignition does not fire.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### ENG MASTER 1 + 2
@@ -35,7 +35,7 @@ It contains Master Switches for each engine and also an Ignition Mode Switch for
 - ON:
     - Depending on the [ENG MAN START](../ovhd/eng-man.md) this tells the FADEC to start the automatic or manual start sequences.
 
-    !!! attention ""
+    !!! info ""
         Manual start is currently not available in the FBW A32NX for for Microsoft Flight Simulator.
 - OFF:
     - Shuts down the engine or aborts the start sequence of this engine.

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/lighting-aids-dfdr.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/lighting-aids-dfdr.md
@@ -16,7 +16,7 @@ Sets brightness of the floodlighting for the pedestal.
 
 To print a specific flight phase dependent report, the crew can push this button and then use the MCDU to select another report for printing.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### DFDR EVENT

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/radar.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/radar.md
@@ -16,7 +16,7 @@ The A320 is fitted with a weather radar system which includes a Predictive Winds
 
 The weather radar data can be displayed on the NDs in ARC or ROSE mode.
 
-!!! attention ""
+!!! info ""
     In Microsoft Flight Simulator the system is limited by what the simulator provides which currently is only precipitation.
 
 ## Usage
@@ -32,7 +32,7 @@ The weather radar data can be displayed on the NDs in ARC or ROSE mode.
 
 - This knob adjusts the sensitivity of the radar.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### MODE - Display mode selector
@@ -48,14 +48,14 @@ The weather radar data can be displayed on the NDs in ARC or ROSE mode.
 - MAP:
     - Map mode: No weather display but ground information: Black for water, green for ground, and amber for cities and mountains.
 
-!!! attention ""
+!!! info ""
     Weather is not available in the Stable version. We are awaiting Asobo API implementation. See [Custom FMS Special Notes](../../../../fbw-a32nx/feature-guides/cFMS.md#special-notes)
 
 ###  TILT
 
 This allows tilting the radar antenna when MULTISCAN is MAN. Zero uses the horizon reference from the IRS.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### MULTISCAN
@@ -65,7 +65,7 @@ This allows tilting the radar antenna when MULTISCAN is MAN. Zero uses the horiz
 - MAN:
     - Manually adjust radar antenna tilt using the TILT knob.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### GCS (Ground Clutter Suppression)
@@ -76,7 +76,7 @@ This allows tilting the radar antenna when MULTISCAN is MAN. Zero uses the horiz
 - OFF:
     - Ground clutter is visible.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### PWS
@@ -86,7 +86,7 @@ This allows tilting the radar antenna when MULTISCAN is MAN. Zero uses the horiz
 - OFF:
     - The Predictive WindShear function is off.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ---

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
@@ -63,7 +63,7 @@ Turning these knobs selects the STBY frequency or CRS.
 
 Used to select AM mode if the aircraft has a VH transceiver.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### SEL indicator
@@ -78,7 +78,7 @@ The SEL indicator glows white on both RMPs when a transceiver normally associate
 
 This is used as a backup to select navigation aids and coursed via the RMP.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### Radio navigation selection keys
@@ -98,7 +98,7 @@ Power supply to the RMP.
 
 ![RMP Transmission Keys](../../../assets/a32nx-briefing/pedestal/RMP-transmission-keys.png)
 
-!!! attention ""
+!!! info ""
     Currently only the VHF1-3 channels are available in the FBW A32NX for Microsoft Flight Simulator.
 
 - Pressed:
@@ -118,7 +118,7 @@ Power supply to the RMP.
 
 ![Reception Knobs](../../../assets/a32nx-briefing/pedestal/RMP-receiption-knobs-2.png "Reception Knobs")
 
-!!! attention ""
+!!! info ""
     Currently only the VHF2-3 channels are available for selection in the FBW A32NX for Microsoft Flight Simulator. VHF1 is always selected although not lit.
 
 These knobs are used to allow the flight crew to activate a channel for reception and to adjust volume.
@@ -130,35 +130,35 @@ These knobs are used to allow the flight crew to activate a channel for receptio
 
 Extinguishes CALL, MECH, and ATT lights.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### VOICE
 
 Inhibit the audio navigation signals (VOR, ADF) and filters out ident signals and turns on the green ON light.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### INT/RAD
 
 Press-to-talk switch for boom mike or oxygen mask mike.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### PA (Passenger Address)
 
 Passenger Address is used by the flight personnel to make passenger announcements through loudspeakers in the cabin.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 #### PA transmission key
 
 Pressed and held: To make an announcement a boom, mask or hand mike is used
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 #### PA reception knob
@@ -168,7 +168,7 @@ Pressed and held: To make an announcement a boom, mask or hand mike is used
 - Pressed (knob in):
     - The PA system is disconnected. The white light goes out.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ---

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/switching.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/switching.md
@@ -49,7 +49,7 @@ To have maximal redundancy A320 pilots can switch backup computers or data sourc
 !!! info ""
     Note: If a DMC fails, each of its associated DUs displays an “INVALID DATA” message.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### ECAM/ND XFR Selector
@@ -61,7 +61,7 @@ To have maximal redundancy A320 pilots can switch backup computers or data sourc
 - F/O:
     - Transfers the System Display to First Officer's ND.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ---

--- a/docs/pilots-corner/a32nx-briefing/mcdu/data.md
+++ b/docs/pilots-corner/a32nx-briefing/mcdu/data.md
@@ -13,7 +13,7 @@ PAGE 1 is dedicated to navigation systems and corresponding sub pages.
 
 PAGE 2 is dedicated to navigation data that is entered or stored in the FMGS.
 
-!!! attention ""
+!!! info ""
     This section will not cover all DATA INDEX pages as most are not useful in a simulation or not 
     implemented yet in the FlyByWire A32NX.
 
@@ -141,7 +141,7 @@ Automatically displayed this page at power up.  Pilots may also call it up by pr
     - Validity period in small font.
     - A press to the 3L key switches to the second database as the active database.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - CHG CODE (5L)
@@ -150,7 +150,7 @@ Automatically displayed this page at power up.  Pilots may also call it up by pr
     - Label is displayed in small white font.
     - The brackets, or the entered value, is displayed in large blue font.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - IDLE/PERF (6L)
@@ -166,13 +166,13 @@ Automatically displayed this page at power up.  Pilots may also call it up by pr
         - PRESS the (6L) key to insert the new IDLE and/or PERF factor.
         - The new IDLE and/or PERF factors are displayed in large blue font.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - STATUS/XLOAD (6R)
     - Calls up the P/N STATUS and P/N XLOAD pages.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### CLOSEST AIRPORTS 1
@@ -210,7 +210,7 @@ Page 1 displays the bearing, distance, and time to go to each airport.
 
 Page 2 displays the EFOB and allows the crew to enter an effective wind to be flown to each airport.
 
-!!! attention ""
+!!! info ""
     Currently not fully available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - AIRPORTS (1-5)
@@ -234,7 +234,7 @@ Page 2 displays the EFOB and allows the crew to enter an effective wind to be fl
 These keys call up details of waypoints, NAVAIDs, runways, and routes
 stored in the database.
 
-!!! attention ""
+!!! info ""
     Currently not all of these are available in the FBW A32NX for Microsoft Flight Simulator.
 
 - STORED WAYPOINTS (1R)
@@ -248,6 +248,6 @@ These keys call up waypoints, NAVAIDs, runways, and routes that the pilot has st
 or delete them from, the database. The airline can choose to have all pilot-stored data automatically erased in the 
 done phase.
 
-!!! attention ""
+!!! info ""
     Currently not all of these are available in the FBW A32NX for Microsoft Flight Simulator.
 

--- a/docs/pilots-corner/a32nx-briefing/mcdu/f-pln.md
+++ b/docs/pilots-corner/a32nx-briefing/mcdu/f-pln.md
@@ -40,7 +40,7 @@ If the route contains a published missed approach procedure, it is shown in blue
 turns green when the go-around phase becomes active. After the last waypoint of the missed approach, the display 
 shows the alternate flight plan in NAV mode.
 
-!!! attention "Missed Approach Procedure and ALTN Flight Plan"
+!!! info "Missed Approach Procedure and ALTN Flight Plan"
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 In NAV mode, the TO waypoint can only be cleared by using the DIR key.
@@ -65,7 +65,7 @@ the constraint and the MCDU displays: “SPD ERROR AT WPT”.
     SPD and ALT CSTR may either be entered on the VERT REV page or directly on the F-PLN A page, whereas TIME CSTR 
     may only be entered from the RTA page.
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 #### Pseudo Waypoints
@@ -117,7 +117,7 @@ Pseudo waypoints are displayed in parentheses.
 
 ## Flight Plan B Page
 
-!!! attention "F-PLN B"
+!!! info "F-PLN B"
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ## Lateral Revision Pages
@@ -172,7 +172,7 @@ STAR revisions are done only at a destination airport (Destination page).
       of the direct line between the waypoints.
     - Only available on waypoint or present position
     
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
   
 - LL XING/INCR/NO (2R)
@@ -180,7 +180,7 @@ STAR revisions are done only at a destination airport (Destination page).
       (in degrees), and the number of crossing points desired in 2R
     - Only available on origin, ppos and waypoint.
     
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
   
 - HOLD (3L)
@@ -200,7 +200,7 @@ STAR revisions are done only at a destination airport (Destination page).
     - Will create a temporary flight plan.
     - Only available on departure, waypoint and destination.
     
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
   
 - NEW DEST (4R)
@@ -214,7 +214,7 @@ STAR revisions are done only at a destination airport (Destination page).
     - Used to display a list of alternate airports from the database.
     - Only available on destination airport.
   
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
   
 - AIRWAYS (5R)
@@ -260,7 +260,7 @@ certain criteria.
     - Shows the estimated fuel on board and the extra fuel consumed after taxi, trip, reserves, alternate and final. 
       Extra fuel might be negative if reserves will be used.
 
-        !!! attention ""
+        !!! info ""
             Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
   
 - CLB/DES SPD LIM (2L)
@@ -277,7 +277,7 @@ certain criteria.
 - MACH/START WPT (4L - only on cruise waypoints)
     - Used to enter start point for a Constant Mach Segment (CMS).
     
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
   
 - QNH (4L - only on destination waypoint)
@@ -291,7 +291,7 @@ certain criteria.
 - RTA (2R)
     - Calls [Required Time of Arrival page](#rta-page)
   
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
   
 - ALT CSTR (3R)
@@ -314,14 +314,14 @@ certain criteria.
     - Used to enter end point for a Constant Mach Segment (CMS).
     - Only for cruise waypoints.
   
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
   
 - ALT ERROR (4R)
     - During CLIMB and DESCENT this shows how far the corresponding constraint will be missed (estimation).
     - When estimated miss is >250ft.
     
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
   
 - STEP ALTS (5R)
@@ -332,7 +332,7 @@ certain criteria.
 - \*CLB OR DES* (6L, 6R)
     - Shown if the system can't determine climb or descent after a constraint has been entered.
     
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 !!! note
@@ -428,7 +428,7 @@ The FIX INFO pages are used to create waypoint intersections of the
 flight plan with radials, radii, and abeam intercept points associated
 with a waypoint.
 
-!!! attention ""
+!!! info ""
     Currently only partly implemented in the FBW A32NX for Microsoft Flight Simulator.
 
 See [Feature Guide: Fix Info](../../../pilots-corner/advanced-guides/flight-planning/fixinfo.md)
@@ -481,7 +481,7 @@ The crew calls up this page, by pressing the AIRWAYS key (5R) on the [LAT REV pa
 
 ## STEP ALTS Page
 
-!!! attention ""
+!!! info ""
     Currently not fully implemented in the FBW A32NX for Microsoft Flight Simulator.
     <p />
     Steps Alts are also currently not considered in the flight planning in the FBW A32NX for Microsoft Flight Simulator.
@@ -513,7 +513,7 @@ The crew calls it up from the vertical revision page.
 
 ## WIND Page
 
-!!! attention ""
+!!! info ""
     The WIND Pages are currently implemented in a simplified manner in the FBW A32NX for Microsoft Flight Simulator.
 
 Winds in climb, cruise, descent, and approach are necessary to provide the flight crew with reliable predictions and 
@@ -544,7 +544,7 @@ ACARS for the various flight phases.
     - This key calls up the history wind page and is only displayed in the preflight phase. It cannot be modified 
       (white font), but can be inserted into the CLIMB WIND page by using the 6R key and modified accordingly.
 
-    !!! attention ""
+    !!! info ""
         Currently only partly implemented in the FBW A32NX for Microsoft Flight Simulator.
 
 - WIND REQUEST (3R)
@@ -567,7 +567,7 @@ ACARS for the various flight phases.
     - They can then modify the temperature or the altitude independently. 
     - SAT and Altitude are displayed in yellow when pending winds exist and in blue otherwise.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### DESCENT WIND
@@ -590,7 +590,7 @@ ACARS for the various flight phases.
 
 ## RTA Page
 
-!!! attention "RTA Page"
+!!! info "RTA Page"
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 The Required Time of Arrival (RTA) is a time constraint that must be respected at the revised

--- a/docs/pilots-corner/a32nx-briefing/mcdu/fuel-pred.md
+++ b/docs/pilots-corner/a32nx-briefing/mcdu/fuel-pred.md
@@ -12,7 +12,7 @@ by pressing the FUEL PRED key on the MCDU.
     The flight crew can also call up this page by pressing the “→” key on the MCDU when on
     the INIT A page.
 
-!!! attention ""
+!!! info ""
     Fuel prediction in the A32NX is not yet accurate.
 
 ## Usage
@@ -71,7 +71,7 @@ by pressing the FUEL PRED key on the MCDU.
     - The flight crew can modify the FOB value in flight, or modify the
       sensors used by entering “/FF”, “/FQ” or “/FF+FQ”, as required.
 
-        !!! attention ""
+        !!! info ""
             Changing sensors is not yet supported by the A32NX. 
 
 - GW/CG (5R)

--- a/docs/pilots-corner/a32nx-briefing/mcdu/init.md
+++ b/docs/pilots-corner/a32nx-briefing/mcdu/init.md
@@ -13,7 +13,7 @@ The INIT A page is used by the flight crew to initialize the flight plan and ali
 - CO RTE (1L):
     - A company route ID can be entered in this field and all data associated with that route.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - ALTN/CO RTE (2L):
@@ -22,7 +22,7 @@ The INIT A page is used by the flight crew to initialize the flight plan and ali
       company route identification.
     - The crew may manually enter an alternate and company route.
 
-    !!! attention ""
+    !!! info ""
         Currently CO RTE is not available in the FBW A32NX for Microsoft Flight Simulator.
 
 - FLIGHT NUMBER (3L):
@@ -45,7 +45,7 @@ The INIT A page is used by the flight crew to initialize the flight plan and ali
     - Automatically deletes any previously entered route and calls up the route selection page.
     - If one airfield of the pair is not in the database, the display changes to the NEW RWY page.
 
-        !!! attention ""
+        !!! info ""
             Currently the "NEW RWY page" is not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - INIT REQUEST (2R):
@@ -56,7 +56,7 @@ The INIT A page is used by the flight crew to initialize the flight plan and ali
       active flight plan does not exist. After engine start, the uplink flight plan is sent to the secondary flight 
       plan and manually inserted or rejected.
 
-    !!! attention ""
+    !!! info ""
         In the FlyByWire A32NX this function is implemented differently and loads a flight plan from 
         SimBrief.
         <p />
@@ -163,7 +163,7 @@ will use the FOB to compute its predictions.
       fuel is computed by the FMGC.
     - Computation automatically restarts if parameters used to compute the prediction are modified before confirmation.
 
-    !!! attention ""
+    !!! info ""
         Currently fuel prediction is not yet accurate in the FBW A32NX for Microsoft Flight Simulator.
 
 - TOW/LW (4R)

--- a/docs/pilots-corner/a32nx-briefing/mcdu/interface.md
+++ b/docs/pilots-corner/a32nx-briefing/mcdu/interface.md
@@ -97,7 +97,7 @@ the destination airport again.
 
 ## Annunciators
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### Top
@@ -174,7 +174,7 @@ The MCDU uses small and large fonts according to the following rules:
 - Tuned Navaid: <span style="color: #00ffff">blue</span>
 - "TO" waypoint and Destination: white
 
-!!! attention ""
+!!! info ""
     Currently only Primary F-PLN is available in the FBW A32NX for Microsoft Flight Simulator.
 
 

--- a/docs/pilots-corner/a32nx-briefing/mcdu/mcdu-menu.md
+++ b/docs/pilots-corner/a32nx-briefing/mcdu/mcdu-menu.md
@@ -30,17 +30,17 @@ displays this page at power up.
         - Shows the DATALINK STATUS page with information about the state of the various data link options.   
     - COMM MENU
   
-        !!! attention ""
+        !!! info ""
             Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
  
 - AIDS (3L)
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - CFDS (4L)
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - NAV B/UP (1R)
@@ -48,7 +48,7 @@ displays this page at power up.
       monitor the navigation and to be provided with some basic flight planning functions in case of FM 1 +
       2 failure.
     
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### AOC MENU Page
@@ -66,12 +66,12 @@ displays this page at power up.
     - Shows list of sent messages (Free Text).
 - DIVERSION (5R)
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - MISC (6R)
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ### INIT/PRES Page

--- a/docs/pilots-corner/a32nx-briefing/mcdu/perf.md
+++ b/docs/pilots-corner/a32nx-briefing/mcdu/perf.md
@@ -86,7 +86,7 @@ Prompts on each PERF page:
 - UPLINK TO DATA (6L)
     - This key calls up the UPLINK TO DATA REQ page. It is only displayed in the preflight and done phases.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - TO SHIFT (2R)
@@ -94,7 +94,7 @@ Prompts on each PERF page:
       crew should insert this value when taking off from an intersection to ensure a correct update of the FM position.
       The takeoff shift value must be positive, and cannot be greater than the runway length.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - FLAPS/THS (3R)
@@ -133,7 +133,7 @@ Prompts on each PERF page:
       SELECTED. 
     - Pressing the 3L key in this case preselects MANAGED speed, and 4L reverts to brackets.
     
-        !!! attention ""
+        !!! info ""
             Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - PRESEL or SELECTED (4L):
@@ -153,20 +153,20 @@ Prompts on each PERF page:
     - The flight crew cannot engage EXPEDITE from this field. It indicates the time and distance required to 
       reach the altitude displayed in the 2R field, in case of climb at green dot.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - EO CLR (1R):
     - The system displays the EO CLR prompt in case of engine out in climb.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - PRED TO... (2R):
     - This field displays the target altitude for the predictions shown in 3R, 4R, or 5L. It defaults to FCU 
       altitude, but the pilot can modify it to any altitude below CRZ FL.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - (3R) (4R) (5R):
@@ -174,7 +174,7 @@ Prompts on each PERF page:
       current vertical mode and speed mode (MANAGED, SELECTED). These fields are displayed only while the 
       takeoff, or climb phase is active.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ## CRUISE
@@ -197,7 +197,7 @@ Prompts on each PERF page:
       SELECTED. 
     - Pressing the 3L key in this case preselects MANAGED speed, and 4L reverts to brackets.
 
-        !!! attention ""
+        !!! info ""
             Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - PRESEL (4L)
@@ -212,20 +212,20 @@ Prompts on each PERF page:
     - After takeoff: Displays the predicted arrival time at destination (UTC) and the remaining fuel on board.
     - EO CLR is displayed when an engine out is detected.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - STEP TO FL XX, DRIFT DOWN TO FLxxx, or TO T/D (2R):
     - The field, in combination with 3R, displays the predictions for the step point and the step altitude, the 
       drift down altitude, or the Top of Descent.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - TIME/UTC and DIST (3R):
     - This field displays the time and distance to go to the various points identified (2R).
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - DES CABIN RATE (4R)
@@ -236,13 +236,13 @@ Prompts on each PERF page:
           reverts to the default value (-350 ft/min). DES CAB RATE being a negative value, 'minus” is not a 
           necessary entry.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
  
 - STEP ALTS (5R)
     - This key calls up the STEP ALTS page .
     
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 
@@ -293,7 +293,7 @@ Prompts on each PERF page:
     - After takeoff: Displays the predicted arrival time at destination (UTC) and the remaining fuel on board.
     - EO CLR is displayed when an engine out is detected.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - PRED TO... (2R)
@@ -301,14 +301,14 @@ Prompts on each PERF page:
     - The display defaults to the altitude selected on the FCU. The flight crew can modify it to any altitude lower 
       than present altitude.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - (3R),(4R) or (5R)
     - These fields display time and distance predictions down to the target altitude selected in (2R), computed for the 
       current vertical mode (DES or OP DES) and the indicated speed mode (MANAGED, SELECTED).
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ## APPROACH
@@ -322,7 +322,7 @@ Prompts on each PERF page:
     - \>180 NM from the destination:
         - Blue brackets are displayed
     
-        !!! attention ""
+        !!! info ""
             Currently shows amber boxes in this case in the FBW A32NX for Microsoft Flight Simulator.
   
     - <180 NM:
@@ -351,7 +351,7 @@ Prompts on each PERF page:
     - \>180 NM from the destination:
         - Blue brackets are displayed
           
-        !!! attention ""
+        !!! info ""
             Currently shows amber boxes in this case in the FBW A32NX for Microsoft Flight Simulator.
   
     - <180 NM:

--- a/docs/pilots-corner/a32nx-briefing/mcdu/prog.md
+++ b/docs/pilots-corner/a32nx-briefing/mcdu/prog.md
@@ -51,12 +51,12 @@ Opens the REPORT page.
 This page displays information related to the FROM, TO, NEXT and DEST waypoints, as well as the current wind, 
 temperature, distance and time to the next cruise profile change.
 
-!!! attention ""
+!!! info ""
     This page is not fully implemented in the current FlyByWire A32NX.
 
 ### Position Update (3L)
 
-!!! attention ""
+!!! info ""
     Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 This functions allows the flight crew to update the aircraft's FMS position to its actual position. The flight crew 
@@ -86,7 +86,7 @@ Opens the PREDICTIVE GPS page.
 Displays information relative to predictive availability of GPS PRIMARY at destination, and at any waypoint selected 
 by the crew.
 
-!!! attention ""
+!!! info ""
     This page is not fully implemented in the current FlyByWire A32NX.
 
 ### GPS Source (5R)

--- a/docs/pilots-corner/a32nx-briefing/mcdu/rad-nav.md
+++ b/docs/pilots-corner/a32nx-briefing/mcdu/rad-nav.md
@@ -9,7 +9,7 @@ These NAVAIDs include: VOR, VOR/DME, TAC, VORTAC, ILS, and ADF.
 
 If either RMP is set on NAV, this page is blank on both MCDUs.
 
-!!! attention ""
+!!! info ""
     Currently RMP based NAV is not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 ## Usage
@@ -40,7 +40,7 @@ If either RMP is set on NAV, this page is blank on both MCDUs.
       Otherwise, the course must be entered manually.
     - The course may be backbeam (Bxxx) or frontbeam (Fxxx).
   
-        !!! attention ""
+        !!! info ""
             Currently the backbeam format is not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 - ADF1/FREQ & FREQ/ADF2 (5L, 5R)
@@ -52,7 +52,7 @@ If either RMP is set on NAV, this page is blank on both MCDUs.
     - The flight crew presses this key once to erase the arrow and revert ADF to BFO (Beat Frequency Oscillator) mode.
     - A clear action recalls the arrow, and cancels BFO.
 
-    !!! attention ""
+    !!! info ""
         Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
 
 !!! note 

--- a/docs/pilots-corner/a32nx-briefing/mcdu/sec-f-plan.md
+++ b/docs/pilots-corner/a32nx-briefing/mcdu/sec-f-plan.md
@@ -2,7 +2,7 @@
 
 ![SEC F-PLN](../../assets/a32nx-briefing/mcdu/mcdu-sec-f-pln-page.png)
 
-!!! attention ""
+!!! info ""
     Currently not implemented yet in the FBW A32NX for Microsoft Flight Simulator.
 
 The SEC F-PLN key on the MCDU console allows the flight crew to call up the secondary index page

--- a/docs/pilots-corner/a32nx-briefing/pfd/first-column.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/first-column.md
@@ -102,7 +102,7 @@ Displayed in amber text. Displayed after autothrust disconnection (either pilot 
      - LVR CLB (If the thrust levers are below the climb detent).
      - LVR MCT ( If the thrust levers are below the FLX/MCT detent).
     
-    !!! attention ""
+    !!! info ""
         Currently not available for the FBW A32NX for Microsoft Flight Simulator
 
 ## Autobrake Description

--- a/docs/pilots-corner/a32nx-briefing/pfd/flags-messages.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/flags-messages.md
@@ -109,7 +109,7 @@ These are flags and messages displayed on the PFD. The numbers correspond to the
 
     This is displayed in red. It appears if the vertical deviation information fails, and the LS pushbutton has not been pressed. This flag replaces the V/DEV scale.
     
-    !!! attention ""
+    !!! info ""
         Currently not available for the FBW A32NX for Microsoft Flight Simulator.
 
 === "16"
@@ -140,7 +140,7 @@ These are flags and messages displayed on the PFD. The numbers correspond to the
 === "21"
     V/DEV Flag (amber)
 
-    !!! attention ""
+    !!! info ""
         Currently not available for the FBW A32nx for Microsoft Flight Simulator.
     
     This is displayed in amber. It flashes on the top of the glide scale when the aircraft is in the approach phase and when either the final mode is armed/engaged or a non ILS approach has been selected, and the LS pushbutton has been selected.
@@ -167,7 +167,7 @@ These are flags and messages displayed on the PFD. The numbers correspond to the
     
     It remains displayed at least 15 seconds after windshear detection and is associated with an aural windshear warning.
     
-    !!! attention ""
+    !!! info ""
         Currently not available for the FBW A32nx for Microsoft Flight Simulator.
 
 === "25"
@@ -177,6 +177,6 @@ These are flags and messages displayed on the PFD. The numbers correspond to the
 
     This is shown when the predictive windshear function has detected a windshear in front of the aircraft.
     
-    !!! attention ""
+    !!! info ""
         Currently not available for the FBW A32nx for Microsoft Flight Simulator.
 

--- a/docs/pilots-corner/a32nx-briefing/pfd/ils-indicator.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/ils-indicator.md
@@ -24,7 +24,7 @@ Most common ones are ILS and RNP-RNAV but depending on aircraft configuration ot
 
 Main features of the approach information are deviation scales for horizontal and vertical path deviation.
 
-!!! attention ""
+!!! info ""
     Currently the FlyByWire A32NX is only capable of ILS approaches. RNP-RNAV will be available once the custom Flight Management System has LNAV and VNAV capabilities.
 
 ## ILS Deviation Scale
@@ -69,7 +69,7 @@ Different audio sounds are played as the aircraft passes over each marker.
 
 This appears to the right of the localiser deviation scale, and flashes amber when the approach mode is armed and the LS display is not selected.
 
-!!! attention ""
+!!! info ""
     Currently not available for the FBW A32NX for Microsoft Flight Simulator
 
 ## Non Precision Approaches
@@ -82,7 +82,7 @@ Each scale graduation represents 100 feet and the range is ± 200 feet. These ar
 
 Note that if the LS pushbutton is pressed, the glide deviation has priority over the vertical deviation information. As long as V/DEV display conditions are met, and the LS pushbutton is selected, an amber V/DEV message flashes above the glide scale.
 
-!!! attention ""
+!!! info ""
     Currently the FlyByWire A32NX is only capable of ILS approaches. RNP-RNAV will be available once the custom Flight Management System has LNAV and VNAV capabilities.
 
 ---

--- a/docs/pilots-corner/a32nx-briefing/pfd/special-message-annunciators.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/special-message-annunciators.md
@@ -69,7 +69,7 @@ Displayed in white when the aircraft is in engine out mode and the speed target 
 - Less than or equal to the green dot speed minus 10kts or
 - Greater than or equal to the green dot speed plus 10kts (except when the aircraft is in ALT\* mode or ALT mode).
 
-!!! attention ""
+!!! info ""
     Currently not available for the FBW A32NX for Microsoft Flight Simulator
 
 ### SET HOLD SPD
@@ -80,7 +80,7 @@ Displayed in white when the aircraft is in selected speed control, a holding pat
 
 Displayed in white if the thrust is not reduced when the aircraft is passing the top of descent point, and the aircraft is above the descent profile.
 
-!!! attention ""
+!!! info ""
     Currently not available for the FBW A32NX for Microsoft Flight Simulator
 
 ### MORE DRAG
@@ -90,7 +90,7 @@ Displayed in white when descent mode is engaged, idle is selected, and:
 - Either the aircraft is above the vertical profile and the predicted intercept point of the profile is at less than 2 nautical miles away from the next altitude constraint or
 - In auto speed control and the aircraft enters a speedbrake decelerating segment.
 
-!!! attention ""
+!!! info ""
     Currently not available for the FBW A32NX for Microsoft Flight Simulator
 
 ### VERT DISCON AHEAD
@@ -100,7 +100,7 @@ Displayed in amber text. Displays when descent mode is engaged and:
 - A vertical path too steep exists on the next leg .
 - The aircraft is less than 30 seconds from a path that is too steep.
 
-!!! attention ""
+!!! info ""
     Currently not available for the FBW A32NX for Microsoft Flight Simulator
 
 ---
@@ -123,7 +123,7 @@ Displayed in green when roll out mode is engaged.
 
 Displayed in green when APP NAV and Final modes are engaged during a non ILS approach.
 
-!!! attention ""
+!!! info ""
     Currently not available for the FBW A32NX for Microsoft Flight Simulator
 
 ---

--- a/docs/pilots-corner/advanced-guides/ice-rain-protection.md
+++ b/docs/pilots-corner/advanced-guides/ice-rain-protection.md
@@ -137,7 +137,7 @@ See also [Anti Ice Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/an
 - IN FLIGHT:  
       - PUSH as required in moderate to heavy rain  
 
-!!! attention ""
+!!! info ""
     RAIN RPLNT is currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator
 
 ### Other Procedures

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,7 +38,7 @@ plugins:
   search:
     lang: en
   # Comment out the plugin below if building docs without an internet connection.
-#  external-markdown: {}
+  external-markdown: {}
   awesome-pages: {}
   tags: {}
   git-revision-date-localized:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,7 +38,7 @@ plugins:
   search:
     lang: en
   # Comment out the plugin below if building docs without an internet connection.
-  external-markdown: {}
+#  external-markdown: {}
   awesome-pages: {}
   tags: {}
   git-revision-date-localized:


### PR DESCRIPTION
## Summary
Noticed in several pages in a32nx-briefing were using the deprecated `!!! attention` admoniition.

- search and replaced with `!!! info`
- qa-process.md page utilized `info` + `warning` admonitions instead when replacing `attention` admonition.

### Location
- repository wide

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
