### PR TITLE
chore: exclude flypad-dev.md from search

### DIFF
--- a/docs/dev-corner/dev-guide/specific/flypad-dev.md
+++ b/docs/dev-corner/dev-guide/specific/flypad-dev.md
@@ -1,3 +1,8 @@
+---
+search:
+    exclude: true
+---
+
 # flyPad Development Guide
 
 ## Quick Reloading the flyPad


### PR DESCRIPTION
## Summary
Oversight on my part from Mav's PR 

- #883

While the page is excluded from navigation it's still searchable. 

Didn't have time to test this but adding the new exclude search feature as meta to the top of the document.

## Testing Instructions

- Please make sure searching flypad dev or other strings does not pull up the page.

### Location
- docs/dev-corner/dev-guide/specific/flypad-dev.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
