### PR TITLE
refactor: clean experimental references from documentation

### DIFF
--- a/docs/dev-corner/dev-guide/resources.md
+++ b/docs/dev-corner/dev-guide/resources.md
@@ -8,13 +8,11 @@ The main GitHub repository for the A32NX aircraft is:
 
 **[https://github.com/flybywiresim/a32nx](https://github.com/flybywiresim/a32nx){target=new}**
 
-The Development version of the FlyByWire A32NX is done in the master branch. Whenever something is merged into the master branch, an automatic build process builds the newest Development version and uploads it to our CDN, so users can download the latest Development version via the FlyByWire Installer.
+The Development version of the FlyByWire A32NX is done in the master branch. Whenever something is merged into the master branch, an automatic build process builds the newest 
+Development version and uploads it to our CDN, so users can download the latest Development version via the FlyByWire Installer. We have a very strict development, review and 
+QA process for for this version.
 
 The Stable version is a snapshot (in git terms, a [Tag](https://github.com/flybywiresim/a32nx/tags){target=new}) of the development branch.
-
-The experimental version is built in the branch [experimental](https://github.com/flybywiresim/a32nx/tree/experimental){target=new}. It is regularly manually updated with the latest commits from the master branch, but its focus is on the development of special larger features like the custom fly-by-wire and autopilot system or the custom flight management system (cFMS).
-
-While the development on the master branch (Development version) follows a very strict development, review and QA process, the development in the experimental branch is less strict and developers can relatively freely commit changes. This is why the Experimental version has a higher risk of bugs and issues and is only meant for testing and not supported on Discord.
 
 The FlyByWire project has other repositories for subprojects like api, msfs-rs, installer, website, docs, etc. Find them [here](https://github.com/orgs/flybywiresim/repositories){target=new}.
 

--- a/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -9,7 +9,7 @@ hide:
 [Clickable Flight Deck](../../pilots-corner/a32nx-briefing/flight-deck/index.md){ .md-button }
 
 !!! note ""
-    The below table might lag behind the current developments of the A32NX. It is based on the A32NX Development version, and we try to keep it updated as good as possible. Some variables/events are only available in the Experimental version of A32NX and are marked as such.
+    The below table might lag behind the current developments of the A32NX. It is based on the A32NX Development version, and we try to keep it updated as best as possible.
 
     You can help us keep this up to date and improve this by reporting any errors or omissions on our [:fontawesome-brands-discord:{: .discord } - **Discord**](https://discord.gg/flybywire){target=new} in the **#a32nx-support** channel or by creating an issue report here: [Docs Issues](https://github.com/flybywiresim/docs/issues){target=new}.
 

--- a/docs/fbw-a32nx/faq.md
+++ b/docs/fbw-a32nx/faq.md
@@ -34,7 +34,7 @@
     Just make sure to search for existing issues first before creating a new one.
 
 ??? info "Q: Why is my version not the same as what I see others using?"
-    We have three versions: Stable, Development, and Experimental.
+    We have two versions: Stable and Development
 
     **Stable**
 
@@ -44,8 +44,9 @@
 
     The Development build is updated daily and is a constant work in progress and although we test each update thoroughly, minor issues may occur from time to time. See [Downloads](installation.md#downloads).
 
-??? info "Q: What is the Experimental Version?"
-    Please read more [here](support/exp.md).
+[//]: # (??? info "Q: What is the Experimental Version?")
+
+[//]: # (    Please read more [here]&#40;support/exp.md&#41;.)
 
 ---
 

--- a/docs/fbw-a32nx/fbw-versions.md
+++ b/docs/fbw-a32nx/fbw-versions.md
@@ -25,22 +25,7 @@ This version will not always be up-to-date, but we work hard at ensuring its com
 
 ### "Experimental Version"
 
-This version is similar to the development version, but contains custom systems in earlier development phases.
-
-We use this version to find problems, issues and to improve functionality based on your feedback. It is not meant to be used for daily use or when you try to do a serious flight on VATSIM.
-
-!!! warning
-
-The Experimental version has a less strict QA process and is used for actual QA testing. Bugs and Issues are to be expected. 
-
-!!! danger ""
-    Before using this version, please read the [Experimental Version Support Page](support/exp.md) to see what is currently being tested. 
-
-The experimental version will be updated regularly and also with the latest changes to the Development version. Expect updates about once a week (not guaranteed).
-
-!!! danger "Do not expect support for the experimental version - use at own risk!"
-
-We ask that you understand that we may not offer support for any experimental issues due to the nature of this version. We will happily answer questions, time permitting.
+We have discontinued our Experimental Version. Development will continue on the Development Version of the aircraft. 
 
 ## Version Comparison
 


### PR DESCRIPTION
## Summary
Supports the discontinuation of the Experimental Version

### Location
- Multiple Locations based on references

### TODO

Working top level directories to tackle:

- [ ] fbw-a32nx
- [ ] dev-corner
- [ ] pilots-corner
- [ ] release-notes
- [ ] simbridge

Check when complete.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
