### PR TITLE
fix: added entry for temperature unit on the COND ECAM Page

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/ecam/sd/cond.md
+++ b/docs/pilots-corner/a32nx-briefing/ecam/sd/cond.md
@@ -21,4 +21,5 @@
 |        |                                   | Amber crossline | The pushbutton is OFF and the valve is closed, or the valve is not coordinated with the control position. |
 |        |                                   | Green inline    | The valve is open.                                                                                        |
 |        |                                   | Amber inline    | The valve is open, but it is not coordinated with the control position.                                   |
+| 7      | Temperature unit                  | Green number    | The unit of temperature indications.                                                                      |             
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
The docs for ECAM COND contain an image with a label "7", the explenation below omits number 7, this is now fixed
### Location
<!-- Please provide the original URL of the page modified or directory location here -->
https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/ecam/sd/cond/
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
