### PR TITLE
fix(pfd-briefing): alternative solution to content tabs

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/pfd/flags-messages.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/flags-messages.md
@@ -1,3 +1,7 @@
+---
+hide: toc
+---
+
 <link rel="stylesheet" href="../../../../stylesheets/pfd-interactive.css">
 
 # Flags and Messages
@@ -23,160 +27,167 @@ These are flags and messages displayed on the PFD. The numbers correspond to the
 
 ![Flags and Messages](../../assets/a32nx-briefing/pfd/pfdflags.png "Flags and Messages"){loading=lazy}
 
-=== "1"
-    ATT FLAG
+<div class="grid cards" markdown>
 
-    This is displayed in red. If the PFD loses all attitude data, the entire artificial horizon is cleared to display the ATT flag.
+!!! info "Elements 1 - 15"
 
-=== "2"
-    CHECK ATT
-
-    CHECK ATT will be displayed in amber when there is a disagreement of at least 5 degrees in the attitude information displayed by the two PFDs. This will be shown on both PFDs and a caution will be shown on the ECAM.
-
-=== "3"
-    SI Flag
-
-    This is displayed in red. If sideslip information is lost, the index disappears and the SI flag is displayed.
-
-=== "4"
-    FPV Flag
-
-    This is displayed in red. It appears in the TRK FPA mode, when the drift angle or flight path angle is not valid.
-
-=== "5"
-    FD Flag
-
-    This is displayed in red. It appears if both of the FMGCs fail, or if both flight directors are disengaged and the FD pushbutton is on, and the attitude is valid.
-
-=== "6"
-    SPD Flag
-
-    This is displayed in red. If the speed information fails, this flag will replace the airspeed indicator.
-
-=== "7"
-    SPD SEL Flag
-
-    This is displayed in red. If the selected speed information fails, this flag will appear.
-
-=== "8"
-    SPD LIM Flag
-
-    This is displayed in red. It appears when both FACs are inoperative, or in case of dual flap/slat channel failure. In this case, the following information is lost:
+    === "1"
+        ATT FLAG
     
-    - V~LS~
-    - S
-    - F
-    - Green Dot
-    - V-trend
-    - V~MAX~
-    - V~FE~ next
-    - VSW
-
-=== "9"
-    V1 INOP Flag
-
-    This is displayed in red. When the V1 signal is not valid, this flag will replace the digital value.
-
-=== "10"
-    ALT Flag
-
-    This is displayed in red. If the altitude information fails, this flag will replace the altitude scale.
-
-=== "11"
-    CHECK ALT Flag
-
-    This is displayed in amber. This appears both as a flag on the PFD, and on the ECAM as a caution if the difference between the two PFD altitude indicators is greater than 250 feet when the QNH Barometric Reference is selected, or 500 feet when STD is selected.
+        This is displayed in red. If the PFD loses all attitude data, the entire artificial horizon is cleared to display the ATT flag.
     
-    This flag disappears when the pilot's and first officer's barometer or references are different.
-
-=== "12"
-    ALT SEL Flag
-
-    This is displayed in red. It appears if the selected altitude information fails.
-
-=== "13"
-    V/S Flag
-
-    This is displayed in red. It appears if the vertical speed information fails and replaces the vertical speed scale.
-
-=== "14"
-    LOC and G/S Flags
-
-    This is displayed in red and appears if the localizer or glideslope receiver fails.
-
-=== "15"
-    V/DEV Flag
-
-    This is displayed in red. It appears if the vertical deviation information fails, and the LS pushbutton has not been pressed. This flag replaces the V/DEV scale.
+    === "2"
+        CHECK ATT
     
