### PR TITLE
docs(zfw-mcdu): update information for zfw autofill

### DIFF
--- a/docs/pilots-corner/beginner-guide/preparing-mcdu.md
+++ b/docs/pilots-corner/beginner-guide/preparing-mcdu.md
@@ -362,7 +362,9 @@ On this page, we can input our zero fuel weight (ZFW) and zero fuel weight cente
 
 !!! warning "Important Info - FMS Gross Weight (FMS GW)"
     Fuel and payload have to be set in the aircraft (see link below) and passenger boarding as to be **complete or in progress** for the ZFW/ZFWCG values to be correct. The 
-    "planned" payload values are used for the calculation if boarding has not been completed.    
+    "planned" payload values are used for the calculation if boarding has not been completed.
+
+    *Ideally you no longer have to wait for boarding to be completed to finalize preparations on the INIT FUEL PRED page.
 
     ??? info "Open for Stable Version Only"
         Fuel and payload have to be set in the aircraft (see link below) and passenger boarding has to be **complete** for the ZFW/ZFWCG to be correct.

--- a/docs/pilots-corner/beginner-guide/preparing-mcdu.md
+++ b/docs/pilots-corner/beginner-guide/preparing-mcdu.md
@@ -361,7 +361,11 @@ To navigate to the `INIT FUEL PRED` page, we first have to select the `INIT` but
 On this page, we can input our zero fuel weight (ZFW) and zero fuel weight center of gravity (ZFWCG).
 
 !!! warning "Important Info - FMS Gross Weight (FMS GW)"
-    Fuel and payload have to be set in the aircraft (see link below) and passenger boarding has to be complete for the ZFW/ZFWCG to be correct.
+    Fuel and payload have to be set in the aircraft (see link below) and passenger boarding as to be **complete or in progress** for the ZFW/ZFWCG values to be correct. The 
+    "planned" payload values are used for the calculation if boarding has not been completed.    
+
+    ??? info "Open for Stable Version Only"
+        Fuel and payload have to be set in the aircraft (see link below) and passenger boarding has to be **complete** for the ZFW/ZFWCG to be correct.
 
     Gross Weight (GW) value on the ECAM will appear only when certain conditions are satisfied:
 

--- a/docs/pilots-corner/beginner-guide/preparing-mcdu.md
+++ b/docs/pilots-corner/beginner-guide/preparing-mcdu.md
@@ -361,7 +361,7 @@ To navigate to the `INIT FUEL PRED` page, we first have to select the `INIT` but
 On this page, we can input our zero fuel weight (ZFW) and zero fuel weight center of gravity (ZFWCG).
 
 !!! warning "Important Info - FMS Gross Weight (FMS GW)"
-    Fuel and payload have to be set in the aircraft (see link below) and passenger boarding as to be **complete or in progress** for the ZFW/ZFWCG values to be correct. The 
+    Fuel and payload have to be set in the aircraft (see link below) and passenger boarding has to be **complete or in progress** for the ZFW/ZFWCG values to be correct. The 
     "planned" payload values are used for the calculation if boarding has not been completed.
 
     *Ideally you no longer have to wait for boarding to be completed to finalize preparations on the INIT FUEL PRED page.*

--- a/docs/pilots-corner/beginner-guide/preparing-mcdu.md
+++ b/docs/pilots-corner/beginner-guide/preparing-mcdu.md
@@ -364,7 +364,7 @@ On this page, we can input our zero fuel weight (ZFW) and zero fuel weight cente
     Fuel and payload have to be set in the aircraft (see link below) and passenger boarding as to be **complete or in progress** for the ZFW/ZFWCG values to be correct. The 
     "planned" payload values are used for the calculation if boarding has not been completed.
 
-    *Ideally you no longer have to wait for boarding to be completed to finalize preparations on the INIT FUEL PRED page.
+    *Ideally you no longer have to wait for boarding to be completed to finalize preparations on the INIT FUEL PRED page.*
 
     ??? info "Open for Stable Version Only"
         Fuel and payload have to be set in the aircraft (see link below) and passenger boarding has to be **complete** for the ZFW/ZFWCG to be correct.


### PR DESCRIPTION
## Summary
As discussed in support-ops, updates the beginner guide information on how autofill works for the zfw on the development version. Adds a breakout `???` admonition to indicate stable version info.

![image](https://github.com/flybywiresim/docs/assets/1619968/244f398c-d157-4ad4-a1c6-ac3aee021307)

![image](https://github.com/flybywiresim/docs/assets/1619968/7870d395-d6e9-45c5-b24e-7081e5fce2f6)

### Location
- docs/pilots-corner/beginner-guide/preparing-mcdu.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): 
