### PR TITLE
docs: add keyboard shortcut support for the mcdu remote display in browser mode

### DIFF
--- a/docs/simbridge/simbridge-feature-guides/remote-displays/remote-mcdu.md
+++ b/docs/simbridge/simbridge-feature-guides/remote-displays/remote-mcdu.md
@@ -90,6 +90,42 @@ If you are using MCDU hardware with a 4:3 display, you can use the 4:3 aspect ra
 
 To use this mode, add `?43` to the URL.
 
+### Keyboard Mapping
+
+The supoorted list of keyboard inputs and shortcuts are available for the MCDU Remote Display in a desktop browser.
+
+| Keyboard Code        | MCDU Key  |
+| -------------------- | --------- |
+| `F1`-`F6`            | LSK1-LSK6 |
+| `F7`-`F12`           | RSK1-RSK6 |
+| `A-Z`                | A-Z       |
+| `0-9`, Digit, Numpad | 0-9       |
+| `Tab`                | DIR       |
+| `Insert`             | PROG      |
+| `Home`               | PERF      |
+| `PageUp`             | INIT      |
+| `Enter`              | DATA      |
+| `NumpadEnter`        | DATA      |
+| `Delete`             | FPLN      |
+| `End`                | RAD       |
+| `PageDown`           | FUEL      |
+| `Escape`             | MENU      |
+| `ShiftLeft`          | AIRPORT   |
+| `ArrowLeft`          | PREVPAGE  |
+| `ArrowRight`         | NEXTPAGE  |
+| `ArrowUp`            | UP        |
+| `ArrowDown`          | DOWN      |
+| `Backspace`          | CLR       |
+| `Space`              | SP        |
+| `Period`             | DOT       |
+| `Slash`              | DIV       |
+| `Minus`              | PLUSMINUS |
+| `NumpadSubtract`     | PLUSMINUS |
+| `NumpadAdd`          | PLUSMINUS |
+| `NumpadDecimal`      | DOT       |
+| `NumpadDivide`       | DIV       |
+| `NumpadMultiply`     | OVFY      |
+
 ## Compatible Browsers
 
 With hundreds of different browsers available today, it is not possible to test and support all browsers and their different versions.

--- a/docs/simbridge/simbridge-feature-guides/remote-displays/remote-mcdu.md
+++ b/docs/simbridge/simbridge-feature-guides/remote-displays/remote-mcdu.md
@@ -94,37 +94,32 @@ To use this mode, add `?43` to the URL.
 
 The list shows the supported keyboard inputs and shortcuts for the MCDU Remote Display in a desktop browser.
 
-| Keyboard Code        | MCDU Key  |
-| -------------------- | --------- |
-| `F1`-`F6`            | LSK1-LSK6 |
-| `F7`-`F12`           | RSK1-RSK6 |
-| `A-Z`                | A-Z       |
-| `0-9`, Digit, Numpad | 0-9       |
-| `Tab`                | DIR       |
-| `Insert`             | PROG      |
-| `Home`               | PERF      |
-| `PageUp`             | INIT      |
-| `Enter`              | DATA      |
-| `NumpadEnter`        | DATA      |
-| `Delete`             | FPLN      |
-| `End`                | RAD       |
-| `PageDown`           | FUEL      |
-| `Escape`             | MENU      |
-| `ShiftLeft`          | AIRPORT   |
-| `ArrowLeft`          | PREVPAGE  |
-| `ArrowRight`         | NEXTPAGE  |
-| `ArrowUp`            | UP        |
-| `ArrowDown`          | DOWN      |
-| `Backspace`          | CLR       |
-| `Space`              | SP        |
-| `Period`             | DOT       |
-| `Slash`              | DIV       |
-| `Minus`              | PLUSMINUS |
-| `NumpadSubtract`     | PLUSMINUS |
-| `NumpadAdd`          | PLUSMINUS |
-| `NumpadDecimal`      | DOT       |
-| `NumpadDivide`       | DIV       |
-| `NumpadMultiply`     | OVFY      |
+| Keyboard Code                          | MCDU Key  |
+| -------------------------------------- | --------- |
+| ++f1++ - ++f6++                        | LSK1-LSK6 |
+| ++f7++ - ++f12++                       | RSK1-RSK6 |
+| ++a++ - ++z++                          | A-Z       |
+| ++0++ - ++9++, ++num0++ - ++num9++     | 0-9       |
+| ++tab++                                | DIR       |
+| ++insert++                             | PROG      |
+| ++home++                               | PERF      |
+| ++page-up++                            | INIT      |
+| ++enter++, ++num-enter++               | DATA      |
+| ++delete++                             | FPLN      |
+| ++end++                                | RAD       |
+| ++page-down++                          | FUEL      |
+| ++escape++                             | MENU      |
+| ++left-shift++                         | AIRPORT   |
+| ++arrow-left++                         | PREVPAGE  |
+| ++arrow-right++                        | NEXTPAGE  |
+| ++arrow-up++                           | UP        |
+| ++arrow-down++                         | DOWN      |
+| ++backspace++                          | CLR       |
+| ++space++                              | SP        |
+| ++period++, ++num-separator++          | DOT       |
+| ++slash++, ++num-slash++               | DIV       |
+| ++minus++, ++num-minus++, ++num-plus++ | PLUSMINUS |
+| ++num-asterisk++                       | OVFY      |
 
 ## Compatible Browsers
 

--- a/docs/simbridge/simbridge-feature-guides/remote-displays/remote-mcdu.md
+++ b/docs/simbridge/simbridge-feature-guides/remote-displays/remote-mcdu.md
@@ -92,7 +92,7 @@ To use this mode, add `?43` to the URL.
 
 ### Keyboard Mapping
 
-The supoorted list of keyboard inputs and shortcuts are available for the MCDU Remote Display in a desktop browser.
+The list shows the supported keyboard inputs and shortcuts for the MCDU Remote Display in a desktop browser.
 
 | Keyboard Code        | MCDU Key  |
 | -------------------- | --------- |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,7 +159,7 @@ markdown_extensions:
   pymdownx.tasklist:
     custom_checkbox: true
   pymdownx.emoji: # Allows emoji style inline embeds for icons
-    emoji_index: !!python/name:materialx.emoji.twemoji
-    emoji_generator: !!python/name:materialx.emoji.to_svg
+    emoji_index: !!python/name:material.extensions.emoji.twemoji
+    emoji_generator: !!python/name:material.extensions.emoji.to_svg
   md_in_html: {} # Allows markdown to be used in HTML
   abbr: {} # Adds abbreviations

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.2.1
+mkdocs-material==9.4.6
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
- add keyboard input documentation for the mcdu remote display in browser mode / ref pr: https://github.com/flybywiresim/simbridge/pull/86

### Location
[simbridge/simbridge-feature-guides/remote-displays/remote-mcdu/](https://docs.flybywiresim.com/simbridge/simbridge-feature-guides/remote-displays/remote-mcdu/)

