### PR TITLE
feat(pilots-corner): Replace RMP labels for INOP & A32NX Flightdeck API 

### DIFF
--- a/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -768,23 +768,34 @@ Flight Deck: [RMP Panel](../../pilots-corner/a32nx-briefing/flight-deck/pedestal
 
 !!! note "The below table shows the API for RMP 1. Replace `1` with `2` or `3` for the other RMPs."
 
-| Function         | API Usage                 | Values           | Read/Write | Type             | Remark                        |
-|:-----------------|:--------------------------|:-----------------|:-----------|:-----------------|:------------------------------|
-| Active Frequency | COM ACTIVE FREQUENCY:1    | 118.000..136.975 | R/W        | SIMCONNECT VAR   |                               |
-|                  |                           |                  |            |                  |                               |
-| Stdby Frequency  | COM STANDBY FREQUENCY:1   | 118.000..136.975 | R/W        | SIMCONNECT VAR   |                               |
-|                  |                           |                  |            |                  |                               |
-| XFER Frequency   | COM1_RADIO_SWAP           | -                | -          | SIMCONNECT EVENT |                               |
-|                  |                           |                  |            |                  |                               |
-| RMP MODE         | A32NX_RMP_L_SELECTED_MODE | 0..3             | R/W        | Custom LVAR      | 0=SEL, 1=VHF1, 2=VHF2, 3=VHF3 |
-|                  |                           |                  |            |                  |                               |
-| RMP ON/OFF       | A32NX_RMP_L_TOGGLE_SWITCH | 0&#124;1         | R/W        | Custom LVAR      |                               |
-|                  |                           |                  |            |                  |                               |
-| Transmit VHF1    | COM TRANSMIT:1            | 0&#124;1         | R          | SIMCONNECT VAR   |                               |
-|                  |                           |                  |            |                  |                               |
-| Transmit VHF2    | COM TRANSMIT:2            | 0&#124;1         | R          | SIMCONNECT VAR   |                               |
-|                  |                           |                  |            |                  |                               |
-| Transmit VHF3    | COM TRANSMIT:3            | 0&#124;1         | R          | SIMCONNECT VAR   |                               |
+| Function                  | API Usage                      | Values              | Read/Write | Type             | Remark                                                          |
+|:--------------------------|:-------------------------------|:--------------------|:-----------|:-----------------|:----------------------------------------------------------------|
+| Active Frequency          | COM ACTIVE FREQUENCY:1         | 118.000..136.975    | R/W        | SIMCONNECT VAR   |                                                                 |
+|                           |                                |                     |            |                  |                                                                 |
+| Stdby Frequency           | COM STANDBY FREQUENCY:1        | 118.000..136.975    | R/W        | SIMCONNECT VAR   |                                                                 |
+|                           |                                |                     |            |                  |                                                                 |
+| XFER Frequency            | COM1_RADIO_SWAP                | -                   | -          | SIMCONNECT EVENT |                                                                 |
+|                           |                                |                     |            |                  |                                                                 |
+| RMP MODE                  | A32NX_RMP_L_SELECTED_MODE      | 0..3                | R/W        | Custom LVAR      | 0=SEL, 1=VHF1, 2=VHF2, 3=VHF3                                   |
+|                           |                                |                     |            |                  |                                                                 |
+| RMP ON/OFF                | A32NX_RMP_L_TOGGLE_SWITCH      | 0&#124;1            | R/W        | Custom LVAR      |                                                                 |
+|                           |                                |                     |            |                  |                                                                 |
+| Transmit VHF1             | COM TRANSMIT:1                 | 0&#124;1            | R          | SIMCONNECT VAR   |                                                                 |
+|                           |                                |                     |            |                  |                                                                 |
+| Transmit VHF2             | COM TRANSMIT:2                 | 0&#124;1            | R          | SIMCONNECT VAR   |                                                                 |
+|                           |                                |                     |            |                  |                                                                 |
+| Transmit VHF3             | COM TRANSMIT:3                 | 0&#124;1            | R          | SIMCONNECT VAR   |                                                                 |
+|                           |                                |                     |            |                  |                                                                 |
+| Pilot Transmitter Type    | PILOT TRANSMITTER TYPE         | 0..8                | R          | SIMCONNECT VAR   | 4=OFF, 0=VHF1, 1=VHF2, 2=VHF3, 3=HF1, 5=HF2, 6=INT, 7=CAB, 8=PA | 
+|                           |                                |                     |            |                  |                                                                 |
+| Co-Pilot Transmitter Type | COPILOT TRANSMITTER TYPE       | 0..8                | R          | SIMCONNECT VAR   | 4=OFF, 0=VHF1, 1=VHF2, 2=VHF3, 3=HF1, 5=HF2, 6=INT, 7=CAB, 8=PA |
+|                           |                                |                     |            |                  |                                                                 |
+| PA Knob Pressed           | A32NX_ACP1_PA_KNOB_VOLUME_DOWN | 0&#124;1            | R/W        | Custom LVAR      |                                                                 |
+|                           |                                |                     |            |                  |                                                                 |
+| PA Knob Volume            | A32NX_ACP1_PA_VOLUME           | 0&#124;1            | R/W        | Custom LVAR      |                                                                 |
+|                           |                                |                     |            |                  |                                                                 |
+| INT/RAD Switch            | A32NX_ACP1_SWITCH_INT          | 0&#124;100&#124;200 | R/W        | Custom LVAR      | 0=RAD (HOLD), 100=NORM, 200=INT                                 |
+
 
 ### Lighting Pedestal Captain Side Panel
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
@@ -156,7 +156,11 @@ Passenger Address is used by the flight personnel to make passenger announcement
 Pressed and held: To make an announcement, a boom, mask, or hand mic is used
 
 !!! info ""
-    Currently only available in the Development version of the aircraft. Due to Microsoft Flight Simulator limitations, this feature will not allow you to talk and hear the PA announcements, however you can use 3rd party addons to allow this functionality. [A32NX Flight Deck API](/fbw-a32nx/a32nx-api/a32nx-flightdeck-api/#rmp)
+    Currently only available in the Development version of the aircraft. 
+    
+    Due to MSFS limitations you are unable to talk and hear your mic transmissions for PA announcements. However you can use 3rd party addons to allow this functionality. 
+    
+    [A32NX Flight Deck API](/fbw-a32nx/a32nx-api/a32nx-flightdeck-api/#rmp){ .md-button }
 
 #### PA reception knob
 
@@ -166,7 +170,11 @@ Pressed and held: To make an announcement, a boom, mask, or hand mic is used
     - The PA system is disconnected. The white light goes out.
 
 !!! info ""
-    Currently only available in the Development version of the aircraft. Due to Microsoft Flight Simulator limitations, this feature will not allow you to talk and hear the PA announcements, however you can use 3rd party addons to allow this functionality. [A32NX Flight Deck API](/fbw-a32nx/a32nx-api/a32nx-flightdeck-api/#rmp)
+    Currently only available in the Development version of the aircraft. 
+    
+    Due to MSFS limitations you are unable to talk and hear your mic transmissions for PA announcements. However you can use 3rd party addons to allow this functionality. 
+    
+    [A32NX Flight Deck API](/fbw-a32nx/a32nx-api/a32nx-flightdeck-api/#rmp){ .md-button }
 
 ---
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
@@ -64,7 +64,7 @@ Turning these knobs selects the STBY frequency or CRS.
 Used to select AM mode if the aircraft has a VH transceiver.
 
 !!! info ""
-    Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
+    Currently only available in the Development version of the aircraft.
 
 ### SEL indicator
 
@@ -131,35 +131,35 @@ These knobs are used to allow the flight crew to activate a channel for receptio
 Extinguishes CALL, MECH, and ATT lights.
 
 !!! info ""
-    Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
+    Currently only available in the Development version of the aircraft.
 
 ### VOICE
 
 Inhibit the audio navigation signals (VOR, ADF) and filters out ident signals and turns on the green ON light.
 
 !!! info ""
-    Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
+    Currently only available in the Development version of the aircraft.
 
 ### INT/RAD
 
 Press-to-talk switch for boom mike or oxygen mask mike.
 
 !!! info ""
-    Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
+    Currently only available in the Development version of the aircraft.
 
 ### PA (Passenger Address)
 
 Passenger Address is used by the flight personnel to make passenger announcements through loudspeakers in the cabin.
 
 !!! info ""
-    Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
+    Currently only available in the Development version of the aircraft.
 
 #### PA transmission key
 
 Pressed and held: To make an announcement, a boom, mask, or hand mike is used
 
 !!! info ""
-    Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
+    Currently only available in the Development version of the aircraft.
 
 #### PA reception knob
 
@@ -169,7 +169,7 @@ Pressed and held: To make an announcement, a boom, mask, or hand mike is used
     - The PA system is disconnected. The white light goes out.
 
 !!! info ""
-    Currently not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
+    Currently only available in the Development version of the aircraft.
 
 ---
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
@@ -142,7 +142,7 @@ Inhibit the audio navigation signals (VOR, ADF) and filters out ident signals an
 
 ### INT/RAD
 
-Press-to-talk switch for boom mike or oxygen mask mike.
+Press-to-talk switch for boom mic or oxygen mask mic.
 
 !!! info ""
     Currently only available in the Development version of the aircraft.
@@ -156,7 +156,7 @@ Passenger Address is used by the flight personnel to make passenger announcement
 
 #### PA transmission key
 
-Pressed and held: To make an announcement, a boom, mask, or hand mike is used
+Pressed and held: To make an announcement, a boom, mask, or hand mic is used
 
 !!! info ""
     Currently only available in the Development version of the aircraft.

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
@@ -99,7 +99,7 @@ Power supply to the RMP.
 ![RMP Transmission Keys](../../../assets/a32nx-briefing/pedestal/RMP-transmission-keys.png)
 
 !!! info ""
-    Currently only the VHF1-3 channels are available in the FBW A32NX for Microsoft Flight Simulator.
+    Only VHF1-3 channels are available in the Stable version of the A32NX. The rest of the channels are available and operational in the Development version of the A32NX. 
 
 - Pressed:
     - Channel selected for transmission.
@@ -119,7 +119,7 @@ Power supply to the RMP.
 ![Reception Knobs](../../../assets/a32nx-briefing/pedestal/RMP-receiption-knobs-2.png "Reception Knobs")
 
 !!! info ""
-    Currently, only the VHF2-3 channels are available for selection in the FBW A32NX for Microsoft Flight Simulator. VHF1 is always selected, although not lit.
+    VHF2-3 channels are available for selection in the while VHF1 is always selected, although not lit in the current Stable version of the A32NX. The rest of the channels are available and operational in the Development version of the A32NX.
 
 These knobs are used to allow the flight crew to activate a channel for reception and to adjust volume.
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
@@ -158,7 +158,7 @@ Pressed and held: To make an announcement, a boom, mask, or hand mic is used
 !!! info ""
     Currently only available in the Development version of the aircraft. 
     
-    Due to MSFS limitations you are unable to talk and hear your mic transmissions for PA announcements. However you can use 3rd party addons to allow this functionality. 
+    Due to MSFS limitations you are unable to talk and hear your mic transmissions for PA announcements, but you can use 3rd party addons to integrate this functionality.
     
     [A32NX Flight Deck API](/fbw-a32nx/a32nx-api/a32nx-flightdeck-api/#rmp){ .md-button }
 
@@ -172,7 +172,7 @@ Pressed and held: To make an announcement, a boom, mask, or hand mic is used
 !!! info ""
     Currently only available in the Development version of the aircraft. 
     
-    Due to MSFS limitations you are unable to talk and hear your mic transmissions for PA announcements. However you can use 3rd party addons to allow this functionality. 
+    Due to MSFS limitations you are unable to talk and hear your mic transmissions for PA announcements, but you can use 3rd party addons to integrate this functionality. 
     
     [A32NX Flight Deck API](/fbw-a32nx/a32nx-api/a32nx-flightdeck-api/#rmp){ .md-button }
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
@@ -151,9 +151,6 @@ Press-to-talk switch for boom mic or oxygen mask mic.
 
 Passenger Address is used by the flight personnel to make passenger announcements through loudspeakers in the cabin.
 
-!!! info ""
-    Currently only available in the Development version of the aircraft.
-
 #### PA transmission key
 
 Pressed and held: To make an announcement, a boom, mask, or hand mic is used

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
@@ -159,7 +159,7 @@ Passenger Address is used by the flight personnel to make passenger announcement
 Pressed and held: To make an announcement, a boom, mask, or hand mic is used
 
 !!! info ""
-    Currently only available in the Development version of the aircraft.
+    Currently only available in the Development version of the aircraft. Due to Microsoft Flight Simulator limitations, this feature will not allow you to talk and hear the PA announcements, however you can use 3rd party addons to allow this functionality. [A32NX Flight Deck API](/fbw-a32nx/a32nx-api/a32nx-flightdeck-api/#rmp)
 
 #### PA reception knob
 
@@ -169,7 +169,7 @@ Pressed and held: To make an announcement, a boom, mask, or hand mic is used
     - The PA system is disconnected. The white light goes out.
 
 !!! info ""
-    Currently only available in the Development version of the aircraft.
+    Currently only available in the Development version of the aircraft. Due to Microsoft Flight Simulator limitations, this feature will not allow you to talk and hear the PA announcements, however you can use 3rd party addons to allow this functionality. [A32NX Flight Deck API](/fbw-a32nx/a32nx-api/a32nx-flightdeck-api/#rmp)
 
 ---
 

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
@@ -64,7 +64,7 @@ Turning these knobs selects the STBY frequency or CRS.
 Used to select AM mode if the aircraft has a VH transceiver.
 
 !!! info ""
-    Currently only available in the Development version of the aircraft.
+    Currently INOP or not implemented for the A32NX.
 
 ### SEL indicator
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
Replaces the INOP labels in the RMP page with remarks that its available for the dev version. 
It also changes the A32NX Flightdeck API to include the values available by the system

This PR is waiting for https://github.com/flybywiresim/aircraft/pull/7866 to be merged first  

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp
/fbw-a32nx/a32nx-api/a32nx-flightdeck-api/#rmp


<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): alepouna
