### PR TITLE
build: remove urllib3 version lock

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ mkdocs-video
 mkdocs-glightbox
 pillow
 cairosvg
-urllib3==1.26.15


### PR DESCRIPTION
## Summary
Testing build without version lock for urllib3.

### Location
- requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