-    !!! info ""
-        Currently not available for the FBW A32NX for Microsoft Flight Simulator.
-
-=== "16"
-    RA Flag
-
-    This is displayed in red. If both radio altimeters fail, this flag appears instead of the radio height indication.
-
-=== "17"
-    DH Flag
-
-    This is displayed in amber and is shown when the aircraft has reached the decision height.
-
-=== "18"
-    HDG Flag
-
-    This is displayed in red and is shown if the heading information has failed. It replaces the heading scale.
-
-=== "19"
-    CHECK HDG Flag
-
-    This is displayed in amber and is also shown on the ECAM as a caution. It is shown if there is a 5-degree difference in heading between the Captain's PFD and the First Officer's PFD.
-
-=== "20"
-    MACH Flag
-
-    This flag is displayed in red and appears if the mach data fails.
-
-=== "21"
-    V/DEV Flag (amber)
-
-    !!! info ""
-        Currently not available for the FBW A32nx for Microsoft Flight Simulator.
+        CHECK ATT will be displayed in amber when there is a disagreement of at least 5 degrees in the attitude information displayed by the two PFDs. This will be shown on both PFDs and a caution will be shown on the ECAM.
     
-    This is displayed in amber. It flashes on the top of the glide scale when the aircraft is in the approach phase and when either the final mode is armed/engaged or a non ILS approach has been selected, and the LS pushbutton has been selected.
-
-=== "22"
-    DME X Flag
-
-    This is displayed in red. When the DME distance is not available, a DME 1 (on PFD 1) or a DME 2 (on PFD 2) flag replaces the DME distance indication.
-
-=== "23"
-    ILS X Flag
-
-    If an ILS frequency is not available, or if the localizer or glideslope signals fail, an ILS 1 (on PFD 1) or an ILS 2 (on PFD 2) flag replaces the ILS frequency indication.
-
-=== "24"
-    WINDSHEAR
-
-    This is displayed in red and is shown when the aircraft has encountered a windshear.
+    === "3"
+        SI Flag
     
-    This function is implemented into the FAC and is available when the slats/flaps are extended as follows:
+        This is displayed in red. If sideslip information is lost, the index disappears and the SI flag is displayed.
     
-    - At takeoff, from 5 seconds after liftoff up to 1300 feet radio altitude.
-    - At landing, from 1300 feet radio altitude down to 50 feet radio altitude.
+    === "4"
+        FPV Flag
     
-    It remains displayed at least 15 seconds after windshear detection and is associated with an aural windshear warning.
+        This is displayed in red. It appears in the TRK FPA mode, when the drift angle or flight path angle is not valid.
     
-    !!! info ""
-        Currently not available for the FBW A32nx for Microsoft Flight Simulator.
-
-=== "25"
-    W/S AHEAD
-
-    This is displayed in either amber or red, depending on the alert level.
-
-    This is shown when the predictive windshear function has detected a windshear in front of the aircraft.
+    === "5"
+        FD Flag
     
-    !!! info ""
-        Currently not available for the FBW A32nx for Microsoft Flight Simulator.
+        This is displayed in red. It appears if both of the FMGCs fail, or if both flight directors are disengaged and the FD pushbutton is on, and the attitude is valid.
+    
+    === "6"
+        SPD Flag
+    
+        This is displayed in red. If the speed information fails, this flag will replace the airspeed indicator.
+    
+    === "7"
+        SPD SEL Flag
+    
+        This is displayed in red. If the selected speed information fails, this flag will appear.
+    
+    === "8"
+        SPD LIM Flag
+    
+        This is displayed in red. It appears when both FACs are inoperative, or in case of dual flap/slat channel failure. In this case, the following information is lost:
+        
+        - V~LS~
+        - S
+        - F
+        - Green Dot
+        - V-trend
+        - V~MAX~
+        - V~FE~ next
+        - VSW
+    
+    === "9"
+        V1 INOP Flag
+    
+        This is displayed in red. When the V1 signal is not valid, this flag will replace the digital value.
+    
+    === "10"
+        ALT Flag
+    
+        This is displayed in red. If the altitude information fails, this flag will replace the altitude scale.
+    
+    === "11"
+        CHECK ALT Flag
+    
+        This is displayed in amber. This appears both as a flag on the PFD, and on the ECAM as a caution if the difference between the two PFD altitude indicators is greater than 250 feet when the QNH Barometric Reference is selected, or 500 feet when STD is selected.
+        
+        This flag disappears when the pilot's and first officer's barometer or references are different.
+    
+    === "12"
+        ALT SEL Flag
+    
+        This is displayed in red. It appears if the selected altitude information fails.
+    
+    === "13"
+        V/S Flag
+    
+        This is displayed in red. It appears if the vertical speed information fails and replaces the vertical speed scale.
+    
+    === "14"
+        LOC and G/S Flags
+    
+        This is displayed in red and appears if the localizer or glideslope receiver fails.
+    
+    === "15"
+        V/DEV Flag
+    
+        This is displayed in red. It appears if the vertical deviation information fails, and the LS pushbutton has not been pressed. This flag replaces the V/DEV scale.
+        
+        !!! info ""
+            Currently not available for the FBW A32NX for Microsoft Flight Simulator.
 
