### PR TITLE
docs: change for AP2 SOP

### DIFF
--- a/docs/pilots-corner/advanced-guides/flight-guidance/autoland.md
+++ b/docs/pilots-corner/advanced-guides/flight-guidance/autoland.md
@@ -116,7 +116,7 @@ Minima:
 - An autoland procedure is very similar to a normal ILS approach and landing
 - Follow the Beginner Guide procedure until the end of this [chapter](../../beginner-guide/landing.md#3-preparation-and-checklist-for-landing)
 - Instead of what is described in the [Beginner Guide for manual landing](../../beginner-guide/landing.md#4-landing) 
-  you will not deactivate the Autopilot AP1 but instead you will activate the AP2 
+  you will not deactivate the Autopilot AP1 but instead you will activate the AP2 if you haven't done so already when activating APPR FCU Mode.
 
 ### FMA Annunciations
 

--- a/docs/pilots-corner/advanced-guides/flight-guidance/autoland.md
+++ b/docs/pilots-corner/advanced-guides/flight-guidance/autoland.md
@@ -116,7 +116,7 @@ Minima:
 - An autoland procedure is very similar to a normal ILS approach and landing
 - Follow the Beginner Guide procedure until the end of this [chapter](../../beginner-guide/landing.md#3-preparation-and-checklist-for-landing)
 - Instead of what is described in the [Beginner Guide for manual landing](../../beginner-guide/landing.md#4-landing) 
-  you will not deactivate the Autopilot AP1 but instead you will activate the AP2 if you haven't done so already when activating APPR FCU Mode.
+  you will not deactivate the Autopilot AP1 but instead you will activate the AP2 if you haven't done so already when activating APPR mode on the FCU.
 
 ### FMA Annunciations
 

--- a/docs/pilots-corner/beginner-guide/landing.md
+++ b/docs/pilots-corner/beginner-guide/landing.md
@@ -83,7 +83,7 @@ To intercept the ILS Localizer we follow these steps:
 
     ![VFE for next configuration](../assets/beginner-guide/landing/PFD-Speed-band-flaps-marker.png "VFE for next configuration"){loading=lazy}
 
-- Turn on `APPR` in the `FCU` to command the aircraft to intercept the ILS localizer. The aircraft will keep the current heading until the localizer is captured and guides the aircraft towards the runway. The `lateral ILS localizer scale` shows the `deviation marker` moving towards the middle of the `lateral deviation scale`. Also the lateral `FMA` shows `LOC` in blue (armed).
+- Turn on `APPR` in the `FCU` to command the aircraft to intercept the ILS localizer. The aircraft will keep the current heading until the localizer is captured and guides the aircraft towards the runway. The `lateral ILS localizer scale` shows the `deviation marker` moving towards the middle of the `lateral deviation scale`. Also the lateral `FMA` shows `LOC` in blue (armed). Usually AP2 is turned on at this point to have a redundancy on the approach, for the sake of this guide you can leave it off.
 
     ![Activate APPR mode on FCU](../assets/beginner-guide/landing/FCU-ILS-APPR.png "Activate APPR mode on FCU"){loading=lazy}
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
The current wording in the guide is to vague about AP2 activation, omitting that it's actually SOP to turn it on durin ILS approach regardless of Intention to Autoland. Minor Changes were made to the docs to reflect this, and educate people better about the role of AP2 on Approach
### Location
<!-- Please provide the original URL of the page modified or directory location here -->
https://docs.flybywiresim.com/pilots-corner/beginner-guide/landing/
https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/autoland/
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
