### PR TITLE
docs(mcdu): add internal links to mcdu advanced flight planning

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/mcdu/f-pln.md
+++ b/docs/pilots-corner/a32nx-briefing/mcdu/f-pln.md
@@ -8,6 +8,17 @@ Revisions to the lateral and vertical flight plans can be made from these pages.
 
 ## Flight Plan A Page
 
+!!! tip "Additional Resources"
+    Also see the following resources for further feature information when utilizing the F-PLN page:
+
+    - [MCDU Setup Procedure](../../beginner-guide/preparing-mcdu.md) in our [Beginner Guide](../../beginner-guide/overview.md).
+    - Advance Flight Planning Guides
+        - [Direct To (DIR TO)](../../advanced-guides/flight-planning/direct.md)
+        - [Discontinuities](../../advanced-guides/flight-planning/disco.md)
+        - [Fix Info](../../advanced-guides/flight-planning/fixinfo.md)
+        - [Holds](../../advanced-guides/flight-planning/holds.md)
+        - [Leg Types](../../advanced-guides/flight-planning/leg-types.md)
+
 ![F-PLAN A Page](../../assets/a32nx-briefing/mcdu/mcdu-fpln-a-page.png "F-PLAN A Page"){loading=lazy}
 
 ### General

--- a/docs/pilots-corner/a32nx-briefing/mcdu/index.md
+++ b/docs/pilots-corner/a32nx-briefing/mcdu/index.md
@@ -41,5 +41,7 @@ After entry or selection of the flight plan and other required performance data 
 
 This section describes the MCDU in detail, covering each page and also the standard process for setting up a flight.
 
-Also see the [MCDU Setup Procedure](../../beginner-guide/preparing-mcdu.md) in our 
-[Beginner Guide](../../beginner-guide/overview.md).
+Also see the following resources:
+
+- [MCDU Setup Procedure](../../beginner-guide/preparing-mcdu.md) in our [Beginner Guide](../../beginner-guide/overview.md).
+- [Advance Flight Planning Guides](../../advanced-guides/flight-planning/overview.md).

--- a/docs/pilots-corner/a32nx-briefing/mcdu/index.md
+++ b/docs/pilots-corner/a32nx-briefing/mcdu/index.md
@@ -41,7 +41,14 @@ After entry or selection of the flight plan and other required performance data 
 
 This section describes the MCDU in detail, covering each page and also the standard process for setting up a flight.
 
-Also see the following resources:
+!!! tip "Additional Resources"
+    Also see the following resources for further feature information:
 
-- [MCDU Setup Procedure](../../beginner-guide/preparing-mcdu.md) in our [Beginner Guide](../../beginner-guide/overview.md).
-- [Advance Flight Planning Guides](../../advanced-guides/flight-planning/overview.md).
+    - [MCDU Setup Procedure](../../beginner-guide/preparing-mcdu.md) in our [Beginner Guide](../../beginner-guide/overview.md).
+    - Advance Flight Planning Guides
+        - [Direct To (DIR TO)](../../advanced-guides/flight-planning/direct.md)
+        - [Discontinuities](../../advanced-guides/flight-planning/disco.md)
+        - [Fix Info](../../advanced-guides/flight-planning/fixinfo.md)
+        - [Holds](../../advanced-guides/flight-planning/holds.md)
+        - [Leg Types](../../advanced-guides/flight-planning/leg-types.md)
+


### PR DESCRIPTION
closes #912

## Summary
Reference Issue.

Provides internal links and a new admonition on MCDU pages that link into advance flight planning guides relevant to the Fpln page.

### Location
- docs/pilots-corner/a32nx-briefing/mcdu/f-pln.md
- docs/pilots-corner/a32nx-briefing/mcdu/index.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
