### PR TITLE
build: bump mkdocs-material -> 9.5.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.5.6
+mkdocs-material==9.5.12
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary
Updates mkdocs-material version.

### Notable upstream changes
- instant navigation fixes
	- meta tags were removed
	- KaTex not rendering 
	- the possibility of table of contents breaking
- bad positioning of the integrated table of contents


### Location
- requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
