### PR TITLE
fix: Typo corrected con > can 

### DIFF
--- a/docs/simbridge/install-configure/configuration.md
+++ b/docs/simbridge/install-configure/configuration.md
@@ -79,4 +79,4 @@ The three settings are:
     - The displays will not make any attempts to connect to SimBridge.
 
 !!! warning "Timeout for SimBridge Connection Attempts"
-    If the aircraft con not connect to SimBridge within 5 min the aircraft will stop any further attempts and `Inactive` will be shown. If `Inactive` is shown, but you want to connect to SimBridge, just click on `Off`, wait a few seconds and then click on `Auto` again.
+    If the aircraft can not connect to SimBridge within 5 minutes the aircraft will stop any further attempts and `Inactive` will be shown. If `Inactive` is shown, but you want to connect to SimBridge, just click on `Off`, wait a few seconds and then click on `Auto` again.

--- a/docs/simbridge/install-configure/configuration.md
+++ b/docs/simbridge/install-configure/configuration.md
@@ -79,4 +79,4 @@ The three settings are:
     - The displays will not make any attempts to connect to SimBridge.
 
 !!! warning "Timeout for SimBridge Connection Attempts"
-    If the aircraft can not connect to SimBridge within 5 minutes the aircraft will stop any further attempts and `Inactive` will be shown. If `Inactive` is shown, but you want to connect to SimBridge, just click on `Off`, wait a few seconds and then click on `Auto` again.
+    If the aircraft can not connect to SimBridge within 5 mins the aircraft will stop any further attempts and `Inactive` will be shown. If `Inactive` is shown, but you want to connect to SimBridge, just click on `Off`, wait a few seconds and then click on `Auto` again.


### PR DESCRIPTION
## Summary
SimBridge Timeout connection warning. `If the aircraft con not correct` - 'con' has been corrected to 'can'. 

I did change mins to minutes in the following sentence but on review earlier in the page and across the docs site, 'min(s) and minute(s) are both used interchangeably across the site so not necessary. 

### Location
(https://docs.flybywiresim.com/simbridge/install-configure/configuration/#aircraft-settings)

Discord username (if different from GitHub): jason_91
