### PR TITLE
fix: typo on fcu page

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/fcu.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/fcu.md
@@ -97,7 +97,7 @@ The flight crew uses this button to arm, activate, or disconnect the Autothrust 
 
 The range of this value is between 100 and 49 000 feet.
 
-The outer knob switches the increment step-size for the inner know from 100 to 1000 and vice versa.
+The outer knob switches the increment step-size for the inner knob from 100 to 1000 and vice versa.
 
 The inner knob sets the altitude in the FCU windows in the chosen increment step-size.
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/fcu.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/glareshield/fcu.md
@@ -97,7 +97,7 @@ The flight crew uses this button to arm, activate, or disconnect the Autothrust 
 
 The range of this value is between 100 and 49 000 feet.
 
-The outer knob switches the increment step-size for the inner knob from 100 to 1000 and vice versa.
+The outer knob switches the step-size of the inner knob from 100 to 1000 and vice versa.
 
 The inner knob sets the altitude in the FCU windows in the chosen increment step-size.
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
small typo fix 
### Location
<!-- Please provide the original URL of the page modified or directory location here -->
https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/flight-deck/glareshield/fcu/#altitude-selector-knob-inner-and-outer
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
