### PR TITLE
build: bump mkdocs-material -> 9.1.18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.1.15
+mkdocs-material==9.1.18
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary
Minor changes from upstream mkdocs material. Tested locally needs a quick vercel sanity check.

Fixes:

- Search separator with lookbhind breaks highlighting
- Regression in social plugin config
- Code annotations lists incorrectly mounted

### Location
- requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
