### PR TITLE
fix: ADIR page warning change

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs.md
@@ -8,7 +8,7 @@
 
 !!! warning ""
 
-    Please note: The labels should say "ADR" rather than "ADIR". This will be fixed in a future update.
+    Please note: The labels under the rotary switches should say "ADR" rather than "ADIR". This will be fixed in a future update.
 
 ![ADIRS Panel](../../../assets/a32nx-briefing/overhead-panel/ADIRS.jpg "ADIRS Panel")
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs.md
@@ -8,7 +8,7 @@
 
 !!! warning ""
 
-    Please note: It should say "ADR" rather than "ADIR". This will be fixed in a future update.
+    Please note: The labels should say "ADR" rather than "ADIR". This will be fixed in a future update.
 
 ![ADIRS Panel](../../../assets/a32nx-briefing/overhead-panel/ADIRS.jpg "ADIRS Panel")
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs.md
@@ -8,7 +8,7 @@
 
 !!! warning ""
 
-    Please note: Currently the ADIRS are labeled ADIR 1, 3 and 2 which is incorrect. They should be labeled ADIR 1, 2 and 3. This will be fixed in a future update.
+    Please note: It should say "ADR" rather than "ADIR". This will be fixed in a future update.
 
 ![ADIRS Panel](../../../assets/a32nx-briefing/overhead-panel/ADIRS.jpg "ADIRS Panel")
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
Statement " ADIR 1, 3 and 2 which is incorrect" is incorrect, 1 - 3 - 2 layout is correct, however, it should asy ADR instead of ADIR, changed the warning message to "It should say "ADR" rather than "ADIR". This will be fixed in a future update."

Source: 
Asked tolip for confirmation of 1-3-2 layout
(https://discord.com/channels/738864299392630914/887806920252076053/1086268617714315365)

multiple devs notified me that it should say ADR rather than ADIR (https://discord.com/channels/738864299392630914/791494566058000434/1086268828322898021)
(https://discord.com/channels/738864299392630914/887806920252076053/1086272032481751160)
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->

### Location
/pilots-corner/a32nx-briefing/flight-deck/ovhd/adirs/
<!-- Please provide the original URL of the page modified or directory location here -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
