### PR TITLE
docs(livery): return livery conversion info into dev-corner

### DIFF
--- a/docs/dev-corner/livery-conversion.md
+++ b/docs/dev-corner/livery-conversion.md
@@ -1,4 +1,4 @@
-# Manual Livery Conversion
+# Converting Liveries Manually
 
 !!! warning "Disclaimer"
 

--- a/docs/dev-corner/livery-conversion.md
+++ b/docs/dev-corner/livery-conversion.md
@@ -10,6 +10,9 @@
     We recommend to **not** converting old liveries. Many liveries for the Asobo A320, especially the ones from livery collections are often very old, low quality and not maintained. They 
     may cause a number of issues and can even lead to CTDs (crash to desktop).
 
+    !!! info ""
+        We instead suggest downloading compatible liveries from [flightsim.to](https://flightsim.to/c/liveries/flybywire-a32nx/most-downloaded){target=new}.
+
 To manually convert a livery made for the default A320neo to work with the new FBW A32NX, you have to edit three files in that livery's folder.
 
 !!! info "Step One"

--- a/docs/dev-corner/livery-conversion.md
+++ b/docs/dev-corner/livery-conversion.md
@@ -1,0 +1,44 @@
+# Manual Livery Conversion
+
+!!! warning "Disclaimer"
+
+    This guide is provided with no guarantee of compatibility and meant for the conversion of liveries for personal use.
+
+    **No support will be provided**
+
+!!! danger "Risk of Convert Liveries"
+    We recommend to **not** converting old liveries. Many liveries for the Asobo A320, especially the ones from livery collections are often very old, low quality and not maintained. They 
+    may cause a number of issues and can even lead to CTDs (crash to desktop).
+
+To manually convert a livery made for the default A320neo to work with the new FBW A32NX, you have to edit three files in that livery's folder.
+
+!!! info "Step One"
+
+    Open the aircraft.cfg in `..\SimObjects\AirPlanes\NAME_OF_THE_LIVERY\`
+
+    The following lines should look like this:
+
+        base_container = "..\FlyByWire_A320_NEO"
+        ui_type = "A320neo (LEAP)"
+        ui_manufacturer = "FlyByWire Simulations"
+
+!!! info "Step Two"
+
+    Open the texture.cfg in `..\SimObjects\AirPlanes\NAME_OF_THE_LIVERY\TEXTURE.XXX`
+
+    There's a fallback which points to the Asobo A320. It should now look like this:
+
+        fallback.X=..\..\FlyByWire_A320_NEO\TEXTURE
+
+    (X = the number of the fallback)
+
+!!! info "Step Three"
+
+    Open the model.cfg in `..\SimObjects\AirPlanes\NAME_OF_THE_LIVERY\MODEL.XXX`
+
+    The two model lines should look like this:
+
+        exterior=../../FlyByWire_A320_NEO/model/A320_NEO.xml
+        interior=../../FlyByWire_A320_NEO/model/A320_NEO_INTERIOR.xml
+
+Ready to go! Launch the sim and see if it worked.

--- a/docs/fbw-a32nx/liveries.md
+++ b/docs/fbw-a32nx/liveries.md
@@ -8,3 +8,16 @@ In version 3.0.0 of the FlyByWire Installer we removed the capability to convert
 
 !!! warning "Always Keep Liveries Up-to-Date"
     Our recommendation is to download the dedicated FlyByWire liveries and also to keep the liveries up to date by regularly updating especially when a patch to MSFS is released. This is important as liveries are one of the main cause for issues and CTD (crash to desktop).
+
+## Manual Livery Conversion
+
+??? warning "Disclaimer"
+    This guide is provided with no guarantee of compatibility and meant for the conversion of liveries for personal use.
+
+    **No support will be provided**
+
+??? danger "Risk of Convert Liveries"
+    We recommend to **not** converting old liveries. Many liveries for the Asobo A320, especially the ones from livery collections are often very old, low quality and not maintained. They 
+    may cause a number of issues and can even lead to CTDs (crash to desktop).
+
+If you have read the above two warnings and still want to convert a livery, please head to our conversion guide in the [Developer Corner](../dev-corner/livery-conversion.md).

--- a/docs/fbw-a32nx/liveries.md
+++ b/docs/fbw-a32nx/liveries.md
@@ -9,7 +9,7 @@ In version 3.0.0 of the FlyByWire Installer we removed the capability to convert
 !!! warning "Always Keep Liveries Up-to-Date"
     Our recommendation is to download the dedicated FlyByWire liveries and also to keep the liveries up to date by regularly updating especially when a patch to MSFS is released. This is important as liveries are one of the main cause for issues and CTD (crash to desktop).
 
-## Manual Livery Conversion
+## Want to Convert a Livery?
 
 ??? warning "Disclaimer"
     This guide is provided with no guarantee of compatibility and meant for the conversion of liveries for personal use.

--- a/docs/fbw-a32nx/liveries.md
+++ b/docs/fbw-a32nx/liveries.md
@@ -1,3 +1,8 @@
+---
+search:
+    boost: 2
+---
+
 # Liveries Guide
 
 Best source for liveries for the FlyByWire A32NX is [FBW A32NX @ flightsim.to](https://flightsim.to/c/liveries/flybywire-a32nx/most-downloaded){target=new}.
@@ -9,7 +14,7 @@ In version 3.0.0 of the FlyByWire Installer we removed the capability to convert
 !!! warning "Always Keep Liveries Up-to-Date"
     Our recommendation is to download the dedicated FlyByWire liveries and also to keep the liveries up to date by regularly updating especially when a patch to MSFS is released. This is important as liveries are one of the main cause for issues and CTD (crash to desktop).
 
-## Want to Convert a Livery?
+## Want to Convert Liveries?
 
 ??? warning "Disclaimer"
     This guide is provided with no guarantee of compatibility and meant for the conversion of liveries for personal use.


### PR DESCRIPTION
## Summary

[Courtesy Link](https://docs-git-fork-valastiri-return-livery-guide-flybywire.vercel.app/dev-corner/livery-conversion/) for testing instructions on manual conversion.

As requested by tracernz - returns the manual livery conversion to the documentation. It is now located within the dev-corner pages. 

There are a few caveats from why we removed it and those are stated in two rather prominent admonitions.  There may be support load attached to this if the CTD issue is still quite in fact a thing.

On the liveries page in `fbw-a32nx` a h2 was created with the admonitions and a link to the actual manual liveries conversion page in dev corner.

- Added a search boost to the liveries.md page to make it appear above manual conversion when searched for `livery`

### Location
- docs/dev-corner/livery-conversion.md
- docs/fbw-a32nx/liveries.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
