### PR TITLE
fix: changed "star" to "asterisk"

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/mcdu/f-pln.md
+++ b/docs/pilots-corner/a32nx-briefing/mcdu/f-pln.md
@@ -46,7 +46,7 @@ Constraints can also be manually added by the flight crew (except at origin, des
 
 Constraints are displayed in magenta, as long as predictions are not completed.
 
-Once predictions are calculated, constraints are replaced by speed and altitude predictions, preceded by stars. If the STAR is magenta, the system predicts that the aircraft will match the constraint (altitude within 250 ft, speed not more than 10 kt above the constraints). If the star is amber, the system predicts that the aircraft will miss the constraint and the MCDU displays: “SPD ERROR AT WPT”.
+Once predictions are calculated, constraints are replaced by speed and altitude predictions, preceded by asterisks. If the asterisk is magenta, the system predicts that the aircraft will match the constraint (altitude within 250 ft, speed not more than 10 kt above the constraints). If the asterisk is amber, the system predicts that the aircraft will miss the constraint and the MCDU displays: “SPD ERROR AT WPT”.
 
 !!! note
     SPD and ALT CSTR may either be entered on the VERT REV page or directly on the F-PLN A page, whereas TIME CSTR may only be entered from the RTA page.


### PR DESCRIPTION
Exchanged the word "star" for "asterisk" as it is about the character symbol, not the procedure.

<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
Changed "star" to "asterisk" since in this case it is about the character symbol on the MCDU, not the procedure. 

### Location
(https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/mcdu/f-pln/#predictions)

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
