### PR TITLE
fix: Flight Plan Redirect from "Enter flightplan manually"

### DIFF
--- a/docs/fbw-a32nx/feature-guides/flight-planning.md
+++ b/docs/fbw-a32nx/feature-guides/flight-planning.md
@@ -38,7 +38,7 @@ flight planning in the Multipurpose Control and Display Unit (MCDU).
 In the A32NX for Microsoft Flight Simulator, we have these options to load a flight plan:
 
 !!! tip ""
-    - [Entering a Flight Plan Manually](../../pilots-corner/beginner-guide/preparing-mcdu.md#--f---light-plan)
+    - [Entering a Flight Plan Manually](../../pilots-corner/beginner-guide/preparing-mcdu.md#flight-plan)
     - [Loading a Flight Plan from SimBrief](simbrief.md) (recommended)
     - [Creating and Loading a Flight Plan from the MSFS World Map](#msfs-world-map-flight-planning-atc-and-vfr-map)
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->

### Location
https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flight-planning/#loading-a-flight-plan-in-the-a32nx
![image](https://user-images.githubusercontent.com/66401072/225398171-c1cf3d2d-524c-4438-8db3-10f70f1128f1.png)

<!-- Please provide the original URL of the page modified or directory location here -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
