### PR TITLE
docs: add <meta> tags (Group 1)

### DIFF
--- a/docs/fbw-a32nx/faq.md
+++ b/docs/fbw-a32nx/faq.md
@@ -1,3 +1,8 @@
+---
+title: FlyByWire A32NX - Common Questions 
+description: Explore the frequently asked questions about the FlyByWire A32NX add-on for Microsoft Flight Simulator 2020, providing insights into its features, installation, and troubleshooting.
+---
+
 ## General
 
 ???+ info "Q: Where is the plane in-sim?"

--- a/docs/fbw-a32nx/faq.md
+++ b/docs/fbw-a32nx/faq.md
@@ -1,6 +1,6 @@
 ---
 title: FlyByWire A32NX - Common Questions 
-description: Explore the frequently asked questions about the FlyByWire A32NX add-on for Microsoft Flight Simulator 2020, providing insights into its features, installation, and troubleshooting.
+description: Frequently Asked Questions about the the FlyByWire A32NX, detailing features, installation, and troubleshooting.
 ---
 
 ## General

--- a/docs/fbw-a32nx/fbw-versions.md
+++ b/docs/fbw-a32nx/fbw-versions.md
@@ -1,3 +1,8 @@
+---
+title: Versions and Features
+description: Explore the distinctions between Development, Stable, and Experimental versions of the FlyByWire A32NX add-on for Microsoft Flight Simulator 2020, along with their respective release notes.
+---
+
 # Versions and Features
 
 ## Version Overview

--- a/docs/fbw-a32nx/fbw-versions.md
+++ b/docs/fbw-a32nx/fbw-versions.md
@@ -1,6 +1,6 @@
 ---
 title: Versions and Features
-description: Explore the distinctions between Development, Stable, and Experimental versions of the FlyByWire A32NX add-on for Microsoft Flight Simulator 2020, along with their respective release notes.
+description: Differences and release notes about the Development, Stable, and Experimental versions of the FlyByWire A32NX.
 ---
 
 # Versions and Features

--- a/docs/fbw-a32nx/index.md
+++ b/docs/fbw-a32nx/index.md
@@ -1,6 +1,6 @@
 ---
 title: FlyByWire A32NX - Overview 
-description: This section is dedicated to the FlyByWire A32NX aircraft and its features.
+description: Explore the documentation for the FlyByWire A32NX add-on for Microsoft Flight Simulator 2020. Access installation guides, settings configurations, support resources, and more.
 ---
 
 <link rel="stylesheet" href="../../stylesheets/toc-tables.css">

--- a/docs/fbw-a32nx/index.md
+++ b/docs/fbw-a32nx/index.md
@@ -1,6 +1,6 @@
 ---
 title: FlyByWire A32NX - Overview 
-description: Explore the documentation for the FlyByWire A32NX add-on for Microsoft Flight Simulator 2020. Access installation guides, settings configurations, support resources, and more.
+description: Documentation and ressources for the FlyByWire A32NX add-on for Microsoft Flight Simulator 2020.
 ---
 
 <link rel="stylesheet" href="../../stylesheets/toc-tables.css">

--- a/docs/fbw-a32nx/installation.md
+++ b/docs/fbw-a32nx/installation.md
@@ -1,3 +1,8 @@
+---
+title: Installation Guide
+description: Learn how to install the FlyByWire A32NX add-on for Microsoft Flight Simulator 2020 with step-by-step guides.
+---
+
 # Installation Guide
 
 Please follow the information on this page to install the FlyByWire Simulations A32NX add-on for Microsoft Flight Simulator 2020