+!!! info "Elements 16 - 25"
+
+    === "16"
+        RA Flag
+    
+        This is displayed in red. If both radio altimeters fail, this flag appears instead of the radio height indication.
+    
+    === "17"
+        DH Flag
+    
+        This is displayed in amber and is shown when the aircraft has reached the decision height.
+    
+    === "18"
+        HDG Flag
+    
+        This is displayed in red and is shown if the heading information has failed. It replaces the heading scale.
+    
+    === "19"
+        CHECK HDG Flag
+    
+        This is displayed in amber and is also shown on the ECAM as a caution. It is shown if there is a 5-degree difference in heading between the Captain's PFD and the First Officer's PFD.
+    
+    === "20"
+        MACH Flag
+    
+        This flag is displayed in red and appears if the mach data fails.
+    
+    === "21"
+        V/DEV Flag (amber)
+    
+        !!! info ""
+            Currently not available for the FBW A32nx for Microsoft Flight Simulator.
+        
+        This is displayed in amber. It flashes on the top of the glide scale when the aircraft is in the approach phase and when either the final mode is armed/engaged or a non ILS approach has been selected, and the LS pushbutton has been selected.
+    
+    === "22"
+        DME X Flag
+    
+        This is displayed in red. When the DME distance is not available, a DME 1 (on PFD 1) or a DME 2 (on PFD 2) flag replaces the DME distance indication.
+    
+    === "23"
+        ILS X Flag
+    
+        If an ILS frequency is not available, or if the localizer or glideslope signals fail, an ILS 1 (on PFD 1) or an ILS 2 (on PFD 2) flag replaces the ILS frequency indication.
+    
+    === "24"
+        WINDSHEAR
+    
+        This is displayed in red and is shown when the aircraft has encountered a windshear.
+        
+        This function is implemented into the FAC and is available when the slats/flaps are extended as follows:
+        
+        - At takeoff, from 5 seconds after liftoff up to 1300 feet radio altitude.
+        - At landing, from 1300 feet radio altitude down to 50 feet radio altitude.
+        
+        It remains displayed at least 15 seconds after windshear detection and is associated with an aural windshear warning.
+        
+        !!! info ""
+            Currently not available for the FBW A32nx for Microsoft Flight Simulator.
+    
+    === "25"
+        W/S AHEAD
+    
+        This is displayed in either amber or red, depending on the alert level.
+    
+        This is shown when the predictive windshear function has detected a windshear in front of the aircraft.
+        
+        !!! info ""
+            Currently not available for the FBW A32nx for Microsoft Flight Simulator.
+
+</div>

--- a/docs/pilots-corner/a32nx-briefing/pfd/flags-messages.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/flags-messages.md
@@ -27,167 +27,136 @@ These are flags and messages displayed on the PFD. The numbers correspond to the
 
 ![Flags and Messages](../../assets/a32nx-briefing/pfd/pfdflags.png "Flags and Messages"){loading=lazy}
 
