### PR TITLE
fix: remove mention of RMP nav backup being INOP

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md
@@ -78,9 +78,6 @@ The SEL indicator glows white on both RMPs when a transceiver normally associate
 
 This is used as a backup to select navigation aids and coursed via the RMP.
 
-!!! info ""
-    Currently, not available or INOP in the FBW A32NX for Microsoft Flight Simulator.
-
 ### Radio navigation selection keys
 
 ![ACP Radio Navigation Keys](../../../assets/a32nx-briefing/pedestal/ACP-radio-nav-keys.png "ACP Radio Navigation Keys")


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
tracernz confirmed on Discord that the RMP NAV key is operable and the backup functionality of this panel does work. I have not tested, but assume this to be true.

It may be worth adding more info on how to use this panel, although I'm not certain that it belongs in this section of the documentation. If so, I'm happy to detail this out as part of this PR.

https://discord.com/channels/738864299392630914/887806920252076053/1210707534449737851

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rmp.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
unworldlyalex