### PR TITLE
fix: correct link on gsx overview

### DIFF
--- a/docs/fbw-a32nx/feature-guides/gsxintegration/index.md
+++ b/docs/fbw-a32nx/feature-guides/gsxintegration/index.md
@@ -47,10 +47,5 @@ The addon comes with a developer-configured GSX profile. Please refer to [here](
 |                      Quick Links                       |
 |:------------------------------------------------------:|
 |            [Payload](payload.md)                       |
-|             [Fuel](fuel.md)                         |
+|             [Fuel](fuel.md)                            |
 |               [Profile](profile.md)                    |
-
-
-
-
-

--- a/docs/fbw-a32nx/feature-guides/gsxintegration/index.md
+++ b/docs/fbw-a32nx/feature-guides/gsxintegration/index.md
@@ -47,7 +47,7 @@ The addon comes with a developer-configured GSX profile. Please refer to [here](
 |                      Quick Links                       |
 |:------------------------------------------------------:|
 |            [Payload](payload.md)                       |
-|             [Fuel](payload.md)                         |
+|             [Fuel](fuel.md)                         |
 |               [Profile](profile.md)                    |
 
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
Corrected the link to the fuel page on the gsx overview page
### Location
<!-- Please provide the original URL of the page modified or directory location here -->
https://docs.flybywiresim.com/fbw-a32nx/feature-guides/gsxintegration/?h=gsx
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):Slein#8982
