### PR TITLE
refactor: update developer API external github links

### DIFF
--- a/docs/fbw-a32nx/a32nx-api/lvars-events.md
+++ b/docs/fbw-a32nx/a32nx-api/lvars-events.md
@@ -2,14 +2,14 @@
 
 Flight-Deck API Documentation: [Flight-Deck API](a32nx-flightdeck-api.md)
 
-In addition to the above documentation, all custom variables and custom events are documented by our developers on our project's GitHub: [:fontawesome-brands-github:{: .github } -  **Docs section on GitHub**](https://github.com/flybywiresim/a32nx/tree/master/docs){target=new}
+In addition to the above documentation, all custom variables and custom events are documented by our developers on our project's GitHub: [:fontawesome-brands-github:{: .github } -  **Docs section on GitHub**](https://github.com/flybywiresim/a32nx/tree/master/fbw-a32nx/docs){target=new}
 
 ## Docs:
 
-- [Custom LVARs](https://github.com/flybywiresim/a32nx/blob/master/docs/a320-simvars.md){target=new}
-- [Custom Events](https://github.com/flybywiresim/a32nx/blob/master/docs/a320-events.md){target=new}
+- [Custom LVARs](https://github.com/flybywiresim/a32nx/blob/master/fbw-a32nx/docs/a320-simvars.md){target=new}
+- [Custom Events](https://github.com/flybywiresim/a32nx/blob/master/fbw-a32nx/docs/a320-events.md){target=new}
 
 ## Templates
 
-- **SPAD.neXt:** [flybywire-aircraft-a320-neo.xml](https://github.com/flybywiresim/a32nx/tree/master/docs/SPAD.neXt){target=new}
-- **FSUIPC:** [flybywire-aircraft-a320-neo.evt](https://github.com/flybywiresim/a32nx/tree/master/docs/FSUIPC){target=new}
+- **SPAD.neXt:** [flybywire-aircraft-a320-neo.xml](https://github.com/flybywiresim/a32nx/tree/master/fbw-a32nx/docs/SPAD.neXt){target=new}
+- **FSUIPC:** [flybywire-aircraft-a320-neo.evt](https://github.com/flybywiresim/a32nx/tree/master/fbw-a32nx/docs/FSUIPC){target=new}


### PR DESCRIPTION

## Summary
As reported on Discord, this PR fixes outdated external A32NX repo links after the change to monorepo.

Small change to the "Docs section on GitHub" external link to point to the new `/docs` directory for fbw-a32nx specifically and not the "tree" found on the root of the repository.

### Location
- docs/fbw-a32nx/a32nx-api/lvars-events.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
