### PR TITLE
build: bump mkdocs-material -> 9.1.21

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.1.18
+mkdocs-material==9.1.21
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary
Fixes and support from upstream mkdocs-material:

- Support for MkDocs 1.5+
- Regressions and compatibility with social plugin

Will provide more fixes and compatibility when material 9.2.0 is released with the following PR:

- #857

### Location
- requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
 valastiri
