### PR TITLE
docs(issues): add new light mod to problematic section

### DIFF
--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -979,26 +979,31 @@ Please try these before reporting any other issue on Discord.
 
 The following add-ons and mods are known to be incompatible and cause issues with the A32NX. We recommend you uninstall these before starting the sim and flying with the A32NX, especially if you experience issues with the aircraft.
 
-??? bug "New Light Mod"
-    ### New Light Mod
+??? bug "Lights Addons"
+    ### Lights Addons
 
     !!! tip ""
         *Affected versions: Stable, Development*
 
     ^^Description^^
 
-    If you are experiencing issues with the lights in the cockpit we have found that the New Light addon creates breaking conflicts with the A32NX.
+    If you are experiencing issues with the lights in the cockpit we have found some addons create breaking conflicts with the A32NX.
 
     You may experience certain lights to not illuminating the cockpit appropriately or refuse to turn on at all.
 
     **Note: This issue is separate from the UTF8 issues and strictly affects lighting only.**
 
-    ^^Root Cause^^
-
     We have identified the following addon to be the main offender:
 
     !!! bug ""
         New Light (enhancement taxi, landing light and other extrior light) | by nicottine
+
+    Please be aware there may be other lights addons that may also cause this issue.
+
+    ^^Root Cause^^
+
+    It isn't currently possible to seamlessly modify lights on planes via mods. Creators would instead have to replace the whole airplane systems definition - which breaks everything when we 
+    update it ourselves.
 
     ^^Possible Solution or Workaround^^
 

--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -989,13 +989,13 @@ The following add-ons and mods are known to be incompatible and cause issues wit
 
     If you are experiencing issues with the lights in the cockpit we have found some addons create breaking conflicts with the A32NX.
 
-    You may experience certain lights to not illuminating the cockpit appropriately or refuse to turn on at all.
+    You may experience various cockpit lights to not illuminate the cockpit appropriately or refuse to turn on at all.
 
     **Note: This issue is separate from the UTF8 issues and strictly affects lighting only.**
 
     We have identified the following addon to be the main offender:
 
-    !!! bug ""
+    !!! warning ""
         New Light (enhancement taxi, landing light and other extrior light) | by nicottine
 
     Please be aware there may be other lights addons that may also cause this issue.
@@ -1054,7 +1054,7 @@ The following add-ons and mods are known to be incompatible and cause issues wit
 
     We have identified the following texture pack to be the main offender:
 
-    !!! bug ""
+    !!! warning ""
         Improved Textures Mod - A32NX & A320neo | by FlightFlow
 
     {--

--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -977,7 +977,33 @@ Please try these before reporting any other issue on Discord.
 
 ## Incompatible and Problematic Add-ons/Mods
 
-The following add-ons and mods are known to be incompatible and cause issues with the A32NX. We recommend you uninstall these before starting the sim and flying with the A32NX, especially if you experience issues with the aircraft. 
+The following add-ons and mods are known to be incompatible and cause issues with the A32NX. We recommend you uninstall these before starting the sim and flying with the A32NX, especially if you experience issues with the aircraft.
+
+??? bug "New Light Mod"
+    ### New Light Mod
+
+    !!! tip ""
+        *Affected versions: Stable, Development*
+
+    ^^Description^^
+
+    If you are experiencing issues with the lights in the cockpit we have found that the New Light addon creates breaking conflicts with the A32NX.
+
+    You may experience certain lights to not illuminating the cockpit appropriately or refuse to turn on at all.
+
+    **Note: This issue is separate from the UTF8 issues and strictly affects lighting only.**
+
+    ^^Root Cause^^
+
+    We have identified the following addon to be the main offender:
+
+    !!! bug ""
+        New Light (enhancement taxi, landing light and other extrior light) | by nicottine
+
+    ^^Possible Solution or Workaround^^
+
+    - Uninstall the mod
+    - Use an add-on linker to ensure the mod is only installed when you plan to use it.
 
 ??? bug "LVFR A321neo Compatibility Mod"
     ### LVFR A321neo Compatibility Mod


### PR DESCRIPTION
## Summary
Allows for removal of temporary command from Discord with direct reference to our reported issues using `.issues new light` as the command invocation.

Issues pertaining to having this installed is not all inclusive.

### Location
- docs/fbw-a32nx/support/reported-issues.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
