### PR TITLE
fix: broken list in abnormallaw.md

### DIFF
--- a/docs/pilots-corner/advanced-guides/protections/abnormallaw.md
+++ b/docs/pilots-corner/advanced-guides/protections/abnormallaw.md
@@ -86,6 +86,7 @@ This fallback mode is triggered when multiple flight-critical redundant systems 
 Unlike normal Alternate Law, Abnormal Alternate Law (also known as Abnormal Attitude Law) is activated when the plane is far outside the normal flight envelope and reaches abnormal attitudes (even when in Normal Law).
 
 Abnormal Law is triggered when one of the following conditions is met:
+
 - Bank angle above 125°
 - Pitch attitude above 50° up or 30° down
 - Speed below 60-90 kt (exact value dependent on pitch)


### PR DESCRIPTION
## Summary
Noticed the abnormal alternate law section had a list that did not have an empty line causing it to appear in a single paragraph.

<img width="861" alt="image" src="https://user-images.githubusercontent.com/1619968/232238515-ed90d057-d478-4679-8e67-b8c63865d7ed.png">


### Location
- docs/pilots-corner/advanced-guides/protections/abnormallaw.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
