### PR TITLE
refactor: admonitions in audio.md

### DIFF
--- a/docs/fbw-a32nx/feature-guides/audio.md
+++ b/docs/fbw-a32nx/feature-guides/audio.md
@@ -12,7 +12,7 @@ For information on the other settings available on the EFB, visit our [flyPad Se
 
 ## Passenger Simulation
 
-!!! important "Cockpit Door"
+!!! warning "Cockpit Door"
     The cockpit door in the A32NX simulates a real A320 cockpit door, which in consequence dampens most of the sounds from the passenger cabin. 
 
     If you want to enjoy the Passenger Ambience sounds, make sure it is open.
@@ -27,7 +27,7 @@ If this setting is enabled, the following ambience sounds are played:
 
 ### Announcements
 
-!!! important "Customizations"
+!!! warning "Customizations"
     Due to limitations with MSFS audio configurations, adding user customizable announcements/sounds is not easily possible.
 
 If this setting is enabled, the following crew announcements are played.


### PR DESCRIPTION
fixes #766 

## Summary
Admonitions are not styled correctly in audio.md -- it is using a deprecated admonition.

## Examples

Current:

<img width="901" alt="Screenshot 2023-03-22 at 2 39 30 PM" src="https://user-images.githubusercontent.com/1619968/226893316-830f05be-a264-4973-8e0a-57e263b230da.png">

New:

<img width="815" alt="Screenshot 2023-03-22 at 2 39 19 PM" src="https://user-images.githubusercontent.com/1619968/226893343-a6bc3f8c-2eb5-465b-85ba-84f713afac1c.png">

### Location
- docs/fbw-a32nx/feature-guides/audio.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
