### PR TITLE
feat: remote simbridge documentation

### DIFF
--- a/docs/simbridge/index.md
+++ b/docs/simbridge/index.md
@@ -23,13 +23,14 @@ require fewer extra steps before launching into your flights.
 
 ## Feature Guides
 
-|                                       Feature                                       |                                         Status                                          |
-|:-----------------------------------------------------------------------------------:|:---------------------------------------------------------------------------------------:|
-|               [Terrain Display](simbridge-feature-guides/terrain.md)                | In [Development](../fbw-a32nx/fbw-versions.md#development-version-recommended) Version  |
-|   [MCDU Remote Display](simbridge-feature-guides/remote-displays/remote-mcdu.md)    |                Available in [All Versions](../fbw-a32nx/fbw-versions.md)                |
-|            [Company Routes Support](simbridge-feature-guides/coroute.md)            |                Available in [All Versions](../fbw-a32nx/fbw-versions.md)                |
-| [flyPad Local Charts](../fbw-a32nx/feature-guides/flypados3/charts.md#local-files)  |                Available in [All Versions](../fbw-a32nx/fbw-versions.md)                |
-|                                   Remote Displays                                   |                                    Work in Progress                                     |
+|                                      Feature                                       |                                          Status                                          |
+|:----------------------------------------------------------------------------------:|:----------------------------------------------------------------------------------------:|
+|               [Terrain Display](simbridge-feature-guides/terrain.md)               |  In [Development](../fbw-a32nx/fbw-versions.md#development-version-recommended) Version  |
+|   [MCDU Remote Display](simbridge-feature-guides/remote-displays/remote-mcdu.md)   |                Available in [All Versions](../fbw-a32nx/fbw-versions.md)                 |
+|           [Company Routes Support](simbridge-feature-guides/coroute.md)            |                Available in [All Versions](../fbw-a32nx/fbw-versions.md)                 |
+| [flyPad Local Charts](../fbw-a32nx/feature-guides/flypados3/charts.md#local-files) |                Available in [All Versions](../fbw-a32nx/fbw-versions.md)                 |
+|                                  Remote Displays                                   |                                     Work in Progress                                     |
+|                                  Remote SimBridge                                  |  In [Development](../fbw-a32nx/fbw-versions.md#development-version-recommended) Version  |
 
 !!! warning "Important Notes"
     Please keep SimBridge updated at all times regardless of the version of aircraft you are currently flying!

--- a/docs/simbridge/simbridge-feature-guides/.pages
+++ b/docs/simbridge/simbridge-feature-guides/.pages
@@ -4,3 +4,4 @@ nav:
     - Terrain Display: terrain.md
     - Company Routes: coroute.md
     - Local Files: local-files.md
+    - Remote SimBridge: remote-simbridge.md

--- a/docs/simbridge/simbridge-feature-guides/remote-simbridge.md
+++ b/docs/simbridge/simbridge-feature-guides/remote-simbridge.md
@@ -2,6 +2,12 @@
 
 This guide details how to run SimBridge on a remote machine and connect to it from your local machine (where your simulator is running).
 
+!!! warning "For Advanced Users"
+    This guide is intended for advanced users who are familiar with networking and have a good understanding of how to configure their network to allow remote connections. If you are not familiar with networking, we recommend you do not attempt to follow this guide.
+
+    While the benefits of running SimBridge on an external machine are few it would allow to users offload some resources from your local machine. If you encounter any issues please resort to this 
+    guide or use SimBridge on your local machine (the same one with MSFS running). Contact our Discord support if you do wish to troubleshoot this feature.
+
 ## PC Requirements
 
 - FlyByWire Installer running on the remote machine - See [Starting SimBridge](../install-configure/start-simbridge.md)
@@ -10,3 +16,9 @@ This guide details how to run SimBridge on a remote machine and connect to it fr
 ## Simulator Requirements
 
 [WIP]
+
+## Troubleshooting
+
+[WIP]
+
+## Known Issues (section may not be required) [WIP]

--- a/docs/simbridge/simbridge-feature-guides/remote-simbridge.md
+++ b/docs/simbridge/simbridge-feature-guides/remote-simbridge.md
@@ -1,0 +1,12 @@
+# Remote SimBridge
+
+This guide details how to run SimBridge on a remote machine and connect to it from your local machine (where your simulator is running).
+
+## PC Requirements
+
+- FlyByWire Installer running on the remote machine - See [Starting SimBridge](../install-configure/start-simbridge.md)
+- SimBridge running on the remote machine - See [Starting SimBridge](../install-configure/start-simbridge.md)
+
+## Simulator Requirements
+
+[WIP]


### PR DESCRIPTION
closes: #739

## Summary

Adds a new feature to the list of feature guides on SimBridge's main page.

Page describes how to utilize SimBridge on an external machine and any caveats / troubleshooting required. 

## TODO

- [ ] Add relevant images
- [ ] Fill out WIP sections
- [ ] Extra guide to find local IP address `/ipconfig` -> should be simple


### Location
-  docs/simbridge/simbridge-feature-guides/remote-simbridge.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
