### PR TITLE
docs(bg): add autotuning capability and not for stable admonition

### DIFF
--- a/docs/pilots-corner/beginner-guide/descent.md
+++ b/docs/pilots-corner/beginner-guide/descent.md
@@ -294,8 +294,11 @@ We repeat the process until we have reached our desired final approach altitude.
     - The PFD displays the LOC and glide scales and deviation symbol, if there is a valid /LS or GLS signal.
     - Check that the /LS/GLS identification is displayed on the PFD.
 - `RAD NAVAIDS` (`RNAV` page on MCDU): Selected/Identified
-    - Ensure that appropriate radio NAVA/OS are tuned and identified.
-        - Currently, the FlyByWire A32NX does not auto-tune NAVAIDS
+    - Ensure that appropriate radio NAVAIDS are tuned and identified. The A32NX is capable of autotuning to the correct frequency.
+  
+        !!! warning ""
+            Autotuning is not available in the Stable version of the A32NX.
+  
     - For NDB approaches, manually select the reference NAVAID.
 
 #### Approach Checklist

--- a/docs/pilots-corner/beginner-guide/descent.md
+++ b/docs/pilots-corner/beginner-guide/descent.md
@@ -296,8 +296,8 @@ We repeat the process until we have reached our desired final approach altitude.
 - `RAD NAVAIDS` (`RNAV` page on MCDU): Selected/Identified
     - Ensure that appropriate radio NAVAIDS are tuned and identified. The A32NX is capable of autotuning to the correct frequency.
   
-        !!! warning ""
-            Autotuning is not available in the Stable version of the A32NX.
+        !!! warning "Autotuning"
+            Not available in the Stable version of the A32NX.
   
     - For NDB approaches, manually select the reference NAVAID.
 


### PR DESCRIPTION
closes: #801

## Summary
Dev+Exp can autotune navaids now. 

Added admonition stating not available in Stable version.

### Location
- docs/pilots-corner/beginner-guide/descent.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
