### PR TITLE
fix: Typo in landing.md

### DIFF
--- a/docs/pilots-corner/beginner-guide/landing.md
+++ b/docs/pilots-corner/beginner-guide/landing.md
@@ -98,7 +98,7 @@ To intercept the ILS Localizer, we follow these steps:
 
     ![Established on ILS localizer](../assets/beginner-guide/landing/PFD-ND-established.png "Established on ILS localizer"){loading=lazy}
 
-Tower ATC will then give us clearance for teh ILS approach to the target runway. This clears us to descend on the ILS glideslope.
+Tower ATC will then give us clearance for the ILS approach to the target runway. This clears us to descend on the ILS glideslope.
 
 **Do not descent without explicit clearance from ATC.**
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
Typo in beginner's guide landing page: teh -> the
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
https://docs.flybywiresim.com/pilots-corner/beginner-guide/landing/#1-intercepting-the-ils-localizer

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
