### PR TITLE
test: add simbridge label to labeler.yml action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,5 +13,8 @@ feature guide:
 support:
   - docs/fbw-a32nx/support/*
 
+simbridge:
+  - docs/simbridge/*
+
 repo:
   - '*'


### PR DESCRIPTION
## Summary
Adds the simbridge label to the labelling automation for better visibility in PR list

### Location
- .github/labeler.yml

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
