### PR TITLE
docs: replace depreciated with deprecated

### DIFF
--- a/docs/fbw-a32nx/feature-guides/nw-tiller.md
+++ b/docs/fbw-a32nx/feature-guides/nw-tiller.md
@@ -66,7 +66,7 @@ Map `NOSE WHEEL STEERING AXIS` to the controller axis you want to use for the ti
 
 ??? warning "How to configure MIXTURE 4 AXIS (-100 % to 100 %) - OLD"
 
-    Please note, this configuration <span style=color:orange>is deprecated and will be removed in future.</span>
+    Please note, this configuration <span style=color:orange>is deprecated and will be removed in the future.</span>
 
     ![MSFS Controller Options Mapping](../assets/nw-tiller/handwheel-controller-mapping.png "MSFS Controller Options Mapping"){loading=lazy}
 

--- a/docs/fbw-a32nx/feature-guides/nw-tiller.md
+++ b/docs/fbw-a32nx/feature-guides/nw-tiller.md
@@ -54,7 +54,7 @@ Microsoft Flight Simulator introduced a separate nose wheel axis with the launch
 For compatibility, we currently have two settings available for use with our Nose Wheel Tiller implementation. Originally, we utilized an unused axis to map the movement of your desired controller. Please see the two options below:
 
 - `NOSE WHEEL STEERING AXIS` - <span style=color:green>**Recommended Setting**</span>
-- `MIXTURE 4 AXIS (-100 % to 100 %)` - <span style=color:orange>To be depreciated soon.</span>
+- `MIXTURE 4 AXIS (-100 % to 100 %)` - <span style=color:orange>Deprecated for future removal.</span>
 
 #### How to Configure NOSE WHEEL STEERING AXIS
 
@@ -66,7 +66,7 @@ Map `NOSE WHEEL STEERING AXIS` to the controller axis you want to use for the ti
 
 ??? warning "How to configure MIXTURE 4 AXIS (-100 % to 100 %) - OLD"
 
-    Please note, this configuration <span style=color:orange>will be depreciated soon.</span>
+    Please note, this configuration <span style=color:orange>is deprecated and will be removed in future.</span>
 
     ![MSFS Controller Options Mapping](../assets/nw-tiller/handwheel-controller-mapping.png "MSFS Controller Options Mapping"){loading=lazy}
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
I noticed strange wording in the nosewheel page while providing it to a user. The correct term here is deprecated, not depreciated. https://en.wikipedia.org/wiki/Deprecation#Software

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
https://docs.flybywiresim.com/fbw-a32nx/feature-guides/nw-tiller/

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
