### PR TITLE
feat: added way to get back ctrl from efb

### DIFF
--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -325,7 +325,9 @@ The following list of issues are commonly reported on our Discord support channe
 
     ^^Possible Solution or Workaround^^
 
-    Please follow the steps below to bypass this issue:
+    Try pressing ++ctrl+z++.
+
+    If this didn't help, please follow the steps below to bypass this issue:
 
     1. Open your browser (i.e., Chrome / Firefox)
     - In the URL field, type - `localhost:19999`


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
added Ctrl+z as possible solution to lost control after entering an efb input field
### Location
<!-- Please provide the original URL of the page modified or directory location here -->
fbw-a32nx/support/reported-issues/#lost-use-of-mouse-after-typing-in-a-flypad-input-field
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Slein
