### PR TITLE
feat(pilots-corner): Include a next chapter text on Preflight guide

### DIFF
--- a/docs/pilots-corner/beginner-guide/preflight.md
+++ b/docs/pilots-corner/beginner-guide/preflight.md
@@ -53,3 +53,7 @@ To configure your aircraft, we have provided options onboard the aircraft to loa
 To help with navigation during your flight, our flyPad EFB can connect to your Navigraph account to provide access to all the en route charts for your flight!
 
 [EFB Navigraph](../../fbw-a32nx/feature-guides/flypados3/charts.md){.md-button}
+
+This concludes the *Preflight* guide.
+
+Continue with [Starting the Aircraft](starting-the-aircraft.md).


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
This PR just adds a simple text to inform the reader that they have reached the end of the page and an easy way to go to the next page. This change is added so that this page is consistent with the other Beginner Guide pages that include a similar text at the end.

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
https://docs-git-fork-auroraisluna-next-chapter-for-pr-de47bc-flybywire.vercel.app/pilots-corner/beginner-guide/preflight/

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): alepouna