-<div class="grid cards" markdown>
 
-!!! info "Elements 1 - 15"
+1. ATT FLAG
 
-    === "1"
-        ATT FLAG
-    
-        This is displayed in red. If the PFD loses all attitude data, the entire artificial horizon is cleared to display the ATT flag.
-    
-    === "2"
-        CHECK ATT
-    
-        CHECK ATT will be displayed in amber when there is a disagreement of at least 5 degrees in the attitude information displayed by the two PFDs. This will be shown on both PFDs and a caution will be shown on the ECAM.
-    
-    === "3"
-        SI Flag
-    
-        This is displayed in red. If sideslip information is lost, the index disappears and the SI flag is displayed.
-    
-    === "4"
-        FPV Flag
-    
-        This is displayed in red. It appears in the TRK FPA mode, when the drift angle or flight path angle is not valid.
-    
-    === "5"
-        FD Flag
-    
-        This is displayed in red. It appears if both of the FMGCs fail, or if both flight directors are disengaged and the FD pushbutton is on, and the attitude is valid.
-    
-    === "6"
-        SPD Flag
-    
-        This is displayed in red. If the speed information fails, this flag will replace the airspeed indicator.
-    
-    === "7"
-        SPD SEL Flag
-    
-        This is displayed in red. If the selected speed information fails, this flag will appear.
-    
-    === "8"
-        SPD LIM Flag
-    
-        This is displayed in red. It appears when both FACs are inoperative, or in case of dual flap/slat channel failure. In this case, the following information is lost:
-        
-        - V~LS~
-        - S
-        - F
-        - Green Dot
-        - V-trend
-        - V~MAX~
-        - V~FE~ next
-        - VSW
-    
-    === "9"
-        V1 INOP Flag
-    
-        This is displayed in red. When the V1 signal is not valid, this flag will replace the digital value.
-    
-    === "10"
-        ALT Flag
-    
-        This is displayed in red. If the altitude information fails, this flag will replace the altitude scale.
-    
-    === "11"
-        CHECK ALT Flag
-    
-        This is displayed in amber. This appears both as a flag on the PFD, and on the ECAM as a caution if the difference between the two PFD altitude indicators is greater than 250 feet when the QNH Barometric Reference is selected, or 500 feet when STD is selected.
-        
-        This flag disappears when the pilot's and first officer's barometer or references are different.
-    
-    === "12"
-        ALT SEL Flag
-    
-        This is displayed in red. It appears if the selected altitude information fails.
-    
-    === "13"
-        V/S Flag
-    
-        This is displayed in red. It appears if the vertical speed information fails and replaces the vertical speed scale.
-    
-    === "14"
-        LOC and G/S Flags
-    
-        This is displayed in red and appears if the localizer or glideslope receiver fails.
-    
-    === "15"
-        V/DEV Flag
-    
-        This is displayed in red. It appears if the vertical deviation information fails, and the LS pushbutton has not been pressed. This flag replaces the V/DEV scale.
-        
-        !!! info ""
-            Currently not available for the FBW A32NX for Microsoft Flight Simulator.
+    This is displayed in red. If the PFD loses all attitude data, the entire artificial horizon is cleared to display the ATT flag.
 
-!!! info "Elements 16 - 25"
+- CHECK ATT
 
