### PR TITLE
build: bump mkdocs-material 9.0.13

### DIFF
--- a/docs/dev-corner/dev-guide/resources.md
+++ b/docs/dev-corner/dev-guide/resources.md
@@ -12,7 +12,8 @@ The Development version of the FlyByWire A32NX is done in the master branch. Whe
 
 The Stable version is a snapshot (in git terms a [Tag](https://github.com/flybywiresim/a32nx/tags){target=new}) of the development branch.
 
-The experimental version is built in the branch [experimental](https://github.com/flybywiresim/a32nx/tree/experimental){target=new}. It is regularly manually updated with the latest commits from the master branch, but its focus is on the development of special larger features like the custom fly-by-wire and autopilot system or the custom flight management system (cFMS).
+The experimental version is built in the branch [experimental](https://github.com/flybywiresim/a32nx/tree/experimental){target=new}. It is regularly manually updated with the latest commits from 
+the master branch but its focus is on the development of special larger features like the custom fly-by-wire and autopilot system or the custom flight management system (cFMS).
 
 While the development on the master branch (Development version) follows a very strict development, review and QA process, the development in the experimental branch is less strict and developers can relatively freely commit changes. This is why the Experimental version has a higher risk of bugs and issues and is only meant for testing and not supported on Discord.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@ mkdocs-redirects
 mkdocs-embed-external-markdown
 mkdocs-video
 mkdocs-glightbox
-mike
 pillow
 cairosvg

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.0.6
+mkdocs-material==9.0.13
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
Minor fixes included from upstream with the notable ones listed below:

- Improved discernibility of table row hover color
- Header title not reset when using instant loading
- Anchor following doesn't bring last item into view

Removed `mike` dependency from requirements as versioning of documentation isn't being attempted any longer.

Minor grammar fix in resources.md in development corner

### Location
- requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
