### PR TITLE
docs(vnav): update documentation to support dev release

### DIFF
--- a/docs/fbw-a32nx/support/exp.md
+++ b/docs/fbw-a32nx/support/exp.md
@@ -53,33 +53,13 @@ The following are features in testing that require the use of SimBridge:
 
 Note: This may not be the final iteration of this feature, nor how it operates. The option to toggle top of descent in the EFB settings may be changed or moved into its own dedicated flyPad page or section in the future.
 
-### Vertical Guidance
-
-- Speed and altitude predictions in the flight plan page, including magenta or amber asterisks.
-- Reworked fuel burn and time predictions in the flight plan page (no flight plan B page).
-- Pseudowaypoints in the flight plan (SPD/LIM, T/C, T/D, S/C, S/D, DECEL).
-- Display of pseudowaypoints on the ND (T/C, T/D, predicted speed changes, etc.)
-- Partial implementation of step climbs/descent.
-- Linear deviation indication during the descent.
-- Following of speed and altitude constraints in the climb phase (credits to tracernz).
-- Partial implementation of descent guidance.
-- Ability to enter winds for climb, cruise, and descent.
-
-#### Vertical Guidance Planned Implementations
-
-These features are not yet available, but will be implemented at a later time.
-
-- Time constraints, RTA
-- Flight plan B
-- Constant Mach segments
-- Vertical guidance for RNAV approaches
-
 ---
 
 ## Released Into Development Version
 
 Features in testing that have been released into Development but not Stable will be listed here. This list will be pruned with every Stable release.
 
+- VNAV version 1
 - flyPad OS 3
 - GSX Integration
 - Simbridge

--- a/docs/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/managed-modes.md
+++ b/docs/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/managed-modes.md
@@ -29,7 +29,7 @@ The SRS guidance law also includes:
 
 ## CLB (Climb)
 
-!!! warning "Managed CLB or DES (VNAV) is currently only available in the Experimental version."
+!!! warning "Managed CLB or DES (VNAV) is currently only available in the Development & Experimental versions."
 
 CLB mode guides the aircraft in a managed climb, at either a managed or a selected target speed, to an FCU selected altitude, considering altitude constraints at waypoints. The system also considers speed constraints if the target speed is managed.
 
@@ -88,7 +88,7 @@ When ALT is engaged, the FMA displays ALT in green (FCU altitude hold), ALT CST 
 
 ## DES (Descent)
 
-!!! warning "Managed CLB or DES (VNAV) is currently only available in the Experimental version."
+!!! warning "Managed CLB or DES (VNAV) is currently only available in the Development & Experimental versions."
 
 The managed descent mode guides the aircraft along the FMS computed vertical flight path. The DES mode is preferred when conditions permit, since it ensures the management of altitude constraints and reduces the operating cost when flying at ECON DES speed.
 

--- a/docs/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/overview.md
+++ b/docs/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/overview.md
@@ -3,6 +3,7 @@ tags:
     - VNAV
 hide:
     - tags
+title: Vertical Guidance - Overview
 ---
 
 <link rel="stylesheet" href="/../../stylesheets/toc-tables.css">
