### PR TITLE
build: bump mkdocs-material -> 9.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.1.1
+mkdocs-material==9.1.3
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary
Includes the following notable fixes from upstream mkdocs-material:

- Fixed #5198: Built-in search plugin not filtering script and style tags
- Fixed #5176: Back-to-top + instant loading not working (9.1.1 regression)

### Location
- requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
