### PR TITLE
fix(radar): adjust weather admonition to be more specific 

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/radar.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/radar.md
@@ -49,7 +49,7 @@ The weather radar data can be displayed on the NDs in ARC or ROSE mode.
     - Map mode: No weather display but ground information: Black for water, green for ground, and amber for cities and mountains.
 
 !!! info ""
-    Weather is not available in the Stable version. We are awaiting Asobo API implementation. See [Custom FMS Special Notes](../../../../fbw-a32nx/feature-guides/cFMS.md#special-notes)
+    Weather is currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator. We are awaiting Asobo API implementation. See [Custom FMS Special Notes](../../../../fbw-a32nx/feature-guides/cFMS.md#special-notes)
 
 ###  TILT
 


### PR DESCRIPTION
closes: #809

## Summary
Admonition corrected to state that weather is not available on any version. 

### Location
- docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/radar.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