@@ -14,6 +15,7 @@ hide:
 | Quick Links                                    |
 |:-----------------------------------------------|
 | [Vertical Modes](#vertical-modes-overview)     |
+| [VNAV - Version 1](#vnav-version-1)            |
 | [Selected Vertical Modes](./selected-modes.md) |
 | [Managed Vertical Modes](./managed-modes.md)   |
 | [Speed/Mach Control](./speed-control.md)       |
@@ -29,6 +31,31 @@ Also, implementing it correctly and realistically is an enormous task and the Fl
 Therefore, the level of detail in this guide is meant to provide FlyByWire A32NX users the ability to adequately use the vertical navigation features of the aircraft in the simulator without overburdening the user with an extreme level of detail.
 
 If you have additional questions beyond the scope of this guide, do not hesitate to come to the ([:fontawesome-brands-discord:{: .discord } - **FlyByWire Discord**](https://discord.gg/flybywire){target=new}) and visit our #flight-school channel. We have many real-world pilots in our community who are happy to help to answer your questions.
+
+## VNAV - Version 1
+This is our first step of custom implementation of the vertical navigation capabilities in the A32NX. It implements the basic vertical prediction and guidance functions. Additional features and 
+improvements to existing functionality will follow in future PRs.
+
+Current feature set:
+
+- Accurate speed, altitude, time and fuel predictions in the MCDU for all phases of flight.
+- Vertical predictions on the navigation display in the form of pseudowaypoints.
+- Ability to program cruise steps in the MCDU.
+- Vertical guidance in managed modes during all phases of flight
+- Pause-at-T/D (Top of Descent) quality of life feature.
+
+!!! warning "Not Yet Implemented"
+    The following features are not yet implemented "Version 1 of VNAV" in the A32NX:
+
+    - Vertical guidance for non-precision approaches, including FINAL APP and FLS.
+    - Required Time of Arrival (RTA) functionality.
+    - TOO STEEP PATH segments and markers in the MCDU.
+    - MORE DRAG message on the PFD
+    - Equitime-point functionality
+    - More sophisticated temperature model (matching H3)
+    - Optimum step alts functionality
+    - Energy circle display on the ND
+    - Accurate data acquisition from ADRs
 
 ## Overview
 

--- a/docs/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/overview.md
+++ b/docs/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/overview.md
@@ -38,11 +38,11 @@ improvements to existing functionality will follow in future PRs.
 
 Current feature set:
 
-- Accurate speed, altitude, time and fuel predictions in the MCDU for all phases of flight.
-- Vertical predictions on the navigation display in the form of pseudowaypoints.
-- Ability to program cruise steps in the MCDU.
-- Vertical guidance in managed modes during all phases of flight
-- Pause-at-T/D (Top of Descent) quality of life feature.
+- [x] Accurate speed, altitude, time and fuel predictions in the MCDU for all phases of flight.
+- [x] Vertical predictions on the navigation display in the form of pseudowaypoints.
+- [x] Ability to program cruise steps in the MCDU.
+- [x] Vertical guidance in managed modes during all phases of flight
+- [x] Pause-at-T/D (Top of Descent) quality of life feature.
 
 !!! warning "Not Yet Implemented"
     The following features are not yet implemented "Version 1 of VNAV" in the A32NX:

--- a/docs/pilots-corner/beginner-guide/descent.md
+++ b/docs/pilots-corner/beginner-guide/descent.md
@@ -250,7 +250,9 @@ A few minutes before we reach our calculated descent point (TOD) we request clea
 **Do NOT start the decent without clearance from ATC.**
 
 !!! info "TOD marker A320"
-    The FlyByWire A32NX has not implemented the TOD (top of descent) marker on the `ND` yet. Usually, the A320 has a downward pointing arrow at the TOD to support the pilot with the decision when to descent. Ultimately, it is still the pilot's responsibility to calculate and validate the TOD.
+    The A320 has a downward pointing arrow at the TOD to support the pilot with the decision of when to descend. Ultimately, it is still the pilot's responsibility to calculate and validate the TOD.
+
+    The Development and Experimental version of the FlyByWire A32NX has implemented the TOD (top of descent) marker on the `ND` yet. 
 
 When clearance is given, we can start our descent to the flight level or altitude ATC has given us.
 
@@ -275,7 +277,8 @@ Also, ATC will often still expect us to respect the STAR's constraints, although
 !!! info "VNAV in the FlyByWire A32NX"
     The scenario that we are cleared to a lower altitude or flight level with altitude constraints above the clearance is an ideal scenario for the called so "VNAV" autopilot mode, which would be activated by using "`Managed Altitude Mode`" (pushing the `ALT selector`). The autopilot will automatically level off at the constraint and continue descending when the constraint is no longer valid.
 
-    Unfortunately, the current version of the FlyByWire A32NX does not yet support VNAV. This is planned to be implemented in one of the next versions.
+    !!! warning ""
+        VNAV is currently only supported in our Development and Experimental versions of the A32NX.
 
 We repeat the process until we have reached our desired final approach altitude.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ plugins:
         'airframe.md': 'https://docs.flybywiresim.com/fbw-a32nx/installation/#simbrief-airframe'
         'fdr.md': 'https://docs.flybywiresim.com/fbw-a32nx/support/#fdr-files'
         'exp.md': 'fbw-a32nx/support/exp.md'
+        'vnav.md': 'pilots-corner/advanced-guides/flight-guidance/vertical-guidance/overview.md'
         # Release Notes Permalink
         'latest-release.md': 'release-notes/v091.md'
         'latest-installer-release.md': 'release-notes/installer/v330.md'


### PR DESCRIPTION
## Summary
Adds feature set and ensures documentation is ready for VNAV v1 release into the development branch

- Adds meta title for better open graph card

There is a possibility that there may be some sections located in nested documentation that have potential vertical guidance information that would be flagged as INOP. We can correct this later but the majority of docs should be ready to roll.

Contains convenience link for marketing and support purposes:

```
https://docs.flybywiresim.com/vnav/
```

### Location
- docs/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/overview.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
