### PR TITLE
refactor: add airframe download information to simbrief.md

### DIFF
--- a/docs/fbw-a32nx/feature-guides/simbrief.md
+++ b/docs/fbw-a32nx/feature-guides/simbrief.md
@@ -1,21 +1,22 @@
 # SimBrief Integration
 
-!!! info "SimBrief Airframe"
-    *If you are planning on using our simBrief integration please ensure you have our custom airframe saved to your account.*
+## SimBrief Airframe
 
-    The FlyByWire Simulations simBrief airframe with correct weights is available below. Please select and update your airframe according to the version you are flying.
-    
-    !!! tip ""
-        The airframe below will always be **kept up-to-date** thanks to Navigraph's new sharable airframe feature.
-    
-        Please stay tuned to our social media for updates.
-    
-    - **All Versions**: ✈ [SimBrief Airframe Link](https://www.simbrief.com/system/dispatch.php?sharefleet=337364_1631550522735){target=new} - Credits: [@sidnov](https://github.
-      com/sidnov){target=new}
-    
-    Pilot ID can be found in the Optional Entries section of the Dispatch Options page.
-    
-    To learn how to use the various features related to our simBrief integration see the page below.
+*If you are planning on using our simBrief integration please ensure you have our custom airframe saved to your account.*
+
+The FlyByWire Simulations simBrief airframe with correct weights is available below. Please select and update your airframe according to the version you are flying.
+
+!!! tip ""
+    The airframe below will always be **kept up-to-date** thanks to Navigraph's new sharable airframe feature.
+
+    Please stay tuned to our social media for updates.
+
+- **All Versions**: ✈ [SimBrief Airframe Link](https://www.simbrief.com/system/dispatch.php?sharefleet=337364_1631550522735){target=new} - Credits: [@sidnov](https://github.
+  com/sidnov){target=new}
+
+Pilot ID can be found in the Optional Entries section of the Dispatch Options page.
+
+To learn how to use the various features related to our simBrief integration see the page below.
 
 ## Flight Planning
 

--- a/docs/fbw-a32nx/feature-guides/simbrief.md
+++ b/docs/fbw-a32nx/feature-guides/simbrief.md
@@ -1,5 +1,22 @@
 # SimBrief Integration
 
+!!! info "SimBrief Airframe"
+    *If you are planning on using our simBrief integration please ensure you have our custom airframe saved to your account.*
+
+    The FlyByWire Simulations simBrief airframe with correct weights is available below. Please select and update your airframe according to the version you are flying.
+    
+    !!! tip ""
+        The airframe below will always be **kept up-to-date** thanks to Navigraph's new sharable airframe feature.
+    
+        Please stay tuned to our social media for updates.
+    
+    - **All Versions**: ✈ [SimBrief Airframe Link](https://www.simbrief.com/system/dispatch.php?sharefleet=337364_1631550522735){target=new} - Credits: [@sidnov](https://github.
+      com/sidnov){target=new}
+    
+    Pilot ID can be found in the Optional Entries section of the Dispatch Options page.
+    
+    To learn how to use the various features related to our simBrief integration see the page below.
+
 ## Flight Planning
 
 Flying IFR (Instrument Flight Rules) even in a simulation like Microsoft Flight Simulator always requires some level of flight planning.

--- a/docs/fbw-a32nx/installation.md
+++ b/docs/fbw-a32nx/installation.md
@@ -239,19 +239,6 @@ More info [A32NX Development Overview](../dev-corner/dev-guide/index.md)
 
 ## SimBrief Airframe
 
-The FlyByWire Simulations simBrief airframe with correct weights is available below. Please select and update your airframe according to the version you are flying.
-
-!!! info ""
-    The airframe below will always be **kept up-to-date** thanks to Navigraph's new sharable airframe feature.
-
-    Please stay tuned to our social media for updates.
-
-- **All Versions**: ✈ [SimBrief Airframe Link](https://www.simbrief.com/system/dispatch.php?sharefleet=337364_1631550522735){target=new} - Credits: [@sidnov](https://github.
-  com/sidnov){target=new}
-
-Pilot ID can be found in the Optional Entries section of the Dispatch Options page.
-
-To learn how to use the various features related to our simBrief integration see the page below.
-
 [SimBrief Integration Guide](feature-guides/simbrief.md){.md-button}
 
+We have moved this information to the location above.


### PR DESCRIPTION
closes #733

## Summary
Provides an onpage description on installation.md that the information has moved to simbrief.md

The airframe information now resides at the top of the simbrief page to make it easier to find and consolidated with the rest of the simbrief integration information.

### Location
- docs/fbw-a32nx/feature-guides/simbrief.md
- docs/fbw-a32nx/installation.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
