### PR TITLE
refactor: back to top button css

### DIFF
--- a/docs/stylesheets/navigation.css
+++ b/docs/stylesheets/navigation.css
@@ -11,9 +11,7 @@
 }
 .md-top {
   color: #ffffff;
-}
-.md-top {
-  color: #ffffff;
+  background-color: #1F2A3C;
 }
 .md-tabs__link--active, .md-tabs__link:focus, .md-tabs__link:hover {
   border-bottom: 1.5px solid #00E0FE;


### PR DESCRIPTION
## Summary
Remove duplicate css for the back top button and change the background color to be our FBW Light Navy to provide slightly better visibility.

### Location
- docs/stylesheets/navigation.css

**Before**
<img width="817" alt="Screenshot 2023-03-31 at 5 25 42 PM" src="https://user-images.githubusercontent.com/1619968/229148365-6b28f6a0-9985-4baa-b411-205e3b959697.png">

**After**
<img width="943" alt="Screenshot 2023-03-31 at 5 26 04 PM" src="https://user-images.githubusercontent.com/1619968/229148395-ed2039f5-5ad4-437c-b4c1-a0611e830e99.png">


<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
