### PR TITLE
build: bump mkdocs-material -> 9.4.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.4.6
+mkdocs-material==9.4.8
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary
Fixes some upstream issues with `navigation.instant`.

- Fixed invalid local address replacement when using instant loading
- Crash after navigation caused 404 when using instant loading

### Location
- requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
