### PR TITLE
docs(local-files): correct the directory + folder name for local files

### DIFF
--- a/docs/fbw-a32nx/feature-guides/flypados3/charts.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/charts.md
@@ -141,7 +141,7 @@ The local files need to be stored in the following folders (located by default i
 | Type   | Folder Location                               |
 |--------|-----------------------------------------------|
 | Images | `<SimBridge-Install-Folder>\resources\images` |
-| PDF    | `<SimBridge-Install-Folder>\resources\pdf`    |
+| PDFs   | `<SimBridge-Install-Folder>\resources\pdfs`   |
 
 The feature does not support any subfolders (yet).
 


### PR DESCRIPTION

## Summary
Minor correction to the local files directory in our flypad documentation. 

Adds an "s" to PDFs and `/pdfs` for consistency. 

### Location
- docs/fbw-a32nx/feature-guides/flypados3/charts.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
