### PR TITLE
refactor(simbridge): make clarifications for aircraft settings in configuration.md

### DIFF
--- a/docs/simbridge/install-configure/configuration.md
+++ b/docs/simbridge/install-configure/configuration.md
@@ -66,6 +66,11 @@ This tab is for modifying settings regarding printing data from the MCDU to your
 
 To use the SimBridge, the aircraft's settings need to allow the SimBridge connection.
 
+!!! warning ""
+    Please note to find following settings please load into our aircraft within the simulator and use our onboard EFB (flyPad).
+
+    The page below is found on the flyPad EFB under `Settings` > `Sim Options`.
+
 ![flyPad EFB Settings Sim Options](../assets/efb-setting-simoptions.png){loading=lazy}
 
 The three settings are:

--- a/docs/simbridge/install-configure/configuration.md
+++ b/docs/simbridge/install-configure/configuration.md
@@ -67,7 +67,7 @@ This tab is for modifying settings regarding printing data from the MCDU to your
 To use the SimBridge, the aircraft's settings need to allow the SimBridge connection.
 
 !!! warning ""
-    Please note to find following settings please load into our aircraft within the simulator and use our onboard EFB (flyPad).
+    To find the following settings, load into our aircraft within the simulator and use our onboard EFB (flyPad).
 
     The page below is found on the flyPad EFB under `Settings` > `Sim Options`.
 


### PR DESCRIPTION
## Summary
Issue presented by Discord user that our SimBridge documentation does not clearly state under "Aircraft Settings" that the user must switch to the aircraft in the simulator to utilize the aircraft settings on the flyPad.

PR adds a small admonition to identify both this and the location on where to find the settings on the EFB.

### Location
- docs/simbridge/install-configure/configuration.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
