### PR TITLE
build: bump mkdocs-material -> 9.2.1

### DIFF
--- a/docs/dev-corner/dev-guide/index.md
+++ b/docs/dev-corner/dev-guide/index.md
@@ -28,10 +28,10 @@ tools, downloading and compiling the A32NX successfully to guidelines how to con
 
 ##  Topics
 
-| Quick Links                                                | Description                                                                                                                                 |
-|:-----------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------|
-| [Resources](resources.md)                                  | General information and documentation resources                                                                                             |
+| Quick Links                                                    | Description                                                                                                                                 |
+|:---------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------------------------------------------|
+| [Resources](resources.md)                                      | General information and documentation resources                                                                                             |
 | [Setting up the Development Environment](setup-environment.md) | From software to troubleshooting - everything you need to successfully change and compile the code.                                           |
-| [Contribution Guidelines](contribute.md)                   | From General Development Process and Practices to Pull Requests - everything you need to know to collaborate and contribute to the project. |
-| [Specific Development Areas](specific/)                    | Information for specific parts of the project like the flyPad or avionics.                                                                  |
+| [Contribution Guidelines](contribute.md)                       | From General Development Process and Practices to Pull Requests - everything you need to know to collaborate and contribute to the project. |
+| [Specific Development Areas](specific/index.md)                | Information for specific parts of the project like the flyPad or avionics.                                                                  |
 

--- a/docs/dev-corner/development-projects/documentation.md
+++ b/docs/dev-corner/development-projects/documentation.md
@@ -119,7 +119,7 @@ feature.
     You can opt to use a faster instance of the developer server by invoking the flag `--dirtyreload`. This just checks for any markdown that has changed since the HTML was rendered and will reconstruct any relevant pages only, rather than rebuilding the entire website.
 
     ```
-    mkdocs.exe serve --dirtyreload
+    mkdocs.exe serve --dirty
     ```
 
     !!! danger ""