-    === "16"
-        RA Flag
-    
-        This is displayed in red. If both radio altimeters fail, this flag appears instead of the radio height indication.
-    
-    === "17"
-        DH Flag
-    
-        This is displayed in amber and is shown when the aircraft has reached the decision height.
-    
-    === "18"
-        HDG Flag
-    
-        This is displayed in red and is shown if the heading information has failed. It replaces the heading scale.
-    
-    === "19"
-        CHECK HDG Flag
-    
-        This is displayed in amber and is also shown on the ECAM as a caution. It is shown if there is a 5-degree difference in heading between the Captain's PFD and the First Officer's PFD.
-    
-    === "20"
-        MACH Flag
-    
-        This flag is displayed in red and appears if the mach data fails.
-    
-    === "21"
-        V/DEV Flag (amber)
-    
-        !!! info ""
-            Currently not available for the FBW A32nx for Microsoft Flight Simulator.
-        
-        This is displayed in amber. It flashes on the top of the glide scale when the aircraft is in the approach phase and when either the final mode is armed/engaged or a non ILS approach has been selected, and the LS pushbutton has been selected.
-    
-    === "22"
-        DME X Flag
-    
-        This is displayed in red. When the DME distance is not available, a DME 1 (on PFD 1) or a DME 2 (on PFD 2) flag replaces the DME distance indication.
-    
-    === "23"
-        ILS X Flag
-    
-        If an ILS frequency is not available, or if the localizer or glideslope signals fail, an ILS 1 (on PFD 1) or an ILS 2 (on PFD 2) flag replaces the ILS frequency indication.
-    
-    === "24"
-        WINDSHEAR
-    
-        This is displayed in red and is shown when the aircraft has encountered a windshear.
-        
-        This function is implemented into the FAC and is available when the slats/flaps are extended as follows:
-        
-        - At takeoff, from 5 seconds after liftoff up to 1300 feet radio altitude.
-        - At landing, from 1300 feet radio altitude down to 50 feet radio altitude.
-        
-        It remains displayed at least 15 seconds after windshear detection and is associated with an aural windshear warning.
-        
-        !!! info ""
-            Currently not available for the FBW A32nx for Microsoft Flight Simulator.
-    
-    === "25"
-        W/S AHEAD
-    
-        This is displayed in either amber or red, depending on the alert level.
-    
-        This is shown when the predictive windshear function has detected a windshear in front of the aircraft.
-        
-        !!! info ""
-            Currently not available for the FBW A32nx for Microsoft Flight Simulator.
+    CHECK ATT will be displayed in amber when there is a disagreement of at least 5 degrees in the attitude information displayed by the two PFDs. This will be shown on both PFDs and a caution will be shown on the ECAM.
 
