### PR TITLE
docs(disco): change styling of documentation

### DIFF
--- a/docs/pilots-corner/advanced-guides/flight-planning/disco.md
+++ b/docs/pilots-corner/advanced-guides/flight-planning/disco.md
@@ -26,8 +26,10 @@ There are basically two types of discontinuities:
 
 ## Discontinuities Between Waypoints
 
-These discontinuities <span style=color:red>should not</span> be cleared from the flight plan in normal operations. Typically, you will notice a discontinuity in the following 
-instances:
+!!! warning ""
+    These discontinuities **should not** be cleared from the flight plan in normal operations.
+
+Typically, you will notice a discontinuity in the following instances:
 
 - Between the SID and the rest of your route.
 - Between the STAR and the selected approach.


### PR DESCRIPTION
## Summary
As indicated by Holland, the red span styling found in the discontinuity page does not meet contrast guidelines and may be hard to read accessibility wise.

Transitioned the specific phrase to be wrapped in the admonition modal without a title and instead of using `<span>` made the "should not" text bold. 

### Location
- docs/pilots-corner/advanced-guides/flight-planning/disco.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
