### PR TITLE
fix: correct format for g load various pages

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/ecam/sd/index.md
+++ b/docs/pilots-corner/a32nx-briefing/ecam/sd/index.md
@@ -90,7 +90,7 @@
 | 1      | Permanent Data Left   | TAT                   | Total Air Temperature is the SAT plus the temperature rise associated with high-speed flight.                                              |
 |        |                       | SAT                   | Static Air Temperature is the temperature of undisturbed air.                                                                              |
 |        |                       | ISA                   | Difference between SAT and the International Standard Atmosphere temperature (ISA) temperature. Only displayed in STD altitude mode.       |
-| 2      | Permanent Data Middle | G LOAD                | G LOAD in amber when g load > 1.4 g or < 0.7 g for more than 2 s. Inhibited in some flight phases.                                         |
+| 2      | Permanent Data Middle | G LOAD                | G LOAD in amber when g load > 1.4*g* or < 0.7*g* for more than 2 s. Inhibited in some flight phases.                                       |
 |        |                       | ALT SEL               | Selected altitude in green when metric units are selected and load factor not displayed.                                                   |
 |        |                       | UTC                   | Universal Time Coordinated (UTC), synchronized with the cockpit clock.                                                                     |
 | 3      | Permanent Data Right  | Gross Weight (GW)     | Gross Weight in green as soon as first engine is started. Last digits dashed if accuracy is degraded. Blue dashes if no data is available. |

--- a/docs/pilots-corner/a32nx-briefing/limitations.md
+++ b/docs/pilots-corner/a32nx-briefing/limitations.md
@@ -24,8 +24,8 @@ This list is incomplete, but should mention the most important operational limit
 
 ### Flight Maneuvering Load Acceleration Limits
 
-- Clean configuration: - 1.0 g to + 2.5 g
-- Other configurations: 0 g to + 2 g
+- Clean configuration: - 1.0*g* to + 2.5*g*
+- Other configurations: 0*g* to + 2*g*
 
 ### Environmental Envelope
 

--- a/docs/pilots-corner/advanced-guides/protections/overview.md
+++ b/docs/pilots-corner/advanced-guides/protections/overview.md
@@ -171,7 +171,7 @@ Maneuvre Protection, also called Maneuvre Protection, enables immediate PF react
 The load factor limit is:
 
 - - 1.0 to + 2.5*g* load factor for clean configuration
-- 0 to + 2.0 *g* positive load factor for other configurations
+- 0 to + 2.0*g* positive load factor for other configurations
 
 ### Indication and warnings
 

--- a/docs/pilots-corner/advanced-guides/protections/overview.md
+++ b/docs/pilots-corner/advanced-guides/protections/overview.md
@@ -170,7 +170,7 @@ Maneuvre Protection, also called Maneuvre Protection, enables immediate PF react
 
 The load factor limit is:
 
-- - 1.0 to + 2.5 *g* load factor for clean configuration
+- - 1.0 to + 2.5*g* load factor for clean configuration
 - 0 to + 2.0 *g* positive load factor for other configurations
 
 ### Indication and warnings

--- a/docs/pilots-corner/advanced-guides/protections/overview.md
+++ b/docs/pilots-corner/advanced-guides/protections/overview.md
@@ -170,15 +170,15 @@ Maneuvre Protection, also called Maneuvre Protection, enables immediate PF react
 
 The load factor limit is:
 
-- - 1.0 to + 2.5 g load factor for clean configuration
-- 0 to + 2.0 g positive load factor for other configurations
+- - 1.0 to + 2.5 *g* load factor for clean configuration
+- 0 to + 2.0 *g* positive load factor for other configurations
 
 ### Indication and warnings
 
 !!! block ""
     ![G LOAD factor warning on ECAM](../../assets/advanced-guides/protections/gload-factor-ecam.png "G LOAD factor warning on ECAM"){loading=lazy align=left}
 
-    The lower ECAM displays the load factor (G LOAD) in amber, when the value is above 1.4 g or below 0.7 g for more than 2 s.
+    The lower ECAM displays the load factor (G LOAD) in amber, when the value is above 1.4*g* or below 0.7*g* for more than 2 s.
 
 ## Pitch Attitude Protection
 


### PR DESCRIPTION
closes: #843

## Summary
Reference issue above.

### Notes
I could not find g load references on the following pages (might be the fatigue - point me in the right direction if there are references):
- custom hydraulics
- abnormal law (protections)

### Location
- pilots-corner/a32nx-briefing/ecam/sd/index.md
- pilots-corner/advanced-guides/protections/overview.md
- pilots-corner/a32nx-briefing/limitations.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
