### PR TITLE
feat: reinstate instant loading

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,8 +24,7 @@ theme:
   features:
     - navigation.tabs
     - navigation.tabs.sticky
-    # Temporarily deactivated to provide support for Discord browser + anchor links
-    # - navigation.instant
+    - navigation.instant
     - navigation.top
     - navigation.tracking
     - search.suggest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.0.13
+mkdocs-material==9.1.1
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.0.6
+mkdocs-material==9.0.13
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary
Uncomments the `navigation.instant` feature in our config to enable instant loading across the site potentially saving bandwidth with the size of our documentation.

### Original Issue

An inherent problem from before is that anchor links to sections clicked on from Discord do not take you to the relevant section on page.

### Benefit

The largest benefit is stated from the mkdocs-material documentation:

> The resulting page is parsed and injected and all event handlers and components are rebound automatically, i.e., Material for MkDocs now behaves like a Single Page Application. Now, the search index survives navigation, which is especially useful for large documentation sites.

### Testing

Requires some testing to see if the original Issue persists but probably the small issue would be outweighed by the performance benefits.

See Discord comment in docs channel [link here](#) for the links for testing.

If reporting testing please provide the following:

```
Device Type + OS: iPhone iOS 16
Browser Used: Chrome / Safari
Arrived at Section on Page: Yes/No
```

### Location
- mkdocs.yml

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
