### PR TITLE
build(vercel): cap urllib3 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ mkdocs-video
 mkdocs-glightbox
 pillow
 cairosvg
+urllib3==1.26.15


### PR DESCRIPTION
## Summary
Fixes vercel build issues

sets the version of urllib3 to latest version before 2.0 for compatibility. Will explore other options later. 

### Location
- requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
