### PR TITLE
docs(beginner guide): correct apu notes

### DIFF
--- a/docs/pilots-corner/beginner-guide/starting-the-aircraft.md
+++ b/docs/pilots-corner/beginner-guide/starting-the-aircraft.md
@@ -134,7 +134,7 @@ To do this, we simply push on the APU `MASTER SW` and `START`. The APU should be
     - Check A/C Packs are OFF before powering the aircraft
     - Set APU MASTER switch to ON
     - Press APU START 
-        - The APS3200 APU equipped on the A32NX is able to activate the start signal during it's self-test sequence after power-up, so there is no need to wait after pressing the master switch. Some A320s are equipped with a different APU that requires approximately a 3 second wait before the start button becomes operative.
+        - The APS3200 APU equipped on the A32NX is able to activate the start signal during its self-test sequence after power-up, so there is no need to wait after pressing the master switch. Some A320s are equipped with a different APU that requires approximately a 3-second wait before the start button becomes operative.
     - Wait until APU START button shows "AVAIL" (or check on lower ECAM APU page)
     - Wait 1 min (use [CHRONO](../a32nx-briefing/flight-deck/glareshield/warning.md#2-chrono) to time this)
     - Set APU BLEED to ON      

--- a/docs/pilots-corner/beginner-guide/starting-the-aircraft.md
+++ b/docs/pilots-corner/beginner-guide/starting-the-aircraft.md
@@ -134,7 +134,7 @@ To do this, we simply push on the APU `MASTER SW` and `START`. The APU should be
     - Check A/C Packs are OFF before powering the aircraft
     - Set APU MASTER switch to ON
     - Press APU START 
-        - Some airlines still require the pilot to wait 3sec for the APU flap to open. This is no longer required in the A320neo as the startup sequence waits for the flap to be open automatically. 
+        - The APS3200 APU equipped on the A32NX is able to activate the start signal during it's self-test sequence after power-up, so there is no need to wait after pressing the master switch. Some A320s are equipped with a different APU that requires approximately a 3 second wait before the start button becomes operative.
     - Wait until APU START button shows "AVAIL" (or check on lower ECAM APU page)
     - Wait 1 min (use [CHRONO](../a32nx-briefing/flight-deck/glareshield/warning.md#2-chrono) to time this)
     - Set APU BLEED to ON      


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
Correct the explanation regarding the 3 second delay for starting some A320 APUs. This is not a ceo/neo difference, but a difference between the Hamilton-Sundstrand/Pratt & Whitney APS3200 APU, and the Honeywell 131-9A/B APU, both of which are available on ceo and neo.

### Location
<!-- Please provide the original URL of the page modified or directory location here -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
