### PR TITLE
fix: vercel builds failing empty index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,3 +4,5 @@ hide:
     - navigation
     - toc
 ---
+
+Welcome to FlyByWire Simulations documentation hub.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 template: home.html
+title: FlyByWire Simulations Documentation
 hide:
     - navigation
     - toc


### PR DESCRIPTION
## Summary
```
ERROR    -  Error reading page 'index.md': Document is empty

...

lxml.etree.ParserError: Document is empty
Error: Command "mkdocs build --config-file production.yml" exited with 1
BUILD_UTILS_SPAWN_1: Command "mkdocs build --config-file production.yml" exited with 1
```

Vercel is failing to build the documentation with only front matter on the index.md file.

Added a title to the meta and some basic text to the document.

### Location
- docs/index.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
