### PR TITLE
docs(api): adjust pump toggle values

### DIFF
--- a/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -266,19 +266,24 @@ Flight Deck: [Fire Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/fi
 
 Flight Deck: [Fuel Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/fuel.md)
 
-!!! note "The below table shows the API for PUMP 1. Replace `1` with `2..6` for the other pumps."
-    L1=2, L2=5. C1=1, C2=4, R1=3, R2=6
+!!! note "The below table shows the API for PUMP 1. Replace with appropriate value for the other pumps."
+    L1=2, L2=5. C1=9, C2=10, R1=3, R2=6
 
-| Function    | API Usage                 | Values   | Read/Write | Type       | Remark |
-|:------------|:--------------------------|:---------|:-----------|:-----------|:-------|
-| Fuel Pump 1 | FUELSYSTEM_PUMP_TOGGLE    | 1..6     | -          | MSFS EVENT |        |
-|             | FUELSYSTEM PUMP ACTIVE:1  | 0&#124;1 | R          | MSFS VAR   |        |
-|             | FUELSYSTEM PUMP SWITCH:1  | 0&#124;1 | R          | MSFS VAR   |        |
-|             |                           |          |            |            |        |
-| X FEED      | FUELSYSTEM_VALVE_TOGGLE   | 3        | -          | MSFS EVENT |        |
-|             | FUELSYSTEM VALVE SWITCH:3 | 0&#124;1 | R          | MSFS VAR   |        |
-|             |                           |          |            |            |        |
-| MODE SEL    | N/A                       |          |            |            |        |
+    !!! warning ""
+        Please note that FUELSYSTEM_PUMP_TOGGLE 1 and 4 for the center tank pump switches don't work anymore because there are no pumps in the neo, which got corrected in a recent update.
+        
+        The new vars or events for these buttons are FUELSYSTEM_VALVE_TOGGLE 9 and 10.
+
+| Function    | API Usage                 | Values        | Read/Write | Type       | Remark |
+|:------------|:--------------------------|:--------------|:-----------|:-----------|:-------|
+| Fuel Pump 1 | FUELSYSTEM_PUMP_TOGGLE    | 2,3,5,6,9,10  | -          | MSFS EVENT |        |
+|             | FUELSYSTEM PUMP ACTIVE:1  | 0&#124;1      | R          | MSFS VAR   |        |
+|             | FUELSYSTEM PUMP SWITCH:1  | 0&#124;1      | R          | MSFS VAR   |        |
+|             |                           |               |            |            |        |
+| X FEED      | FUELSYSTEM_VALVE_TOGGLE   | 3             | -          | MSFS EVENT |        |
+|             | FUELSYSTEM VALVE SWITCH:3 | 0&#124;1      | R          | MSFS VAR   |        |
+|             |                           |               |            |            |        |
+| MODE SEL    | N/A                       |               |            |            |        |
 
 ### Air Condition Panel
 

--- a/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -270,7 +270,7 @@ Flight Deck: [Fuel Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/fu
     L1=2, L2=5, C1=9, C2=10, R1=3, R2=6
 
     !!! warning ""
-        Please note that FUELSYSTEM_PUMP_TOGGLE 1 and 4 for the center tank pump switches don't work anymore because these pumps do not exist in the NEO, which was corrected in a recent update.
+        Please note that FUELSYSTEM_PUMP_TOGGLE 1 and 4 for the center tank pump switches got replaced with FUELSYSTEM_VALVE_TOGGLE 9 and 10, due to the NEO having jet pumps instead of conventional pumps, which was corrected in a recent update.
         
         The new vars or events for these buttons are FUELSYSTEM_VALVE_TOGGLE 9 and 10.
 

--- a/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -270,7 +270,7 @@ Flight Deck: [Fuel Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/fu
     L1=2, L2=5. C1=9, C2=10, R1=3, R2=6
 
     !!! warning ""
-        Please note that FUELSYSTEM_PUMP_TOGGLE 1 and 4 for the center tank pump switches don't work anymore because there are no pumps in the neo, which got corrected in a recent update.
+        Please note that FUELSYSTEM_PUMP_TOGGLE 1 and 4 for the center tank pump switches don't work anymore because these pumps do not exist in the NEO, which was corrected in a recent update.
         
         The new vars or events for these buttons are FUELSYSTEM_VALVE_TOGGLE 9 and 10.
 

--- a/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -267,7 +267,7 @@ Flight Deck: [Fire Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/fi
 Flight Deck: [Fuel Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/fuel.md)
 
 !!! note "The below table shows the API for PUMP 1. Replace with appropriate value for the other pumps."
-    L1=2, L2=5. C1=9, C2=10, R1=3, R2=6
+    L1=2, L2=5, C1=9, C2=10, R1=3, R2=6
 
     !!! warning ""
         Please note that FUELSYSTEM_PUMP_TOGGLE 1 and 4 for the center tank pump switches don't work anymore because these pumps do not exist in the NEO, which was corrected in a recent update.

--- a/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -271,8 +271,6 @@ Flight Deck: [Fuel Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/fu
 
     !!! warning ""
         Please note that FUELSYSTEM_PUMP_TOGGLE 1 and 4 for the center tank pump switches got replaced with FUELSYSTEM_VALVE_TOGGLE 9 and 10, due to the NEO having jet pumps instead of conventional pumps, which was corrected in a recent update.
-        
-        The new vars or events for these buttons are FUELSYSTEM_VALVE_TOGGLE 9 and 10.
 
 | Function        | API Usage                 | Values   | Read/Write | Type       | Remark                                      |
 |:----------------|:--------------------------|:---------|:-----------|:-----------|:--------------------------------------------|

--- a/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -274,16 +274,17 @@ Flight Deck: [Fuel Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/fu
         
         The new vars or events for these buttons are FUELSYSTEM_VALVE_TOGGLE 9 and 10.
 
-| Function    | API Usage                 | Values        | Read/Write | Type       | Remark |
-|:------------|:--------------------------|:--------------|:-----------|:-----------|:-------|
-| Fuel Pump 1 | FUELSYSTEM_PUMP_TOGGLE    | 2,3,5,6,9,10  | -          | MSFS EVENT |        |
-|             | FUELSYSTEM PUMP ACTIVE:1  | 0&#124;1      | R          | MSFS VAR   |        |
-|             | FUELSYSTEM PUMP SWITCH:1  | 0&#124;1      | R          | MSFS VAR   |        |
-|             |                           |               |            |            |        |
-| X FEED      | FUELSYSTEM_VALVE_TOGGLE   | 3             | -          | MSFS EVENT |        |
-|             | FUELSYSTEM VALVE SWITCH:3 | 0&#124;1      | R          | MSFS VAR   |        |
-|             |                           |               |            |            |        |
-| MODE SEL    | N/A                       |               |            |            |        |
+| Function        | API Usage                 | Values   | Read/Write | Type       | Remark                                      |
+|:----------------|:--------------------------|:---------|:-----------|:-----------|:--------------------------------------------|
+| Fuel Pump 1     | FUELSYSTEM_PUMP_TOGGLE    | 2,3,5,6  | -          | MSFS EVENT | Fuel pumps only available in the wing tanks |
+| Fuel Jet Pump 1 | FUELSYSTEM_VALVE_TOGGLE   | 9,10     | -          | MSFS EVENT | Used for center tank fuel jet pump valves   |
+|                 | FUELSYSTEM PUMP ACTIVE:1  | 0&#124;1 | R          | MSFS VAR   |                                             |
+|                 | FUELSYSTEM PUMP SWITCH:1  | 0&#124;1 | R          | MSFS VAR   |                                             |
+|                 |                           |          |            |            |                                             |
+| X FEED          | FUELSYSTEM_VALVE_TOGGLE   | 3        | -          | MSFS EVENT |                                             |
+|                 | FUELSYSTEM VALVE SWITCH:3 | 0&#124;1 | R          | MSFS VAR   |                                             |
+|                 |                           |          |            |            |                                             |
+| MODE SEL        | N/A                       |          |            |            |                                             |
 
 ### Air Condition Panel
 


### PR DESCRIPTION
fixes #792

## Summary
Corrects API table references as per the issue linked above.

### Location
- docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
