### PR TITLE
fix: Fixed fuelsystem vars

### DIFF
--- a/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -266,23 +266,27 @@ Flight Deck: [Fire Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/fi
 
 Flight Deck: [Fuel Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/fuel.md)
 
-!!! note "The below table shows the API for PUMP 1. Replace with appropriate value for the other pumps."
+!!! note "The below table shows ':' if a pump index has to be added. Replace with appropriate value for the corresponding pump. E.g. FUELSYSTEM_PUMP_TOGGLE:2"
     L1=2, L2=5, C1=9, C2=10, R1=3, R2=6
 
     !!! warning ""
         Please note that FUELSYSTEM_PUMP_TOGGLE 1 and 4 for the center tank pump switches got replaced with FUELSYSTEM_VALVE_TOGGLE 9 and 10, due to the NEO having jet pumps instead of conventional pumps, which was corrected in a recent update.
 
-| Function        | API Usage                 | Values   | Read/Write | Type       | Remark                                      |
-|:----------------|:--------------------------|:---------|:-----------|:-----------|:--------------------------------------------|
-| Fuel Pump 1     | FUELSYSTEM_PUMP_TOGGLE    | 2,3,5,6  | -          | MSFS EVENT | Fuel pumps only available in the wing tanks |
-| Fuel Jet Pump 1 | FUELSYSTEM_VALVE_TOGGLE   | 9,10     | -          | MSFS EVENT | Used for center tank fuel jet pump valves   |
-|                 | FUELSYSTEM PUMP ACTIVE:1  | 0&#124;1 | R          | MSFS VAR   |                                             |
-|                 | FUELSYSTEM PUMP SWITCH:1  | 0&#124;1 | R          | MSFS VAR   |                                             |
-|                 |                           |          |            |            |                                             |
-| X FEED          | FUELSYSTEM_VALVE_TOGGLE   | 3        | -          | MSFS EVENT |                                             |
-|                 | FUELSYSTEM VALVE SWITCH:3 | 0&#124;1 | R          | MSFS VAR   |                                             |
-|                 |                           |          |            |            |                                             |
-| MODE SEL        | N/A                       |          |            |            |                                             |
+| Function         | API Usage                | Values   | Read/Write | Type       | Remark                                      |
+|:-----------------|:-------------------------|:---------|:-----------|:-----------|:--------------------------------------------|
+| Fuel L&R Tank    | FUELSYSTEM_PUMP_TOGGLE   | 2,3,5,6  | -          | MSFS EVENT | Fuel pumps only available in the wing tanks |
+|                  | FUELSYSTEM PUMP ACTIVE:  | 0&#124;1 | R          | MSFS VAR   | To check the current state of the pump      |
+|                  | FUELSYSTEM PUMP SWITCH:  | 0&#124;1 | R          | MSFS VAR   | To check the current state of the switch    |
+|                  |                          |          |            |            |                                             |
+| Fuel Center Tank | FUELSYSTEM_VALVE_TOGGLE  | 9,10     | -          | MSFS EVENT | Used for center tank fuel jet pump valves   |
+|                  | FUELSYSTEM_VALVE_OPEN:   | 0&#124;1 | R          | MSFS VAR   | To check the current state of the valve     |
+|                  | FUELSYSTEM VALVE SWITCH: | 0&#124;1 | R          | MSFS VAR   | To check the current state of the switch    |
+|                  |                          |          |            |            |                                             |
+| X FEED           | FUELSYSTEM_VALVE_TOGGLE  | 3        | -          | MSFS EVENT | X-Feed Pump                                 |
+|                  | FUELSYSTEM_VALVE_OPEN:   | 0&#124;1 | R          | MSFS VAR   | To check the current state of the valve     |
+|                  | FUELSYSTEM VALVE SWITCH: | 0&#124;1 | R          | MSFS VAR   | To check the current state of the switch    |
+|                  |                          |          |            |            |                                             |
+| MODE SEL         | N/A                      |          |            |            |                                             |
 
 ### Air Condition Panel
 

--- a/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -279,11 +279,11 @@ Flight Deck: [Fuel Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/fu
 |                  | FUELSYSTEM PUMP SWITCH:  | 0&#124;1 | R          | MSFS VAR   | To check the current state of the switch    |
 |                  |                          |          |            |            |                                             |
 | Fuel Center Tank | FUELSYSTEM_VALVE_TOGGLE  | 9,10     | -          | MSFS EVENT | Used for center tank fuel jet pump valves   |
-|                  | FUELSYSTEM_VALVE_OPEN:   | 0&#124;1 | R          | MSFS VAR   | To check the current state of the valve     |
+|                  | FUELSYSTEM VALVE OPEN:   | 0&#124;1 | R          | MSFS VAR   | To check the current state of the valve     |
 |                  | FUELSYSTEM VALVE SWITCH: | 0&#124;1 | R          | MSFS VAR   | To check the current state of the switch    |
 |                  |                          |          |            |            |                                             |
 | X FEED           | FUELSYSTEM_VALVE_TOGGLE  | 3        | -          | MSFS EVENT | X-Feed Pump                                 |
-|                  | FUELSYSTEM_VALVE_OPEN:   | 0&#124;1 | R          | MSFS VAR   | To check the current state of the valve     |
+|                  | FUELSYSTEM VALVE OPEN:   | 0&#124;1 | R          | MSFS VAR   | To check the current state of the valve     |
 |                  | FUELSYSTEM VALVE SWITCH: | 0&#124;1 | R          | MSFS VAR   | To check the current state of the switch    |
 |                  |                          |          |            |            |                                             |
 | MODE SEL         | N/A                      |          |            |            |                                             |

--- a/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -272,21 +272,21 @@ Flight Deck: [Fuel Panel](../../pilots-corner/a32nx-briefing/flight-deck/ovhd/fu
     !!! warning ""
         Please note that FUELSYSTEM_PUMP_TOGGLE 1 and 4 for the center tank pump switches got replaced with FUELSYSTEM_VALVE_TOGGLE 9 and 10, due to the NEO having jet pumps instead of conventional pumps, which was corrected in a recent update.
 
-| Function         | API Usage                | Values   | Read/Write | Type       | Remark                                      |
-|:-----------------|:-------------------------|:---------|:-----------|:-----------|:--------------------------------------------|
-| Fuel L&R Tank    | FUELSYSTEM_PUMP_TOGGLE   | 2,3,5,6  | -          | MSFS EVENT | Fuel pumps only available in the wing tanks |
-|                  | FUELSYSTEM PUMP ACTIVE:  | 0&#124;1 | R          | MSFS VAR   | To check the current state of the pump      |
-|                  | FUELSYSTEM PUMP SWITCH:  | 0&#124;1 | R          | MSFS VAR   | To check the current state of the switch    |
-|                  |                          |          |            |            |                                             |
-| Fuel Center Tank | FUELSYSTEM_VALVE_TOGGLE  | 9,10     | -          | MSFS EVENT | Used for center tank fuel jet pump valves   |
-|                  | FUELSYSTEM VALVE OPEN:   | 0&#124;1 | R          | MSFS VAR   | To check the current state of the valve     |
-|                  | FUELSYSTEM VALVE SWITCH: | 0&#124;1 | R          | MSFS VAR   | To check the current state of the switch    |
-|                  |                          |          |            |            |                                             |
-| X FEED           | FUELSYSTEM_VALVE_TOGGLE  | 3        | -          | MSFS EVENT | X-Feed Pump                                 |
-|                  | FUELSYSTEM VALVE OPEN:   | 0&#124;1 | R          | MSFS VAR   | To check the current state of the valve     |
-|                  | FUELSYSTEM VALVE SWITCH: | 0&#124;1 | R          | MSFS VAR   | To check the current state of the switch    |
-|                  |                          |          |            |            |                                             |
-| MODE SEL         | N/A                      |          |            |            |                                             |
+| Function         | API Usage                | Values   | Read/Write | Type       | Remark                                |
+|:-----------------|:-------------------------|:---------|:-----------|:-----------|:--------------------------------------|
+| Fuel L&R Tank    | FUELSYSTEM_PUMP_TOGGLE   | 2,3,5,6  | -          | MSFS EVENT | Fuel pumps for wing tanks             |
+|                  | FUELSYSTEM PUMP ACTIVE:  | 0&#124;1 | R          | MSFS VAR   | Current state of the pump             |
+|                  | FUELSYSTEM PUMP SWITCH:  | 0&#124;1 | R          | MSFS VAR   | Current state of the switch           |
+|                  |                          |          |            |            |                                       |
+| Fuel Center Tank | FUELSYSTEM_VALVE_TOGGLE  | 9,10     | -          | MSFS EVENT | Fuel jet pump valves for center tanks |
+|                  | FUELSYSTEM VALVE OPEN:   | 0&#124;1 | R          | MSFS VAR   | Current state of the valve            |
+|                  | FUELSYSTEM VALVE SWITCH: | 0&#124;1 | R          | MSFS VAR   | Current state of the switch           |
+|                  |                          |          |            |            |                                       |
+| X FEED           | FUELSYSTEM_VALVE_TOGGLE  | 3        | -          | MSFS EVENT | X-Feed pump                           |
+|                  | FUELSYSTEM VALVE OPEN:   | 0&#124;1 | R          | MSFS VAR   | Current state of the valve            |
+|                  | FUELSYSTEM VALVE SWITCH: | 0&#124;1 | R          | MSFS VAR   | Current state of the switch           |
+|                  |                          |          |            |            |                                       |
+| MODE SEL         | N/A                      |          |            |            |                                       |
 
 ### Air Condition Panel
 


### PR DESCRIPTION
## Summary
Tested and fixed fuelsystems vars documentation

### Location
https://docs-git-fork-frankkopp-fix-fuelsystem-vars-flybywire.vercel.app/fbw-a32nx/a32nx-api/a32nx-flightdeck-api/#fuel-panel

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Cdr_Maverick#6475
