### PR TITLE
fix: updated broken links

### DIFF
--- a/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -212,7 +212,7 @@ Flight Deck: [APU Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/apu
 | START     | A32NX_OVHD_APU_START_PB_IS_ON         | 0&#124;1 | R/W        | Custom LVAR |        |
 |           | A32NX_OVHD_APU_START_PB_IS_AVAILABLE  | 0&#124;1 | R          | Custom LVAR |        |
 
-!!! note "Search for APU in our [list for all Custom LVARS](https://github.com/flybywiresim/a32nx/blob/master/docs/a320-simvars.md){target=new} for further variables."
+!!! note "Search for APU in our [list for all Custom LVARS](https://github.com/flybywiresim/a32nx/blob/master/fbw-a32nx/docs/a320-simvars.md){target=new} for further variables."
 
 ### RCDR Panel
 

--- a/docs/fbw-a32nx/feature-guides/autopilot-fbw.md
+++ b/docs/fbw-a32nx/feature-guides/autopilot-fbw.md
@@ -210,7 +210,7 @@ The recommendation is to use a combination of default events and the custom even
 
 You can grab the required files with the links below.
 
-[:fontawesome-brands-github:{: .github } FSUIPC Event File](https://github.com/flybywiresim/a32nx/tree/master/docs/FSUIPC){ .md-button target=new} [:fontawesome-brands-github:{: .github } SPAD.neXt Profile](https://github.com/flybywiresim/a32nx/tree/master/docs/SPAD.neXt){ .md-button target=new}
+[:fontawesome-brands-github:{: .github } FSUIPC Event File](https://github.com/flybywiresim/a32nx/tree/master/fbw-a32nx/docs/FSUIPC){ .md-button target=new} [:fontawesome-brands-github:{: .github } SPAD.neXt Profile](https://github.com/flybywiresim/a32nx/tree/master/fbw-a32nx/docs/SPAD.neXt){ .md-button target=new}
 
 ***
 
@@ -276,7 +276,7 @@ You can grab the required files with the links below.
 
 The following gives an overview of the used variables in relation to the FCU. For a more detailed explanation of the values, please refer to this page:
 
-[:fontawesome-brands-github:{: .github } SimVars Documentation](https://github.com/flybywiresim/a32nx/blob/master/docs/a320-simvars.md){ .md-button }
+[:fontawesome-brands-github:{: .github } SimVars Documentation](https://github.com/flybywiresim/a32nx/blob/master/fbw-a32nx/docs/a320-simvars.md){ .md-button }
 
 ##### Common
 


### PR DESCRIPTION
## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->

Fixed a few hyperlinks to correctly point to the a320-simvars, FSUIPC and SPAD.neXt Profile file accomodating changes from a recent repository restructure.

### Location
<!-- Please provide the original URL of the page modified or directory location here -->

[https://docs.flybywiresim.com/fbw-a32nx/a32nx-api/a32nx-flightdeck-api/](https://docs.flybywiresim.com/fbw-a32nx/a32nx-api/a32nx-flightdeck-api/)

https://docs.flybywiresim.com/fbw-a32nx/feature-guides/autopilot-fbw/

Discord username (if different from GitHub): nonsen5e#1713