### PR TITLE
fix: rudder trim reset event

### DIFF
--- a/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -908,7 +908,7 @@ Flight Deck: [Rudder Trim Panel](../../pilots-corner/a32nx-briefing/flight-deck/
 | Display  | RUDDER TRIM PCT   | -1.0..1.0     | R          | SIMCONNECT VAR   | -1.0=20° left, 1.0=20° right                                                   |
 |          | RUDDER TRIM       | -0.35..0.35   | R          | SIMCONNECT VAR   | Radians: 0.3490×180°/π = 19.99°                                                |
 |          |                   |               |            |                  |                                                                                |
-| RESET    | RUDDER TRIM SET   | -16383..16384 | .          | SIMCONNECT EVENT |                                                                                |
+| RESET    | RUDDER_TRIM_RESET | -             | .          | SIMCONNECT EVENT |                                                                                |
 |          |                   |               |            |                  |                                                                                |
 | RUD TRIM | XMLVAR_RUDDERTRIM | 0 &#124; 2    | R/W        | Custom LVAR      | ~~Knob jumps back. Needs to be set repeatably until the target value is reached~~ |
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
Fixes the rudder trim reset event (we just use the standard sim event). Thanks to LesOReilly for pointing this out!

### Location
<!-- Please provide the original URL of the page modified or directory location here -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
