### PR TITLE
refactor: remove experimental references from documentation

### DIFF
--- a/archive/exp.md
+++ b/archive/exp.md
@@ -21,7 +21,7 @@ We are testing the new FWS (Flight Warning System) which replaces the previous p
 See technical details in the respective 
 [GitHub Pull Request #4872](https://github.com/flybywiresim/a32nx/pull/4872){target=new}.
 
-![fws-init-ecam](../../pilots-corner/assets/beginner-guide/starting-aircraft/fws-init-ecam.png){loading=lazy width=50%}
+![fws-init-ecam](../docs/pilots-corner/assets/beginner-guide/starting-aircraft/fws-init-ecam.png){loading=lazy width=50%}
 
 Summary:
 
@@ -34,15 +34,15 @@ powered by the FWS truly won't work when both FWCs are unpowered or have failed.
 
 The following are features in testing that require the use of SimBridge:
 
-- [Terrain Display](../../simbridge/simbridge-feature-guides/terrain.md) - **Now Available on the Development Version**
+- [Terrain Display](../docs/simbridge/simbridge-feature-guides/terrain.md) - **Now Available on the Development Version**
 - Remote MCDU (Web MCDU) - **Now Available on the Development Version**
-    - [Setup and Configuration Guide](../../simbridge/simbridge-feature-guides/remote-displays/remote-mcdu.md)
-    - [Usage Guide](../../simbridge/simbridge-feature-guides/remote-displays/remote-mcdu.md)
-- [Company Routes](../../simbridge/simbridge-feature-guides/coroute.md) - **Now Available on the Development Version**
+    - [Setup and Configuration Guide](../docs/simbridge/simbridge-feature-guides/remote-displays/remote-mcdu.md)
+    - [Usage Guide](../docs/simbridge/simbridge-feature-guides/remote-displays/remote-mcdu.md)
+- [Company Routes](../docs/simbridge/simbridge-feature-guides/coroute.md) - **Now Available on the Development Version**
 
 !!! tip "SimBridge Information"
-    - Learn about SimBridge and further status of various features, please - [Read Here](../../simbridge/index.md).
-    - [SimBridge setup and configuration guide](../../simbridge/install-configure/configuration.md).
+    - Learn about SimBridge and further status of various features, please - [Read Here](../docs/simbridge/index.md).
+    - [SimBridge setup and configuration guide](../docs/simbridge/install-configure/configuration.md).
 
 ### Pause at Top of Descent (TOD)
 
@@ -137,4 +137,4 @@ the C* law, this is incorrect and will result in issues if no ADR is available.
 
 ### Download and Install
 
-See [Installation Guide](../installation.md#downloads).
+See [Installation Guide](../docs/fbw-a32nx/installation.md#downloads).

--- a/docs/dev-corner/dev-guide/resources.md
+++ b/docs/dev-corner/dev-guide/resources.md
@@ -8,13 +8,11 @@ The main GitHub repository for the A32NX aircraft is:
 
 **[https://github.com/flybywiresim/a32nx](https://github.com/flybywiresim/a32nx){target=new}**
 
-The Development version of the FlyByWire A32NX is done in the master branch. Whenever something is merged into the master branch, an automatic build process builds the newest Development version and uploads it to our CDN, so users can download the latest Development version via the FlyByWire Installer.
+The Development version of the FlyByWire A32NX is done in the master branch. Whenever something is merged into the master branch, an automatic build process builds the newest 
+Development version and uploads it to our CDN, so users can download the latest Development version via the FlyByWire Installer. We have a very strict development, review and 
+QA process for for this version.
 
 The Stable version is a snapshot (in git terms, a [Tag](https://github.com/flybywiresim/a32nx/tags){target=new}) of the development branch.
-
-The experimental version is built in the branch [experimental](https://github.com/flybywiresim/a32nx/tree/experimental){target=new}. It is regularly manually updated with the latest commits from the master branch, but its focus is on the development of special larger features like the custom fly-by-wire and autopilot system or the custom flight management system (cFMS).
-
-While the development on the master branch (Development version) follows a very strict development, review and QA process, the development in the experimental branch is less strict and developers can relatively freely commit changes. This is why the Experimental version has a higher risk of bugs and issues and is only meant for testing and not supported on Discord.
 
 The FlyByWire project has other repositories for subprojects like api, msfs-rs, installer, website, docs, etc. Find them [here](https://github.com/orgs/flybywiresim/repositories){target=new}.
 

--- a/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -9,7 +9,7 @@ hide:
 [Clickable Flight Deck](../../pilots-corner/a32nx-briefing/flight-deck/index.md){ .md-button }
 
 !!! note ""
-    The below table might lag behind the current developments of the A32NX. It is based on the A32NX Development version, and we try to keep it updated as good as possible. Some variables/events are only available in the Experimental version of A32NX and are marked as such.
+    The below table might lag behind the current developments of the A32NX. It is based on the A32NX Development version, and we try to keep it updated as best as possible.
 
     You can help us keep this up to date and improve this by reporting any errors or omissions on our [:fontawesome-brands-discord:{: .discord } - **Discord**](https://discord.gg/flybywire){target=new} in the **#a32nx-support** channel or by creating an issue report here: [Docs Issues](https://github.com/flybywiresim/docs/issues){target=new}.
 

--- a/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -661,10 +661,10 @@ Flight Deck: [Chrono Panel](../../pilots-corner/a32nx-briefing/flight-deck/front
 
 Flight Deck: [ND Panel](../../pilots-corner/a32nx-briefing/flight-deck/front/nd.md)
 
-| Function       | API Usage                | Values   | Read/Write | Type        | Remark                         |
-|:---------------|:-------------------------|:---------|:-----------|:------------|:-------------------------------|
-| TERR ON ND L   | A32NX_EFIS_TERR_L_ACTIVE | 0&#124;1 | R/W        | Custom LVAR | Currently only in Experimental |
-| TERR ON ND R   | A32NX_EFIS_TERR_R_ACTIVE | 0&#124;1 | R/W        | Custom LVAR | Currently only in Experimental |
+| Function     | API Usage                | Values   | Read/Write | Type        | Remark |
+|:-------------|:-------------------------|:---------|:-----------|:------------|:-------|
+| TERR ON ND L | A32NX_EFIS_TERR_L_ACTIVE | 0&#124;1 | R/W        | Custom LVAR |        |
+| TERR ON ND R | A32NX_EFIS_TERR_R_ACTIVE | 0&#124;1 | R/W        | Custom LVAR |        |
 
 ### DCDU
 

--- a/docs/fbw-a32nx/faq.md
+++ b/docs/fbw-a32nx/faq.md
@@ -34,7 +34,7 @@
     Just make sure to search for existing issues first before creating a new one.
 
 ??? info "Q: Why is my version not the same as what I see others using?"
-    We have three versions: Stable, Development, and Experimental.
+    We have two versions: Stable and Development
 
     **Stable**
 
@@ -44,8 +44,9 @@
 
     The Development build is updated daily and is a constant work in progress and although we test each update thoroughly, minor issues may occur from time to time. See [Downloads](installation.md#downloads).
 
-??? info "Q: What is the Experimental Version?"
-    Please read more [here](support/exp.md).
+[//]: # (??? info "Q: What is the Experimental Version?")
+
+[//]: # (    Please read more [here]&#40;support/exp.md&#41;.)
 
 ---
 

--- a/docs/fbw-a32nx/faq.md
+++ b/docs/fbw-a32nx/faq.md
@@ -34,7 +34,7 @@
     Just make sure to search for existing issues first before creating a new one.
 
 ??? info "Q: Why is my version not the same as what I see others using?"
-    We have two versions: Stable and Development
+    We have two versions: Stable and Development.
 
     **Stable**
 

--- a/docs/fbw-a32nx/fbw-versions.md
+++ b/docs/fbw-a32nx/fbw-versions.md
@@ -25,7 +25,7 @@ This version will not always be up-to-date, but we work hard at ensuring its com
 
 ### "Experimental Version"
 
-We have discontinued our Experimental Version. Development will continue on the Development Version of the aircraft. 
+We have discontinued our Experimental Version. Latest features and testing will be on the Development Version of the aircraft. 
 
 ## Version Comparison
 

--- a/docs/fbw-a32nx/fbw-versions.md
+++ b/docs/fbw-a32nx/fbw-versions.md
@@ -25,22 +25,7 @@ This version will not always be up-to-date, but we work hard at ensuring its com
 
 ### "Experimental Version"
 
-This version is similar to the development version, but contains custom systems in earlier development phases.
-
-We use this version to find problems, issues and to improve functionality based on your feedback. It is not meant to be used for daily use or when you try to do a serious flight on VATSIM.
-
-!!! warning
-
-The Experimental version has a less strict QA process and is used for actual QA testing. Bugs and Issues are to be expected. 
-
-!!! danger ""
-    Before using this version, please read the [Experimental Version Support Page](support/exp.md) to see what is currently being tested. 
-
-The experimental version will be updated regularly and also with the latest changes to the Development version. Expect updates about once a week (not guaranteed).
-
-!!! danger "Do not expect support for the experimental version - use at own risk!"
-
-We ask that you understand that we may not offer support for any experimental issues due to the nature of this version. We will happily answer questions, time permitting.
+We have discontinued our Experimental Version. Development will continue on the Development Version of the aircraft. 
 
 ## Version Comparison
 

--- a/docs/fbw-a32nx/feature-guides/cFMS.md
+++ b/docs/fbw-a32nx/feature-guides/cFMS.md
@@ -96,7 +96,7 @@ It is important to note that the weather radar is not available yet with the lat
 We believe the benefits that cFMS provides outweigh the temporary lack of WX functionality. Weather will still prove to be a challenge due to the lack of a native SDK API. We have posted about it on the MSFS forums, where it currently sits at the top of the wishlist, and Asobo are investigating how to best improve their API.
 
 [Read more about the weather and terrain API.](https://forums.flightsimulator.com/t/implement-weather-and-terrain-api-s-for-aircraft-developers-to-implement-accurate-radar-predictive-windshear-egpws-and-metar-wind-uplink/442016){target=new}
-**Please note again that terrain radar is being tested in our Experimental version.**
+**Please note again that terrain radar is available on our Stable and Development Versions.**
 
 ## Flight Path Rendering
 

--- a/docs/fbw-a32nx/feature-guides/flypados3/settings.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/settings.md
@@ -227,7 +227,7 @@ Settings for integrations with various 3rd party applications
 </div>
 
 !!! warning ""
-    This feature is only available in the [Development Version](../../fbw-versions.md#development-version-recommended) and [Experimental Version](../../fbw-versions.md#experimental-version)
+    This feature is only available in the [Development Version](../../fbw-versions.md#development-version-recommended)
 
 #### GSX Integration
 These options are separate to provide you with the flexibility to choose what to sync with GSX and what not to sync. 

--- a/docs/fbw-a32nx/feature-guides/gsxintegration/index.md
+++ b/docs/fbw-a32nx/feature-guides/gsxintegration/index.md
@@ -11,7 +11,7 @@ description: A guide to the GSX Integration provided in the development version.
 ## Description
 
 !!! warning "Please Note"
-    This guide covers GSX Integration and the features available in the latest FlyByWire [Development Version](../../fbw-versions.md#development-version-recommended) and [Experimental Version](../../fbw-versions.md#experimental-version).
+    This guide covers GSX Integration and the features available in the latest FlyByWire [Development Version](../../fbw-versions.md#development-version-recommended).
 
     If you use the FlyByWire Stable version, you might not have these features available.
 

--- a/docs/fbw-a32nx/installation.md
+++ b/docs/fbw-a32nx/installation.md
@@ -61,7 +61,7 @@ You can send us logs to our [Discord](https://discord.gg/flybywire){target=new} 
 
           [Download Stable](https://github.com/flybywiresim/a32nx/releases/download/assets/stable/A32NX-stable.zip){.md-button target=new}
 
-          Latest release notes: [View Here](https://docs.flybywiresim.com/latest-release/)
+          Latest release notes: [View Here](/latest-release/)
 
 
     === "Development Version"

--- a/docs/fbw-a32nx/installation.md
+++ b/docs/fbw-a32nx/installation.md
@@ -27,7 +27,7 @@ Please follow the information on this page to install the FlyByWire Simulations 
 
 ### FlyByWire Installer
 
-Download the new FlyByWire installer where you can select either the Stable, Development, or Experimental build. Our installer downloads and installs the add-on directly into your community folder.
+Download the new FlyByWire installer where you can select either the Stable, or Development build. Our installer downloads and installs the add-on directly into your community folder.
 
 The following commands can be used:
 
@@ -74,19 +74,26 @@ You can send us logs to our [Discord](https://discord.gg/flybywire){target=new} 
          
          [**IMPORTANT:** View information on Autopilot / Fly-By-Wire here](feature-guides/autopilot-fbw.md)
 
-    === "Experimental Version"
+[//]: # (    === "Experimental Version")
 
-        This version is similar to the development version, but contains custom systems early in the development phase - expect issues.
+[//]: # ()
+[//]: # (        This version is similar to the development version, but contains custom systems early in the development phase - expect issues.)
 
-        To see what features are being tested in our experimental version, please read [Experimental Version Support 
-        Page](support/exp.md) before using this version.
-    
-        It will be updated with the latest changes to the development version every week or so while new major features are tested (not guaranteed).
+[//]: # ()
+[//]: # (        To see what features are being tested in our experimental version, please read [Experimental Version Support )
 
-        [Download Experimental](https://github.com/flybywiresim/a32nx/releases/download/assets/experimental/A32NX-experimental.zip){.md-button target=new}
+[//]: # (        Page]&#40;support/exp.md&#41; before using this version.)
 
-        !!! danger "No Support for Experimental - use at own risk"
-            Please do not seek support for the Experimental Version on Discord, and only report issues if you have read this page and the reported and known issues.
+[//]: # (    )
+[//]: # (        It will be updated with the latest changes to the development version every week or so while new major features are tested &#40;not guaranteed&#41;.)
+
+[//]: # ()
+[//]: # (        [Download Experimental]&#40;https://github.com/flybywiresim/a32nx/releases/download/assets/experimental/A32NX-experimental.zip&#41;{.md-button target=new})
+
+[//]: # ()
+[//]: # (        !!! danger "No Support for Experimental - use at own risk")
+
+[//]: # (            Please do not seek support for the Experimental Version on Discord, and only report issues if you have read this page and the reported and known issues.)
 
 ---
 

--- a/docs/fbw-a32nx/installation.md
+++ b/docs/fbw-a32nx/installation.md
@@ -61,7 +61,7 @@ You can send us logs to our [Discord](https://discord.gg/flybywire){target=new} 
 
           [Download Stable](https://github.com/flybywiresim/a32nx/releases/download/assets/stable/A32NX-stable.zip){.md-button target=new}
 
-          You can see the changelog on the releases page: [View Here](https://github.com/flybywiresim/a32nx/releases){target=new}
+          Latest release notes: [View Here](https://docs.flybywiresim.com/latest-release/)
 
 
     === "Development Version"

--- a/docs/fbw-a32nx/support/exp.md
+++ b/docs/fbw-a32nx/support/exp.md
@@ -1,0 +1,8 @@
+# Experimental Version
+
+Our Experimental Version is temporarily on hold and all of its features have been moved to the Development Version. 
+
+See our versions here:
+
+[A32NX Versions](../fbw-versions.md){.md-button}
+

--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -190,8 +190,6 @@ The following list of issues are commonly reported on our Discord support channe
 
     The Stable and Development versions of the A32NX are working well for most of our users. If you encounter problems, you might need to tune your system to handle the complexity of the A32NX (see solutions below).
 
-    The Experimental version has a higher risk of having performance issues. Switch to Development, if these issues make the aircraft unusable for you. 
-
     ^^Possible Solution or Workaround^^
 
     - [Do Not Use DX12](#do-not-use-dx12)

--- a/docs/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/managed-modes.md
+++ b/docs/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/managed-modes.md
@@ -29,7 +29,7 @@ The SRS guidance law also includes:
 
 ## CLB (Climb)
 
-!!! warning "Managed CLB or DES (VNAV) is currently only available in the Development & Experimental versions."
+!!! warning "Managed CLB or DES (VNAV) is currently only available in the Development version."
 
 CLB mode guides the aircraft in a managed climb, at either a managed or a selected target speed, to an FCU selected altitude, considering altitude constraints at waypoints. The system also considers speed constraints if the target speed is managed.
 
@@ -88,7 +88,7 @@ When ALT is engaged, the FMA displays ALT in green (FCU altitude hold), ALT CST 
 
 ## DES (Descent)
 
-!!! warning "Managed CLB or DES (VNAV) is currently only available in the Development & Experimental versions."
+!!! warning "Managed CLB or DES (VNAV) is currently only available in the Development version."
 
 The managed descent mode guides the aircraft along the FMS computed vertical flight path. The DES mode is preferred when conditions permit, since it ensures the management of altitude constraints and reduces the operating cost when flying at ECON DES speed.
 

--- a/docs/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/managed-modes.md
+++ b/docs/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/managed-modes.md
@@ -29,7 +29,7 @@ The SRS guidance law also includes:
 
 ## CLB (Climb)
 
-!!! warning "Managed CLB or DES (VNAV) is currently only available in the Development version."
+!!! warning "Managed CLB or DES (VNAV) is currently only available in the Development Version."
 
 CLB mode guides the aircraft in a managed climb, at either a managed or a selected target speed, to an FCU selected altitude, considering altitude constraints at waypoints. The system also considers speed constraints if the target speed is managed.
 
@@ -88,7 +88,7 @@ When ALT is engaged, the FMA displays ALT in green (FCU altitude hold), ALT CST 
 
 ## DES (Descent)
 
-!!! warning "Managed CLB or DES (VNAV) is currently only available in the Development version."
+!!! warning "Managed CLB or DES (VNAV) is currently only available in the Development Version."
 
 The managed descent mode guides the aircraft along the FMS computed vertical flight path. The DES mode is preferred when conditions permit, since it ensures the management of altitude constraints and reduces the operating cost when flying at ECON DES speed.
 

--- a/docs/pilots-corner/beginner-guide/descent.md
+++ b/docs/pilots-corner/beginner-guide/descent.md
@@ -250,7 +250,7 @@ A few minutes before we reach our calculated descent point (TOD) we request clea
 !!! info "TOD marker A320"
     The A320 has a downward pointing arrow at the TOD to support the pilot with the decision of when to descend. Ultimately, it is still the pilot's responsibility to calculate and validate the TOD.
 
-    The TOD (top of descent) marker on the `ND` is available in the Development and Experimental version. 
+    The TOD (top of descent) marker on the `ND` is available in the Development version. 
 
 When clearance is given, we can start our descent to the flight level or altitude ATC has given us.
 
@@ -278,7 +278,7 @@ Also, ATC will often still expect us to respect the STAR's constraints, although
     The scenario that we are cleared to a lower altitude or flight level with altitude constraints above the clearance is an ideal scenario for the called so "VNAV" autopilot mode, which would be activated by using "`Managed Altitude Mode`" (pushing the `ALT selector`). The autopilot will automatically level off at the constraint and continue descending when the constraint is no longer valid.
 
     !!! warning ""
-        VNAV is currently only supported in our Development and Experimental versions of the A32NX.
+        VNAV is currently only supported in our Development version of the A32NX.
 
 We repeat the process until we have reached our desired final approach altitude.
 

--- a/docs/pilots-corner/beginner-guide/descent.md
+++ b/docs/pilots-corner/beginner-guide/descent.md
@@ -250,7 +250,7 @@ A few minutes before we reach our calculated descent point (TOD) we request clea
 !!! info "TOD marker A320"
     The A320 has a downward pointing arrow at the TOD to support the pilot with the decision of when to descend. Ultimately, it is still the pilot's responsibility to calculate and validate the TOD.
 
-    The TOD (top of descent) marker on the `ND` is available in the Development version. 
+    The TOD (top of descent) marker on the `ND` is available in the Development Version. 
 
 When clearance is given, we can start our descent to the flight level or altitude ATC has given us.
 
@@ -278,7 +278,7 @@ Also, ATC will often still expect us to respect the STAR's constraints, although
     The scenario that we are cleared to a lower altitude or flight level with altitude constraints above the clearance is an ideal scenario for the called so "VNAV" autopilot mode, which would be activated by using "`Managed Altitude Mode`" (pushing the `ALT selector`). The autopilot will automatically level off at the constraint and continue descending when the constraint is no longer valid.
 
     !!! warning ""
-        VNAV is currently only supported in our Development version of the A32NX.
+        VNAV is currently only supported in our Development Version of the A32NX.
 
 We repeat the process until we have reached our desired final approach altitude.
 
@@ -300,7 +300,7 @@ We repeat the process until we have reached our desired final approach altitude.
     - Ensure that appropriate radio NAVAIDS are tuned and identified. The A32NX is capable of autotuning to the correct frequency.
   
         !!! warning "Autotuning"
-            Not available in the Stable version of the A32NX.
+            Not available in the Stable Version of the A32NX.
   
     - For NDB approaches, manually select the reference NAVAID.
 

--- a/docs/pilots-corner/beginner-guide/starting-the-aircraft.md
+++ b/docs/pilots-corner/beginner-guide/starting-the-aircraft.md
@@ -71,6 +71,9 @@ If ground power is available, we should see a green `AVAIL` light on the `EXT PW
 
 #### Flight Warning System Initialization
 
+!!! warning ""
+    Various aspects of this system is being reworked and it may not function as intended. This section will be updated once the rework is complete.
+
 The Flight Warning System (FWS) is a system that monitors the aircraft and alerts the crew of any abnormalities. The FWS initializes as soon as AC Bus power (External Power or APU) becomes available. 
 
 The initialization takes about 50 seconds and is indicated by the `FWS FWC 1+2 FAULT` message on the ECAM. The message will disappear, and various alarms may play once the initialization is complete.

--- a/docs/pilots-corner/beginner-guide/starting-the-aircraft.md
+++ b/docs/pilots-corner/beginner-guide/starting-the-aircraft.md
@@ -71,8 +71,6 @@ If ground power is available, we should see a green `AVAIL` light on the `EXT PW
 
 #### Flight Warning System Initialization
 
-!!! warning "Currently on the Experimental version only."
-
 The Flight Warning System (FWS) is a system that monitors the aircraft and alerts the crew of any abnormalities. The FWS initializes as soon as AC Bus power (External Power or APU) becomes available. 
 
 The initialization takes about 50 seconds and is indicated by the `FWS FWC 1+2 FAULT` message on the ECAM. The message will disappear, and various alarms may play once the initialization is complete.

--- a/docs/simbridge/index.md
+++ b/docs/simbridge/index.md
@@ -32,9 +32,6 @@ SimBridge is our custom-built solution to connect our aircraft to various extern
 
 !!! warning "Important Notes"
     Please keep SimBridge updated at all times, regardless of the version of aircraft you are currently flying!
-
-    !!! tip ""
-        Reminder: Any feature available in the Development version will also be available in the Experimental version.
     
     ---
 

--- a/docs/simbridge/install-configure/installation.md
+++ b/docs/simbridge/install-configure/installation.md
@@ -10,7 +10,7 @@ Please follow the information on this page to install the FlyByWire SimBridge to
 
 #### Add-on Install
 
-When you attempt to install an add-on or different add-on version (for example, switching from Development to Experimental) you will be prompted to install SimBridge
+When you attempt to install an add-on or different add-on version (for example, switching from Stable to Development) you will be prompted to install SimBridge
 
 ![SimBridge install prompt](../assets/installer_prompt.png "Prompt to install SimBridge when installing an add-on that requires it"){loading=lazy}
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,7 +54,8 @@ plugins:
         'start/support.md': 'fbw-a32nx/support/index.md'
         'start/reported-issues.md': 'fbw-a32nx/support/reported-issues.md'
         'start/autopilot-fbw.md': 'fbw-a32nx/feature-guides/autopilot-fbw.md'
-        'start/exp.md': 'fbw-a32nx/support/exp.md'
+        # Commented out in case we want to use this in the future
+#        'start/exp.md': 'fbw-a32nx/support/exp.md'
         # Folder: /beginner-guide/
         'beginner-guide/overview.md': 'pilots-corner/beginner-guide/overview.md'
         # Folder: /airliner-flying-guide/
@@ -84,7 +85,8 @@ plugins:
         'discord-bot.md': 'dev-corner/development-projects/discord-bot.md'
         'airframe.md': 'https://docs.flybywiresim.com/fbw-a32nx/installation/#simbrief-airframe'
         'fdr.md': 'https://docs.flybywiresim.com/fbw-a32nx/support/#fdr-files'
-        'exp.md': 'fbw-a32nx/support/exp.md'
+        # Commented out in case we want to use this in the future
+        #        'exp.md': 'fbw-a32nx/support/exp.md'
         'vnav.md': 'pilots-corner/advanced-guides/flight-guidance/vertical-guidance/overview.md'
         # Release Notes Permalink
         'latest-release.md': 'release-notes/v0101.md'


### PR DESCRIPTION
## Summary
Supports the discontinuation of the Experimental Version

### Location
- Multiple Locations based on references

### TODO

Working top level directories to tackle:

- [x] fbw-a32nx - WIP Val
- [x] dev-corner
- [x] pilots-corner
- [x] release-notes
- [x] simbridge
- [x] Verify mention of FWS initialization is correct
- [x] Fix Installation.md changelog link to go to /release-notes directory instead

Check when complete.

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