-</div>
+- SI Flag
+
+    This is displayed in red. If sideslip information is lost, the index disappears and the SI flag is displayed.
+
+- FPV Flag
+
+    This is displayed in red. It appears in the TRK FPA mode, when the drift angle or flight path angle is not valid.
+
+- FD Flag
+
+    This is displayed in red. It appears if both of the FMGCs fail, or if both flight directors are disengaged and the FD pushbutton is on, and the attitude is valid.
+
+- SPD Flag
+
+    This is displayed in red. If the speed information fails, this flag will replace the airspeed indicator.
+
+- SPD SEL Flag
+
+    This is displayed in red. If the selected speed information fails, this flag will appear.
+
+- SPD LIM Flag
+
+    This is displayed in red. It appears when both FACs are inoperative, or in case of dual flap/slat channel failure. In this case, the following information is lost:
+    
+    - V~LS~
+    - S
+    - F
+    - Green Dot
+    - V-trend
+    - V~MAX~
+    - V~FE~ next
+    - VSW
+
+- V1 INOP Flag
+
+    This is displayed in red. When the V1 signal is not valid, this flag will replace the digital value.
+
+- ALT Flag
+
+    This is displayed in red. If the altitude information fails, this flag will replace the altitude scale.
+
+- CHECK ALT Flag
+
+    This is displayed in amber. This appears both as a flag on the PFD, and on the ECAM as a caution if the difference between the two PFD altitude indicators is greater than 250 feet when the QNH Barometric Reference is selected, or 500 feet when STD is selected.
+    
+    This flag disappears when the pilot's and first officer's barometer or references are different.
+
+- ALT SEL Flag
+
+    This is displayed in red. It appears if the selected altitude information fails.
+
+- V/S Flag
+
+    This is displayed in red. It appears if the vertical speed information fails and replaces the vertical speed scale.
+
+- LOC and G/S Flags
+
+    This is displayed in red and appears if the localizer or glideslope receiver fails.
+
+- V/DEV Flag
+
+    This is displayed in red. It appears if the vertical deviation information fails, and the LS pushbutton has not been pressed. This flag replaces the V/DEV scale.
+    
+    !!! info ""
+        Currently not available for the FBW A32NX for Microsoft Flight Simulator.
+
+- RA Flag
+
+    This is displayed in red. If both radio altimeters fail, this flag appears instead of the radio height indication.
+
+- DH Flag
+
+    This is displayed in amber and is shown when the aircraft has reached the decision height.
+
+- HDG Flag
+
+    This is displayed in red and is shown if the heading information has failed. It replaces the heading scale.
+
+- CHECK HDG Flag
+
+    This is displayed in amber and is also shown on the ECAM as a caution. It is shown if there is a 5-degree difference in heading between the Captain's PFD and the First Officer's PFD.
+
+- MACH Flag
+
+    This flag is displayed in red and appears if the mach data fails.
+
+- V/DEV Flag (amber)
+    
+    This is displayed in amber. It flashes on the top of the glide scale when the aircraft is in the approach phase and when either the final mode is armed/engaged or a non ILS approach has been selected, and the LS pushbutton has been selected.
+
+
+    !!! info ""
+        Currently not available for the FBW A32NX for Microsoft Flight Simulator.
+
+- DME X Flag
+
+    This is displayed in red. When the DME distance is not available, a DME 1 (on PFD 1) or a DME 2 (on PFD 2) flag replaces the DME distance indication.
+
+- ILS X Flag
+
+    If an ILS frequency is not available, or if the localizer or glideslope signals fail, an ILS 1 (on PFD 1) or an ILS 2 (on PFD 2) flag replaces the ILS frequency indication.
+
+- WINDSHEAR
+
+    This is displayed in red and is shown when the aircraft has encountered a windshear.
+    
+    This function is implemented into the FAC and is available when the slats/flaps are extended as follows:
+    
+    - At takeoff, from 5 seconds after liftoff up to 1300 feet radio altitude.
+    - At landing, from 1300 feet radio altitude down to 50 feet radio altitude.
+    
+    It remains displayed at least 15 seconds after windshear detection and is associated with an aural windshear warning.
+    
+    !!! info ""
+        Currently not available for the FBW A32NX for Microsoft Flight Simulator.
+
+- W/S AHEAD
+
+    This is displayed in either amber or red, depending on the alert level.
+
+    This is shown when the predictive windshear function has detected a windshear in front of the aircraft.
+    
+    !!! info ""
+        Currently not available for the FBW A32NX for Microsoft Flight Simulator.

--- a/docs/pilots-corner/a32nx-briefing/pfd/flags-messages.md
+++ b/docs/pilots-corner/a32nx-briefing/pfd/flags-messages.md
@@ -1,7 +1,3 @@
----
-hide: toc
----
-
 <link rel="stylesheet" href="../../../../stylesheets/pfd-interactive.css">
 
 # Flags and Messages


### PR DESCRIPTION
## Summary
As indicated in our docs channel content tabs were not working due to a limitation of the theme.

We could either pull it apart and customize it or just change our implementation.

~~Suggested in PR is using the new card grid feature to split the elements into two groups. Removing the TOC also helps spread out the page and layout.~~ Additional options are welcome. 

We've gotten rid of the below and transitioned this into bullet points instead. Just to keep this page relatively simple as it's the only content on the page. 
```
Option 1:
<img width="1407" alt="image" src="https://github.com/flybywiresim/docs/assets/1619968/2508b618-b569-47a0-b31c-ae5f790c181b">


Option 2: instead of `card grids` is just two simple admonitions:
<img width="1584" alt="image" src="https://github.com/flybywiresim/docs/assets/1619968/49fe7b85-b96a-4522-baea-0603dd5f3135">
```

### Location
- docs/pilots-corner/a32nx-briefing/pfd/flags-messages.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
