### PR TITLE
docs(resources): add tech stack / language table summary

### DIFF
--- a/docs/dev-corner/dev-guide/resources.md
+++ b/docs/dev-corner/dev-guide/resources.md
@@ -32,10 +32,21 @@ There are many other channels for specific systems or subprojects. If you are wo
 
 Our tech stack includes the following:
 
-- Systems development for aircraft uses Rust and the `msfs-rs` library
+!!! info "Tech Stack / Language Summary"
+    Below you can find a table summary of the languages and technologies used in the A32NX project.
+
+    |           Category            | Language / Technology                                     |
+    |:-----------------------------:|-----------------------------------------------------------|
+    |            General            | React                                                     |
+    |           flyPadOS            | Tailwind CSS, Redux                                       |
+    |  Autopilot / Flight Controls  | MATLAB / C++                                              |
+    | Systems / Physics Simulations | Rust                                                      |
+    |      Displays / Avionics      | Typescript / React (deprecated) / MSFS Avionics Framework |
+
+- Systems development for aircraft uses Rust and the `msfs-rs` library.
 - Avionics programming is done using JavaScript or TypeScript (depending on the project), with the `React.js` rendering library.
-- Front-end web or desktop app development uses the same technologies outlined above
-- Server-side development uses `nest.js` for the API and `MySQL` for the database backend
+- Front-end web or desktop app development uses the same technologies outlined above.
+- Server-side development uses `nest.js` for the API and `MySQL` for the database backend.
 
 Knowledge of all items on this list is obviously not necessary, but this can hopefully give you a better insight into what your skills can fit into.
 

--- a/docs/dev-corner/dev-guide/resources.md
+++ b/docs/dev-corner/dev-guide/resources.md
@@ -35,13 +35,13 @@ Our tech stack includes the following:
 !!! info "Tech Stack / Language Summary"
     Below you can find a table summary of the languages and technologies used in the A32NX project.
 
-    |           Category            | Language / Technology                                     |
-    |:-----------------------------:|-----------------------------------------------------------|
-    |            General            | React                                                     |
-    |           flyPadOS            | Tailwind CSS, Redux                                       |
-    |  Autopilot / Flight Controls  | MATLAB / C++                                              |
+    | Category                      | Language / Technology                                     |
+    |:------------------------------|-----------------------------------------------------------|
+    | General                       | React                                                     |
+    | flyPadOS                      | Tailwind CSS, Redux                                       |
+    | Autopilot / Flight Controls   | MATLAB / C++                                              |
     | Systems / Physics Simulations | Rust                                                      |
-    |      Displays / Avionics      | Typescript / React (deprecated) / MSFS Avionics Framework |
+    | Displays / Avionics           | Typescript / React (deprecated) / MSFS Avionics Framework |
 
 - Systems development for aircraft uses Rust and the `msfs-rs` library.
 - Avionics programming is done using JavaScript or TypeScript (depending on the project), with the `React.js` rendering library.


### PR DESCRIPTION
closes: #853

## Summary
See issue.

Provides neat little table for overview of tech stack

### Location
- docs/dev-corner/dev-guide/resources.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
