### PR TITLE
fix: change thrust to N1

### DIFF
--- a/docs/pilots-corner/beginner-guide/takeoff-climb-cruise.md
+++ b/docs/pilots-corner/beginner-guide/takeoff-climb-cruise.md
@@ -209,7 +209,7 @@ Shortly before we start our takeoff roll, we do the following steps:
 
 1. Release parking brake and hold down manual brakes.
 
-- Apply thrust slowly to about 50 % thrust until both engines are stabilized (N1 stays constant at around 50 %) while still holding the brakes.
+- Apply thrust slowly to about 50 % N1 until both engines are stabilized (N1 stays constant at around 50 %) while still holding the brakes.
 
 - Push sidestick forward half the way to put pressure on the front gear<br/>
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->
fixes #821 
## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
changes wording in BG because thrust setting for takeoff is not 50%, instead it's whatever corresponds to 50% N1
### Location
<!-- Please provide the original URL of the page modified or directory location here -->
https://docs.flybywiresim.com/pilots-corner/beginner-guide/takeoff-climb-cruise/#2-takeoff
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
