### PR TITLE
build: bump mkdocs-material -> 9.1.11

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -2,16 +2,18 @@
 
 /*Primary Thematic Colors*/
 :root > * {
-  --md-primary-fg-color:        #00E0FE;
-  --md-primary-fg-color--dark:  hsl(216,32%,17%);
-  --md-primary-fg-color--light: #00E0FE;
-  --md-accent-fg-color:         #00E0FE;
-  --md-secondary-accent-color:  #0E131B;
-  --header-font:                Manrope;
+    --header-font:                Manrope;
+    --md-primary-fg-color:        #00E0FE;
+    --md-primary-fg-color--dark:  hsl(216,32%,17%);
+    --md-primary-fg-color--light: var(--md-primary-fg-color);
+    --md-accent-fg-color:         var(--md-primary-fg-color);
+    --md-secondary-accent-color:  #0E131B;
+    --md-typeset-a-color:         var(--md-primary-fg-color);
 }
 
 [data-md-color-scheme="slate"] {
-  --md-default-bg-color: rgb(23,30,44);
+    --md-default-bg-color: rgb(23,30,44);
+
 }
 
 /*Search Function Modification*/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ theme:
     text: Inter
   palette:
     scheme: slate
+    primary: custom
   features:
     - navigation.tabs
     - navigation.tabs.sticky

--- a/production.yml
+++ b/production.yml
@@ -3,6 +3,6 @@ INHERIT: mkdocs.yml
 # on production only
 plugins:
   social:
-    cards_color:
-      fill: "#171E2C"
-    cards_font: Manrope
+    cards_layout_options:
+      background_color: "#171E2C"
+      font_family: Manrope

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.1.5
+mkdocs-material==9.1.11
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary
Upstream Changes
- social plugin fixes
- theme issues with new CSS palette changes

repo changes
- swapped :root styles to be variable based on the primary-fg-color
- fixed mkdocs.yml to ensure that the palette is set (even though not required). 

### TODO

- [x] Refactor social cards setting in production.yml due to changes with version

### Location
- requirements.txt
- extra.css

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