--- a/docs/dev-corner/development-projects/documentation.md
+++ b/docs/dev-corner/development-projects/documentation.md
@@ -123,7 +123,7 @@ feature.
     ```
 
     !!! danger ""
-        Navigation and new internal links may not get updated on other pages while using `--dirtyreload`. Verify links using the standard serve or build command.
+        Navigation and new internal links may not get updated on other pages while using `--dirty`. Verify links using the standard serve or build command.
 
 - You can now browse the current checked out branch in a browser at this address: [http://127.0.0.1:8000/](http://127.0.0.1:8000/). The site renders every time you save any `filename.md` you are working on.
 - Optional: Build a static site locally for testing:

--- a/docs/dev-corner/index.md
+++ b/docs/dev-corner/index.md
@@ -13,10 +13,10 @@ This section of the FlyByWire Documentation is dedicated to the development aspe
 
 ## Quick Links
 
-| Topics                                      |
-|:--------------------------------------------|
-| [Development Guide](dev-guide/index.md)     |
-| [Texture Changes](texture-changes.md)       |
-| [Scenery Developers](scenery-developers.md) |
-| [FlyByWire Projects](development-projects/) |
+| Topics                                              |
+|:----------------------------------------------------|
+| [Development Guide](dev-guide/index.md)             |
+| [Texture Changes](texture-changes.md)               |
+| [Scenery Developers](scenery-developers.md)         |
+| [FlyByWire Projects](development-projects/index.md) |
 

--- a/docs/dev-corner/texture-changes.md
+++ b/docs/dev-corner/texture-changes.md
@@ -23,7 +23,7 @@ The A32NX has a [toggle option in the EFB to disable the dynamic registration nu
 !!! warning "Avoid Using panel.cfg"
     Overriding `panel.cfg` creates future conflicts with A32NX development.
 
-    Please avoid using `panel.cfg` to disable the registration number decal, and instead advise users to [disable the dynamic decal in the EFB settings](../../fbw-a32nx/feature-guides/flypados3/settings/#sim-options).
+    Please avoid using `panel.cfg` to disable the registration number decal, and instead advise users to [disable the dynamic decal in the EFB settings](../fbw-a32nx/feature-guides/flypados3/settings.md#sim-options).
 
 ## Mirrored Wheel Texture
 

--- a/docs/fbw-a32nx/faq.md
+++ b/docs/fbw-a32nx/faq.md
@@ -1,3 +1,7 @@
+---
+status: new
+---
+
 ## General
 
 ???+ info "Q: Where is the plane in-sim?"

--- a/docs/fbw-a32nx/faq.md
+++ b/docs/fbw-a32nx/faq.md
@@ -1,7 +1,3 @@
----
-status: new
----
-
 ## General
 
 ???+ info "Q: Where is the plane in-sim?"

--- a/docs/fbw-a32nx/fbw-versions.md
+++ b/docs/fbw-a32nx/fbw-versions.md
@@ -29,7 +29,7 @@ We have discontinued our Experimental Version. Latest features and testing will 
 
 ## Version Comparison
 
-See [Latest Release Notes for Stable](/latest-release)
+See [Latest Release Notes for Stable](/latest-release/)
 
 For all changes made to the Development version since the last major release of the Stable version, refer to:
 

--- a/docs/fbw-a32nx/fbw-versions.md
+++ b/docs/fbw-a32nx/fbw-versions.md
@@ -2,7 +2,7 @@
 
 ## Version Overview
 
-### "Development Version (recommended)"
+### Development Version (recommended)
 
 Development will have the latest features that will eventually end up in the next stable release.
 
@@ -14,7 +14,7 @@ Every addition to the development version is code-reviewed and tested by several
 
 The latest additions to this version can be seen either in the official [CHANGELOG](https://github.com/flybywiresim/aircraft/blob/master/.github/CHANGELOG.md) or the commits to the master branch of the project: [GitHub Commits to Master](https://github.com/flybywiresim/aircraft/commits/master){target=new}
 
-### "Stable Version"
+### Stable Version
 
 !!! info ""
     **Current Stable Version -** <img src="https://img.shields.io/github/v/release/flybywiresim/aircraft.svg?color=2F4E5B&style=flat" />
@@ -23,7 +23,7 @@ Stable is our version which contains features that are the most mature and most 
 
 This version will not always be up-to-date, but we work hard at ensuring its compatibility with the current version of Microsoft Flight Simulator.
 
-### "Experimental Version"
+### Experimental Version
 
 We have discontinued our Experimental Version. Latest features and testing will be on the Development Version of the aircraft. 
 

--- a/docs/fbw-a32nx/feature-guides/flypados3/settings.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/settings.md
@@ -226,8 +226,9 @@ Settings for integrations with various 3rd party applications
     <span class="imagesub">Click on the menu icons in this image to see other flyPad pages.</span>
 </div>
 
-!!! warning ""
-    This feature is only available in the [Development Version](../../fbw-versions.md#development-version-recommended)
+[//]: # (!!! warning "")
+
+[//]: # (    This feature is only available in the [Development Version]&#40;../../fbw-versions.md#development-version-recommended&#41;)
 
 #### GSX Integration
 These options are separate to provide you with the flexibility to choose what to sync with GSX and what not to sync. 

--- a/docs/fbw-a32nx/index.md
+++ b/docs/fbw-a32nx/index.md
@@ -21,6 +21,7 @@ Engine      CFM LEAP 1A-26
 APU         APS3200
 FMS         Honeywell Release H3
 FWC Std.    H2F13
+RA          Honeywell ALA-52B
 TAWS        Honeywell EGPWS
 ACAS        Honeywell TPA-100B
 ATC         Honeywell TRA-100B

--- a/docs/fbw-a32nx/index.md
+++ b/docs/fbw-a32nx/index.md
@@ -38,12 +38,12 @@ WXR         Honeywell RDR-4000
 ##  Topics
 
 | Featured List                                |
-| :----                                        |
+|:---------------------------------------------|
 | [Installation Guide](installation.md)        |
 | [Version and Feature Guide](fbw-versions.md) |
 | [Livery Guide](liveries.md)                  |
 | [Support](support/index.md)                  |
-| [API and Hardware](a32nx-api)                |
+| [API and Hardware](a32nx-api/index.md)       |
 
 
 

--- a/docs/simbridge/simbridge-feature-guides/remote-displays/remote-mcdu.md
+++ b/docs/simbridge/simbridge-feature-guides/remote-displays/remote-mcdu.md
@@ -19,7 +19,7 @@ It also allows you to use your real printer as a cockpit printer for the MCDU.
     Please note the following requirements before trying to use this feature:
 
     - SimBridge *must* be [running](../../install-configure/start-simbridge.md#autostart) in order to connect remotely.
-    - See [Autostart](../../install-configure/start-simbridge#autostart) documentation on how to start it.
+    - See [Autostart](../../install-configure/start-simbridge.md#autostart) documentation on how to start it.
     - Check [Troubleshooting](../../troubleshooting.md) if you are having issues.
 
     !!! tip ""

--- a/docs/stylesheets/navigation.css
+++ b/docs/stylesheets/navigation.css
@@ -13,9 +13,9 @@
   color: #ffffff;
   background-color: #1F2A3C;
 }
-.md-tabs__link--active, .md-tabs__link:focus, .md-tabs__link:hover {
+
+.md-tabs__item--active, .md-tabs__item:focus, .md-tabs__item:hover {
   border-bottom: 1.5px solid #00E0FE;
-  height: -webkit-fill-available;
 }
 
 /* Sidebar Navigation Modifications */

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ theme:
     scheme: slate
     primary: custom
   features:
+    - navigation.prune
     - navigation.tabs
     - navigation.tabs.sticky
     # Removed this feature again as it's breaking TOC navigation on reported-issues.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,6 +136,8 @@ extra:
     - icon: fontawesome/brands/youtube
       link: https://www.youtube.com/@FlyByWireSim
       name: FlyByWire Simulations on Youtube
+  status:
+    new: Recently Updated
 
 # Additional Markdown Extensions to use bundled icon sets
 markdown_extensions:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,6 +117,8 @@ extra_css:
 
 # Extra Functions / Customizations
 extra:
+  status:
+    new: Recently Updated
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/flybywiresim
@@ -136,8 +138,6 @@ extra:
     - icon: fontawesome/brands/youtube
       link: https://www.youtube.com/@FlyByWireSim
       name: FlyByWire Simulations on Youtube
-  status:
-    new: Recently Updated
 
 # Additional Markdown Extensions to use bundled icon sets
 markdown_extensions:

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -8,8 +8,8 @@
         <div class="hero">
             <div class="hero-content">
                 <h1> FlyByWire Documentation </h1>
-                    <p>Welcome to our documentation and guides website for FlyByWire Simulations open source, community-driven projects.</p>
-                    <p>Here you'll find plenty of resources that help you pilot and use our aircraft. This is also where you can find information on how to contribute to ongoing FlyByWire projects!</p>
+                    <p>Welcome to the documentation and guides website for FlyByWire Simulations open source, community-driven projects.</p>
+                    <p>You'll find plenty of resources that help you pilot and use our aircraft. You can also find information on how to contribute to ongoing FlyByWire projects!</p>
                 <a href="{{ page.next_page.url | url }}" title="{{ page.next_page.title | striptags }}" class="md-button md-button--primary">
                     Start Here
                 </a>

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -8,7 +8,7 @@
         <div class="hero">
             <div class="hero-content">
                 <h1> FlyByWire Documentation </h1>
-                    <p>Welcome to the documentation and guides for FlyByWire Simulations open source community-driven projects. Here you'll find plenty of resources that help you to pilot and use our aircraft or contribute towards development of ongoing FlyByWire projects.</p>
+                    <p>Welcome to the documentation and guides for FlyByWire Simulations open source, community-driven projects. Here you'll find plenty of resources that help you pilot and use our aircraft. This is also where you can find information on how to contribute to ongoing FlyByWire projects!</p>
                 <a href="{{ page.next_page.url | url }}" title="{{ page.next_page.title | striptags }}" class="md-button md-button--primary">
                     Start Here
                 </a>

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -8,7 +8,8 @@
         <div class="hero">
             <div class="hero-content">
                 <h1> FlyByWire Documentation </h1>
-                    <p>Welcome to the documentation and guides for FlyByWire Simulations open source, community-driven projects. Here you'll find plenty of resources that help you pilot and use our aircraft. This is also where you can find information on how to contribute to ongoing FlyByWire projects!</p>
+                    <p>Welcome to our documentation and guides website for FlyByWire Simulations open source, community-driven projects.</p>
+                    <p>Here you'll find plenty of resources that help you pilot and use our aircraft. This is also where you can find information on how to contribute to ongoing FlyByWire projects!</p>
                 <a href="{{ page.next_page.url | url }}" title="{{ page.next_page.title | striptags }}" class="md-button md-button--primary">
                     Start Here
                 </a>

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ mkdocs-video
 mkdocs-glightbox
 pillow
 cairosvg
-urllib3==1.26.15
+urllib3<2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.2.0b3
+mkdocs-material==9.2.1
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.1.21
+mkdocs-material==9.2.0b0
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.2.0b2
+mkdocs-material==9.2.0b3
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.2.0b1
+mkdocs-material==9.2.0b2
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.2.0b0
+mkdocs-material==9.2.0b1
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary

Notable new features to test are related to navigation.
There is a blog plugin now! Not sure if useful for docs.
Annotations is also new could be interesting use case.

## TODO
- [x] Test for anything broken
- [x] Add new features if relevant
- [x] Test new features

### Added for testing

- Recently Updated flag - can also be used for "added" but since we rarely add pages updated could be better // manual setting on each page. Sample below using faq.md:
![image](https://github.com/flybywiresim/docs/assets/1619968/aa5c1522-df49-453e-b84f-1bc9733caa4c)
  - I have removed this example from the build but will keep this here to reference for later usage.
- navigation pruning
  - only the visible navigation items are included in the rendered HTML

### Updated/Fixed for build update

- Fixed Versions page to not have "" surrounding the headers
- Updated the simulated hardware list on the about FBW A32NX page
- Fixed broken styling in navigation.css for the border-bottom in the main navigation bar

### MkDocs 1.5.0 Changes

- New mkdocs 1.5.0 flag for dirty builds reflected in documentation.md
- Cleaned up INFO status when serving / bulding so that links don't generate any potential warnings reference block below:

```
FIXED - Doc file 'dev-corner/index.md' contains an unrecognized relative link 'development-projects/', it was left as is. Did you mean 'development-projects/index.md'? 
FIXED -  Doc file 'dev-corner/texture-changes.md' contains an unrecognized relative link '../../fbw-a32nx/feature-guides/flypados3/settings/#sim-options', it was left as is. --fixed
FIXED    -  Doc file 'dev-corner/dev-guide/index.md' contains an unrecognized relative link 'specific/', it was left as is. Did you mean 'specific/index.md'? - fixed
INTERNAL REDIRECT OK -  Doc file 'fbw-a32nx/installation.md' contains an absolute link '/latest-release/', it was left as is.
INTERNAL REDIRECT OK -  Doc file 'fbw-a32nx/fbw-versions.md' contains an absolute link '/latest-release', it was left as is.
FIXED -  Doc file 'simbridge/simbridge-feature-guides/remote-displays/remote-mcdu.md' contains an unrecognized relative link '../../install-configure/start-simbridge#autostart', it was left as is. Did you mean
           '../../install-configure/start-simbridge.md#autostart'?
```

**Note**: Latest shipped version of Mkdocs is 1.5.2

### Location
- requirements.txt
- stylesheets/navigation.css
- fbw-a32nx/fbw-versions.md
- fbw-a32nx/index.md
- mkdocs.yml

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
 valastiri
