### PR TITLE
docs: Update a link for the airport sign and marking reference guide

### DIFF
--- a/docs/pilots-corner/beginner-guide/engine-start-taxi.md
+++ b/docs/pilots-corner/beginner-guide/engine-start-taxi.md
@@ -407,7 +407,7 @@ This section provides you with information on understanding the different signs 
 
 The FAA has a handy guide available for download that contains images of all the pertinent signs you may encounter, their purpose, and location at the airport.
 
-[Download FAA Guide](https://www.faa.gov/airports/runway_safety/publications/media/QuickReferenceGuideProof8.pdf){ .md-button }
+[Download FAA Guide](https://www.faa.gov/sites/faa.gov/files/airports/runway_safety/publications/QuickReferenceGuideProof8.pdf){ .md-button }
 
 ---
 


### PR DESCRIPTION
## Summary

The Engine Start and Taxi page links to a quick reference document from the FAA that explains the airport signs and markings. However, that links leads to a 404 page. I found the document on a new location, so I'm submitting this PR to update the relevant link.

### Location
- https://docs.flybywiresim.com/pilots-corner/beginner-guide/engine-start-taxi/
- https://github.com/flybywiresim/docs/blob/primary/docs/pilots-corner/beginner-guide/engine-start-taxi.md

Discord username (if different from GitHub): xmudrii