### PR TITLE
build: bump mkdocs-material -> 9.4.2

### DIFF
--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -13,7 +13,7 @@
 
     <img src="https://img.shields.io/github/v/release/flybywiresim/aircraft.svg?color=2F4E5B&style=flat" /> <img src="https://img.shields.io/badge/dynamic/json?color=00848A&label=Development&query=shortSha&url=https%3A%2F%2Fapi.flybywiresim.com%2Fapi%2Fv1%2Fgit-versions%2Fflybywiresim%2Faircraft%2Fbranches%2Fmaster&style=flat" alt="Development Version" />
 
-    FBW Installer - [Download Here](https://api.flybywiresim.com/installer){target=new} / *Latest Sim Version: 1.33.8.0*
+    FBW Installer - [Download Here](https://api.flybywiresim.com/installer){target=new} / *Latest Sim Version: 1.34.16.0*
 
 !!! warning "Read our Support Guide"
 

--- a/docs/stylesheets/admonitions.css
+++ b/docs/stylesheets/admonitions.css
@@ -4,9 +4,11 @@
 .md-typeset .admonition-title, .md-typeset summary {
     font-size: .8rem;
     font-weight: inherit;
+    color: #fff;
 }
 .md-typeset .admonition, .md-typeset details {
     font-size: .8rem;
+    color: #fff;
 }
 .md-typeset :is(.admonition,details) {
     font-size: .8rem;

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -9,6 +9,7 @@
     --md-accent-fg-color:         var(--md-primary-fg-color);
     --md-secondary-accent-color:  #0E131B;
     --md-typeset-a-color:         var(--md-primary-fg-color);
+    --md-typeset-color:           #ffffff;
 }
 
 [data-md-color-scheme="slate"] {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.2.1
+mkdocs-material==9.4.2
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary

**Previous Version: 9.2.1**
Version bump with latest fixes. [Material Release Notes](https://squidfunk.github.io/mkdocs-material/changelog/)

Includes (collated relevant list):

Major:
- Updated MkDocs -> 1.5.3 -> [Release Notes](https://www.mkdocs.org/about/release-notes/)
- Slate Theme (Dark Mode) has style changes
	- Modified CSS to ensure all font is `#fff`

Minor:
- Various blog plugin related fixes
- Dropped support for Python 3.7 EOL
- "Grouped plugins" -> enables plugins conditionally
- Note: Python dependencies in requirements use minimum versions (by default)
- Admonitions have borders that match font-weight
- Alignment and spacing of sidebar navigation alignment refactored
- Fixed: viewport offset restoration on first load
- Fixed: Repeated click on anchor ignored when using instant navigation
- Fixed: Keyboard navigation broken when using instant navigation

Internal Changes
- Updated Reported Issues Sim Version

## TODO/Tests

- [x] Fix text color slightly dimmer now
- [x] Check all text is `#fff`
- [x] Check admonitions perform normally

### Location
- requirements.txt
- stylesheets/admonitions.css
- stylesheets/extra.css

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
