### PR TITLE
fix: section anchors not working

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,5 @@
 ---
 template: home.html
-title: FlyByWire Simulations Documentation
 hide:
     - navigation
     - toc

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ theme:
   features:
     - navigation.tabs
     - navigation.tabs.sticky
+    # Removed this feature again as it's breaking TOC navigation on reported-issues.md
 #    - navigation.instant
     - navigation.top
     - navigation.tracking

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,7 @@ theme:
   features:
     - navigation.tabs
     - navigation.tabs.sticky
-    - navigation.instant
+#    - navigation.instant
     - navigation.top
     - navigation.tracking
     - search.suggest


### PR DESCRIPTION
## Summary
PR fixes section anchors not working on certain browsers

### Testing

- [x] Firefox
- [x] Safari
- [x] Mobile Devices (Multi-browser)

### Location
- docs/index.md
- mkdocs.yml

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
