### PR TITLE
fix(efb): Moved Simbrief Username Location from Admonition header to body

### DIFF
--- a/docs/fbw-a32nx/feature-guides/flypados3/settings.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/settings.md
@@ -299,7 +299,7 @@ Settings for integration with various data and information sources.
 
 Before you can use the A32NX simBrief Integration, you need to provide your simBrief account details.
 
-!!! tip "Locating the Simbrief EFB Settings"
+!!! tip "Locating the SimBrief EFB Settings"
     If you have arrived at this section from the [SimBrief Integration](../simbrief.md) page, please make note this setting is found on the EFB, under Settings -> ATSU/AOC.
 
 - SimBrief Pilot ID:

--- a/docs/fbw-a32nx/feature-guides/flypados3/settings.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/settings.md
@@ -299,8 +299,8 @@ Settings for integration with various data and information sources.
 
 Before you can use the A32NX simBrief Integration, you need to provide your simBrief account details.
 
-!!! tip "Found in Settings -> ATSU/AOC"
-    If you have arrived at this section from the [SimBrief Integration](../simbrief.md) page, please make note this setting is found on the EFB.
+!!! tip "Locating the Simbrief EFB Settings"
+    If you have arrived at this section from the [SimBrief Integration](../simbrief.md) page, please make note this setting is found on the EFB, under Settings -> ATSU/AOC.
 
 - SimBrief Pilot ID:
     - Enter your SimBrief Pilot ID.


### PR DESCRIPTION
## Summary
From understanding feedback obtained from the Discord, the information to where to find the location of the Simbrief Username field within the EFB Settings was not clear. The documentation did have the location within the Admonition header, where as it makes more sense to be within the body.

### Location
https://docs.flybywiresim.com/fbw-a32nx/feature-guides/flypados3/settings/#simbrief-integration

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Jason#0963
