### PR TITLE
build: bump mkdocs-material 9.1.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.1.11
+mkdocs-material==9.1.14
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary
Updates from mkdocs-material with most notable for compatibility:

- Social plugin crashes for some fonts (e.g. Open Sans) as part of 9.1.13


### Location
- requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri#8902
