### PR TITLE
docs: Added instruments page and temp removed outdated flypad-dev page

### DIFF
--- a/docs/dev-corner/dev-guide/specific/.pages
+++ b/docs/dev-corner/dev-guide/specific/.pages
@@ -1,6 +1,7 @@
 title: Specific
 nav:
   - index.md
-  - flypad-dev.md
+# - flypad-dev.md
+  - instruments.md
   - flypad-translations.md
   - javascript.md

--- a/docs/dev-corner/dev-guide/specific/instruments.md
+++ b/docs/dev-corner/dev-guide/specific/instruments.md
@@ -1,0 +1,7 @@
+# Instruments Build Guide
+
+This page is pulled externally from the FBW Aircraft repository and describes the processes of building the instruments.
+
+---
+
+{{ external_markdown('https://raw.githubusercontent.com/flybywiresim/aircraft/master/fbw-a32nx/src/systems/instruments/README.md', '') }}


### PR DESCRIPTION
Closes #882 

## Summary
Adding a page pulling the instruments build documentation from the main repo

### Location
[/dev-corner/dev-guide/specific/instruments.md](https://docs-git-fork-frankkopp-instruments-pull-flybywire.vercel.app/dev-corner/dev-guide/specific/instruments/)

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): cdr_maverick
