### PR TITLE
refactor(install): update dev version download link

### DIFF
--- a/docs/fbw-a32nx/installation.md
+++ b/docs/fbw-a32nx/installation.md
@@ -70,7 +70,7 @@ You can send us logs to our [Discord](https://discord.gg/flybywire){target=new} 
 
         It updates whenever something is added to the 'master' branch on GitHub. 
 
-         [Download Development](https://github.com/flybywiresim/aircraft/releases/download/assets/master/A32NX-master.zip){.md-button target=new}
+         [Download Development](https://github.com/flybywiresim/a32nx/releases/download/assets/master/A32NX-master.7z){.md-button target=new}
          
          [**IMPORTANT:** View information on Autopilot / Fly-By-Wire here](feature-guides/autopilot-fbw.md)
 

--- a/docs/fbw-a32nx/installation.md
+++ b/docs/fbw-a32nx/installation.md
@@ -55,7 +55,7 @@ You can send us logs to our [Discord](https://discord.gg/flybywire){target=new} 
 
     === "Latest Stable Version"
 
-        **Current Stable Version - ** <img src="https://img.shields.io/github/v/release/flybywiresim/aircraft.svg?color=2F4E5B&style=flat" />
+        **Current Stable Version -** <img src="https://img.shields.io/github/v/release/flybywiresim/aircraft.svg?color=2F4E5B&style=flat" />
 
           Stable is our variant that has the least bugs and best performance. This version will not always be up-to-date, but we guarantee its compatibility with each major patch from MSFS. 
 

--- a/docs/fbw-a32nx/installation.md
+++ b/docs/fbw-a32nx/installation.md
@@ -70,7 +70,7 @@ You can send us logs to our [Discord](https://discord.gg/flybywire){target=new} 
 
         It updates whenever something is added to the 'master' branch on GitHub. 
 
-         [Download Development](https://github.com/flybywiresim/a32nx/releases/download/assets/master/A32NX-master.7z){.md-button target=new}
+         [Download Development](https://github.com/flybywiresim/aircraft/releases/download/assets/master/A32NX-master.7z){.md-button target=new}
          
          [**IMPORTANT:** View information on Autopilot / Fly-By-Wire here](feature-guides/autopilot-fbw.md)
 


### PR DESCRIPTION
## Summary
Update download URL for 
development version in line:

- https://github.com/flybywiresim/website/pull/514/
- Also fixes a minor issue with markdown formatting for the stable admonition.

### Location
- docs/fbw-a32nx/installation.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
 valastiri
