### PR TITLE
fix(pilots-corner): replace SET MANAGED SPEED with CHECK SPEED MODE

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/pfd/special-message-annunciators.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/special-message-annunciators.md
@@ -58,7 +58,7 @@ Displayed in white when the aircraft is in cruise at less than 100 nautical mile
 - A non ILS approach has been selected.
 - An ILS frequency is tuned on the MCDU RAD NAV page.
 
-### SET MANAGED SPD
+### CHECK SPEED MODE
 
 Displayed in white when the speed target is selected, but a preselected speed does not exist for the next flight phase.
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
Newer EIS standards change the wording from "SET MANAGED SPEED" to "CHECK SPEED MODE". Ideally, there would also be an annotation that this message is not implemented yet. However, https://github.com/flybywiresim/aircraft/pull/8205 will implement it, so I think we can just leave it as is.

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
https://docs.flybywiresim.com/pilots-corner/a32nx-briefing/pfd/special-message-annunciators/#set-managed-spd

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): BlueberryKing