--- a/docs/fbw-a32nx/liveries.md
+++ b/docs/fbw-a32nx/liveries.md
@@ -1,3 +1,8 @@
+---
+title: Liveries Guide
+description: Discover how to access a variety of liveries to personalize your FlyByWire A32NX aircraft.
+---
+
 # Liveries Guide
 
 The best source for liveries for the FlyByWire A32NX is [FBW A32NX @ flightsim.to](https://flightsim.to/liveries/flybywire-a32nx/most-downloads/){target=new}.

--- a/docs/fbw-a32nx/settings.md
+++ b/docs/fbw-a32nx/settings.md
@@ -1,6 +1,6 @@
 ---
 title: Recommended Settings
-description: Explore the recommended settings to ensure a smooth flight with the FlyByWire A32NX add-on for Microsoft Flight Simulator 2020.
+description: Find the recommended settings to ensure a smooth flight with the FlyByWire A32NX add-on for Microsoft Flight Simulator 2020.
 ---
 
 # Recommended Settings

--- a/docs/fbw-a32nx/settings.md
+++ b/docs/fbw-a32nx/settings.md
@@ -1,3 +1,8 @@
+---
+title: Recommended Settings
+description: Explore the recommended settings to ensure a smooth flight with the FlyByWire A32NX add-on for Microsoft Flight Simulator 2020.
+---
+
 # Recommended Settings
 
 <style>

--- a/docs/fbw-a32nx/support/exp.md
+++ b/docs/fbw-a32nx/support/exp.md
@@ -1,3 +1,8 @@
+---
+title: Experimental Version
+description: Explore the Experimental version of the FlyByWire A32NX add-on for Microsoft Flight Simulator 2020.
+---
+
 # Experimental Version
 
 Our Experimental Version is temporarily on hold and all of its features have been moved to the Development Version. 

--- a/docs/fbw-a32nx/support/exp.md
+++ b/docs/fbw-a32nx/support/exp.md
@@ -1,6 +1,6 @@
 ---
 title: Experimental Version
-description: Explore the Experimental version of the FlyByWire A32NX add-on for Microsoft Flight Simulator 2020.
+description: Information about the discontinued Experimental version of the FlyByWire A32NX add-on for Microsoft Flight Simulator 2020.
 ---
 
 # Experimental Version

--- a/docs/fbw-a32nx/support/index.md
+++ b/docs/fbw-a32nx/support/index.md
@@ -1,3 +1,8 @@
+---
+title: Support Guide
+description: Get assistance and support for the FlyByWire A32NX add-on for Microsoft Flight Simulator 2020. Find resources, troubleshooting guides, and community forums to help resolve any issues you may encounter.
+---
+
 <link rel="stylesheet" href="../../stylesheets/toc-tables.css">
 
 # Support Guide

--- a/docs/fbw-a32nx/support/index.md
+++ b/docs/fbw-a32nx/support/index.md
@@ -1,6 +1,6 @@
 ---
 title: Support Guide
-description: Get assistance and support for the FlyByWire A32NX add-on for Microsoft Flight Simulator 2020. Find resources, troubleshooting guides, and community forums to help resolve any issues you may encounter.
+description: Receive support for the FlyByWire A32NX. Access resources, troubleshooting guides, and community forums for assistance.
 ---
 
 <link rel="stylesheet" href="../../stylesheets/toc-tables.css">

--- a/docs/fbw-a32nx/support/performance-tips.md
+++ b/docs/fbw-a32nx/support/performance-tips.md
@@ -1,3 +1,8 @@
+---
+title: Performance Tips
+description: Learn how to maximize performance and minimize resource usage in Microsoft Flight Simulator 2020.
+---
+
 # Performance Tips
 ---
 

--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -1,3 +1,8 @@
+---
+title: Reported Known Issues
+description: Explore reported issues and known bugs for the FlyByWire A32NX add-on for Microsoft Flight Simulator 2020.
+---
+
 # Reported Known Issues
 
 <link rel="stylesheet" href="/stylesheets/toc-tables.css">


### PR DESCRIPTION
## Summary
This PR adds `<meta>` tags to the pages listed as "Group 1" in this issue #791 .

I tried to be as descriptive as possible and to use relevant keywords for the FBW cause.

I'm not a SEO expert though and English is not my primary language so feel free to nitpick the wording. If this is useful, I'll be happy to add meta tags to the remaining groups in #791.

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
- https://docs.flybywiresim.com/fbw-a32nx/
- https://docs.flybywiresim.com/fbw-a32nx/faq/
- https://docs.flybywiresim.com/fbw-a32nx/fbw-versions/
- https://docs.flybywiresim.com/fbw-a32nx/installation/
- https://docs.flybywiresim.com/fbw-a32nx/settings/
- https://docs.flybywiresim.com/fbw-a32nx/liveries/
- https://docs.flybywiresim.com/fbw-a32nx/support/
- https://docs.flybywiresim.com/fbw-a32nx/support/reported-issues/
- https://docs.flybywiresim.com/fbw-a32nx/support/exp/




