### PR TITLE
build: bump mkdocs-material -> 9.1.5

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,7 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     # Removed this feature again as it's breaking TOC navigation on reported-issues.md
-#    - navigation.instant
+    - navigation.instant
     - navigation.top
     - navigation.tracking
     - search.suggest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.1.1
+mkdocs-material==9.1.5
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary
Bumps version to 9.1.5 and brings back `navigation.instant` as the anchor texts nested within admonitions now navigates properly when clicked on in the TOC.

- PR feat: return of `navigation.instant`

### Upstream Fixes

9.1.4
- Instant loading breaks anchors in details (9.1.1 regression)

9.1.5 
- Footer previous/next labels cut-off for short page titles


### Location
- requirements.txt
- mkdocs.yml

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902