### PR TITLE
docs(issues): add pop out screen issue

### DIFF
--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -692,8 +692,8 @@ The following list of issues are commonly reported on our Discord support channe
     
     - If you do use GSX, then much of the boarding and refueling process is completed through GSX itself, while also still requiring some interaction with the A32NX EFB. This is explained in detail in our [GSX Integration Guide](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/gsxintegration).
 
-??? warning "MSFS Pop-out Feature Not Working"
-    ### MSFS Pop-out Feature Not Working
+??? warning "Pop-out Feature Not Working"
+    ### Pop-out Feature Not Working
 
     !!! tip ""
         *Affected versions: Stable, Development*
@@ -810,17 +810,6 @@ The following list of issues are commonly reported on our Discord support channe
     ^^Read the documentation about Discontinuities^^
 
     - [Discontinuities](../../pilots-corner/advanced-guides/flight-planning/disco.md)
-
-??? issue "Issue Headline"
-
-!!! tip ""
-*Affected versions: Stable, Development*
-
-^^Description^^
-^^Root Cause^^
-^^Possible Solution or Workaround^^
-^^Additional Information^^
-    
 
 ## Solutions to Commonly Reported Issues 
 The following list of solutions solves most reported issues on our Discord support channel. 

--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -692,6 +692,32 @@ The following list of issues are commonly reported on our Discord support channe
     
     - If you do use GSX, then much of the boarding and refueling process is completed through GSX itself, while also still requiring some interaction with the A32NX EFB. This is explained in detail in our [GSX Integration Guide](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/gsxintegration).
 
+??? warning "MSFS Pop-out Feature Not Working"
+    ### MSFS Pop-out Feature Not Working
+
+    !!! tip ""
+        *Affected versions: Stable, Development*
+
+    ^^Description^^
+
+    The MSFS pop-out feature is not working for certain screens in the A32NX flight deck. 
+
+    While this is an MSFS issue it can cause problems if you regularly enjoy popping out various screens for use with external hardware or another monitor.
+
+    ^^Root Cause^^
+
+    MSFS off-screen pop out issue when your monitor setup may have changed between Sim Updates. This data is reportedly stored locally and in the cloud.
+
+    ^^Possible Solution or Workaround^^
+
+    !!! tip ""
+        Please note that you should first check if the following is try before trying any workarounds.
+
+        - You can see the **magnifying glass** when attempting to pop out the panel. 
+
+    You can try using the popout panel manager to restore the position if you suspect the pop-out is off screen. Please see the following GitHub issue for more information: 
+    [Popout Panel Manager](https://github.com/hawkeye-stan/msfs-popout-panel-manager/issues/73){target=new}.
+
 ??? tip "++ctrl+'E'++ - Engine Start Unsupported" 
     ### ++ctrl+'E'++ - Engine Start Unsupported
 
@@ -784,6 +810,16 @@ The following list of issues are commonly reported on our Discord support channe
     ^^Read the documentation about Discontinuities^^
 
     - [Discontinuities](../../pilots-corner/advanced-guides/flight-planning/disco.md)
+
+??? issue "Issue Headline"
+
+!!! tip ""
+*Affected versions: Stable, Development*
+
+^^Description^^
+^^Root Cause^^
+^^Possible Solution or Workaround^^
+^^Additional Information^^
     
 
 ## Solutions to Commonly Reported Issues 

--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -715,8 +715,13 @@ The following list of issues are commonly reported on our Discord support channe
 
         - You can see the **magnifying glass** when attempting to pop out the panel. 
 
-    You can try using the popout panel manager to restore the position if you suspect the pop-out is off screen. Please see the following GitHub issue for more information: 
-    [Popout Panel Manager](https://github.com/hawkeye-stan/msfs-popout-panel-manager/issues/73){target=new}.
+    You can try using the popout panel manager application to restore the position if you suspect the pop-out is off screen. 
+
+    [Download MSFS Pop Out Panel Manager](https://github.com/hawkeye-stan/msfs-popout-panel-manager)
+
+    For more information on how to actually solve the issue please reference the following GitHub issue for more information:
+
+    [MSFS Popout Workaround / Pop out panel manager issue](https://github.com/hawkeye-stan/msfs-popout-panel-manager/issues/73){target=new .md-button}
 
 ??? tip "++ctrl+'E'++ - Engine Start Unsupported" 
     ### ++ctrl+'E'++ - Engine Start Unsupported

--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -711,7 +711,7 @@ The following list of issues are commonly reported on our Discord support channe
     ^^Possible Solution or Workaround^^
 
     !!! tip ""
-        Please note that you should first check if the following is try before trying any workarounds.
+        Please note that you should first check the following before trying any workarounds.
 
         - You can see the **magnifying glass** when attempting to pop out the panel. 
 

--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -702,11 +702,11 @@ The following list of issues are commonly reported on our Discord support channe
 
     The MSFS pop-out feature is not working for certain screens in the A32NX flight deck. 
 
-    While this is an MSFS issue it can cause problems if you regularly enjoy popping out various screens for use with external hardware or another monitor.
+    While this is an MSFS issue, it can cause problems if you regularly enjoy popping out various screens for use with external hardware or another monitor.
 
     ^^Root Cause^^
 
-    MSFS off-screen pop out issue when your monitor setup may have changed between Sim Updates. This data is reportedly stored locally and in the cloud.
+    MSFS off-screen pop-out issue when your monitor setup may have changed between Sim Updates. This data is reportedly stored locally and in the cloud.
 
     ^^Possible Solution or Workaround^^
 
@@ -715,11 +715,11 @@ The following list of issues are commonly reported on our Discord support channe
 
         - You can see the **magnifying glass** when attempting to pop out the panel. 
 
-    You can try using the popout panel manager application to restore the position if you suspect the pop-out is off screen. 
+    You can try using the MSFS Pop Out Panel Manager application to restore the position if you suspect the pop-out is off-screen. 
 
     [Download MSFS Pop Out Panel Manager](https://github.com/hawkeye-stan/msfs-popout-panel-manager)
 
-    For more information on how to actually solve the issue please reference the following GitHub issue for more information:
+    For more information on how to actually solve the issue, please reference the following GitHub issue for more information:
 
     [MSFS Popout Workaround / Pop out panel manager issue](https://github.com/hawkeye-stan/msfs-popout-panel-manager/issues/73){target=new .md-button}
 


### PR DESCRIPTION
## Summary
As discussed in FBW Support Ops. 

While not specifically an issue with our aircraft it is a minor inconvenience to explain and iterate why something in MSFS does not work appropriately when flying with our aircraft.

This issue should be easily referenced by support teams invoking the `.issues` 
command in applicable support channels.

Quick Sample
![image](https://github.com/flybywiresim/docs/assets/1619968/f4c1a784-3a47-4c4d-8c20-328e9dcd8e67)


### Location
- docs/fbw-a32nx/support/reported-issues.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
 valastiri
