### PR TITLE
docs: add <meta> tags (Group 2)

### DIFF
--- a/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/fbw-a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -1,4 +1,6 @@
 ---
+title: FlyByWire A32NX API - A32NX Flight Deck API
+description: Documentation for the FlyByWire A32NX FlightDeck API.
 hide:
     - navigation
 ---

--- a/docs/fbw-a32nx/a32nx-api/hardware.md
+++ b/docs/fbw-a32nx/a32nx-api/hardware.md
@@ -1,3 +1,8 @@
+---
+title: FlyByWire A32NX API - Common Hardware Controllers and Setup
+description: A collection of common flight simulation hardware which can be used together with Microsoft Flight Simulator 2020 and the FlyByWire A32NX.
+---
+
 # Common Hardware Controllers and Setup
 
 This page shows you a collection of common flight simulation hardware which can be used together with Microsoft Flight Simulator and the FlyByWire A32NX.

--- a/docs/fbw-a32nx/a32nx-api/lvars-events.md
+++ b/docs/fbw-a32nx/a32nx-api/lvars-events.md
@@ -1,3 +1,8 @@
+---
+title: FlyByWire A32NX Developer API
+description: Documentation for the FlyByWire A32NX FlightDeck API.
+---
+
 # A32NX Developer API
 
 Flight-Deck API Documentation: [Flight-Deck API](a32nx-flightdeck-api.md)

--- a/docs/fbw-a32nx/feature-guides/audio.md
+++ b/docs/fbw-a32nx/feature-guides/audio.md
@@ -1,3 +1,8 @@
+---
+title: Audio Configuration
+description: Explore FlyByWire A32NX's audio settings regarding flight crew interactions, passengers, engine and wind sounds for an authentic flight experience.
+---
+
 # Audio Configuration
 
 This page provides an overview of the various audio settings available in the A32NX and their respective functions.

--- a/docs/fbw-a32nx/feature-guides/autopilot-fbw.md
+++ b/docs/fbw-a32nx/feature-guides/autopilot-fbw.md
@@ -1,3 +1,8 @@
+---
+title: Custom Autopilot / Fly-By-Wire A32NX
+description: Explore the advanced autopilot features of the FlyByWire A32NX, including detailed guides on setup, usage, and tips for a seamless flight experience.
+---
+ 
 # Custom Autopilot / Fly-By-Wire
 
 !!! warning "Important"

--- a/docs/fbw-a32nx/feature-guides/cFMS.md
+++ b/docs/fbw-a32nx/feature-guides/cFMS.md
@@ -1,3 +1,8 @@
+---
+title: Custom Custom Flight Management System
+description: Dive into the A32NX's custom FMS and stay informed with the latest known issues. Get tips for effective flight planning and troubleshooting.
+---
+
 <link rel="stylesheet" href="/../../stylesheets/reported-issues.css">
 
 # Custom Flight Management System

--- a/docs/fbw-a32nx/feature-guides/cFMS.md
+++ b/docs/fbw-a32nx/feature-guides/cFMS.md
@@ -1,6 +1,6 @@
 ---
 title: Custom Custom Flight Management System
-description: Dive into the A32NX's custom FMS and stay informed with the latest known issues. Get tips for effective flight planning and troubleshooting.
+description: Dive into the A32NX's custom FMS and stay informed with the latest known issues and troubleshooting tips.
 ---
 
 <link rel="stylesheet" href="/../../stylesheets/reported-issues.css">

--- a/docs/fbw-a32nx/feature-guides/camera-views.md
+++ b/docs/fbw-a32nx/feature-guides/camera-views.md
@@ -1,3 +1,8 @@
+---
+title: Custom Camera Views
+description: Learn about the built-in pre-configured custom camera views for the FlyByWire A32NX, including a comprehensive overview and usage instructions.
+---
+
 # Custom Camera Views
 
 The FlyByWire A32NX comes with some built in pre-configured custom camera views.

--- a/docs/fbw-a32nx/feature-guides/custom-air-conditioning.md
+++ b/docs/fbw-a32nx/feature-guides/custom-air-conditioning.md
@@ -1,3 +1,8 @@
+---
+title: Custom Air Conditioning System
+description: Explore the air conditioning system of the FlyByWire A32NX, understand how it works, and learn how to mitigate failures in its components.
+---
+
 # Custom Air Conditioning System
 
 ## System Description

--- a/docs/fbw-a32nx/feature-guides/custom-hydraulics.md
+++ b/docs/fbw-a32nx/feature-guides/custom-hydraulics.md
@@ -1,3 +1,8 @@
+---
+title: Custom Hydraulics
+description: Explore the detailed workings of the A32NX's custom hydraulics system, including features, known issues, and expert tips.
+---
+
 # Custom Hydraulics
 
 ## Gear system

--- a/docs/fbw-a32nx/feature-guides/flight-planning.md
+++ b/docs/fbw-a32nx/feature-guides/flight-planning.md
@@ -1,6 +1,6 @@
 ---
 title: Flight Planning
-description: Discover how to load a flight plan into the FlyByWire A32NX across various methods, and seamlessly integrate it with your chosen ATC service.
+description: Discover how to load a flight plan into the FlyByWire A32NX across various methods, and integrate it with your chosen ATC service.
 ---
 
 # Flight Planning

--- a/docs/fbw-a32nx/feature-guides/flight-planning.md
+++ b/docs/fbw-a32nx/feature-guides/flight-planning.md
@@ -1,3 +1,8 @@
+---
+title: Flight Planning
+description: Discover how to load a flight plan into the FlyByWire A32NX across various methods, and seamlessly integrate it with your chosen ATC service.
+---
+
 # Flight Planning
 
 ## Overview

--- a/docs/fbw-a32nx/feature-guides/flypados3/charts.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/charts.md
@@ -1,6 +1,6 @@
 ---
 title: flyPadOS 3 EFB - Navigation & Charts
-description: Learn how to access and utilize charts on FlyPadOS3 with a Navigraph account or local files.
+description: Learn how to access and utilize charts on flyPadOS 3 with a Navigraph account or local files.
 ---
 
 <link rel="stylesheet" href="../../../../stylesheets/efb-interactive.css">

--- a/docs/fbw-a32nx/feature-guides/flypados3/charts.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/charts.md
@@ -1,3 +1,8 @@
+---
+title: flyPadOS 3 EFB - Navigation & Charts
+description: Learn how to access and utilize charts on FlyPadOS3 with a Navigraph account or local files.
+---
+
 <link rel="stylesheet" href="../../../../stylesheets/efb-interactive.css">
 
 # flyPad Navigation & Charts

--- a/docs/fbw-a32nx/feature-guides/flypados3/checklists.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/checklists.md
@@ -1,3 +1,8 @@
+---
+title: flyPadOS 3 EFB - Checklists
+description: Discover how to configure and how to use the interactive checklists provided with flyPadOS 3 for the FlyByWire A32NX.
+---
+
 <link rel="stylesheet" href="../../../../stylesheets/efb-interactive.css">
 
 # Interactive Checklists

--- a/docs/fbw-a32nx/feature-guides/flypados3/dashboard.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/dashboard.md
@@ -1,3 +1,8 @@
+---
+title: flyPadOS 3 EFB - Dashboard
+description: A comprehensive guide on how to use the Dashboard widgets in FlyPadOS3 for the FlyByWire A32NX.
+---
+
 <link rel="stylesheet" href="../../../../stylesheets/efb-interactive.css">
 
 # flyPad Dashboard

--- a/docs/fbw-a32nx/feature-guides/flypados3/dashboard.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/dashboard.md
@@ -1,6 +1,6 @@
 ---
 title: flyPadOS 3 EFB - Dashboard
-description: A comprehensive guide on how to use the Dashboard widgets in FlyPadOS3 for the FlyByWire A32NX.
+description: A comprehensive guide on how to use the Dashboard widgets in flyPadOS 3 for the FlyByWire A32NX.
 ---
 
 <link rel="stylesheet" href="../../../../stylesheets/efb-interactive.css">

--- a/docs/fbw-a32nx/feature-guides/flypados3/dispatch.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/dispatch.md
@@ -1,3 +1,8 @@
+---
+title: flyPadOS 3 EFB - Dispatch
+description: Information about the Dispatch menu provided by FlyPadOS3 in the FlyByWire A32NX.
+---
+
 <link rel="stylesheet" href="../../../../stylesheets/efb-interactive.css">
 
 # flyPad Dispatch

--- a/docs/fbw-a32nx/feature-guides/flypados3/dispatch.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/dispatch.md
@@ -1,6 +1,6 @@
 ---
 title: flyPadOS 3 EFB - Dispatch
-description: Information about the Dispatch menu provided by FlyPadOS3 in the FlyByWire A32NX.
+description: Information about the Dispatch menu provided by flyPadOS 3 in the FlyByWire A32NX.
 ---
 
 <link rel="stylesheet" href="../../../../stylesheets/efb-interactive.css">

--- a/docs/fbw-a32nx/feature-guides/flypados3/failures.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/failures.md
@@ -1,3 +1,8 @@
+---
+title: flyPadOS 3 EFB - Failures
+description: Discover how to simulate various system failures with flyPadOS 3 for the FlyByWire A32NX.
+---
+
 <link rel="stylesheet" href="../../../../stylesheets/efb-interactive.css">
 
 # flyPad Failures

--- a/docs/fbw-a32nx/feature-guides/flypados3/ground.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/ground.md
@@ -1,3 +1,8 @@
+---
+title: flyPadOS 3 EFB - Ground
+description: A comprehensive guide on how to use the ground services provided by FlyPadOS3 in the FlyByWire A32NX.
+---
+
 <link rel="stylesheet" href="../../../../stylesheets/efb-interactive.css">
 
 # flyPad Ground

--- a/docs/fbw-a32nx/feature-guides/flypados3/ground.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/ground.md
@@ -1,6 +1,6 @@
 ---
 title: flyPadOS 3 EFB - Ground
-description: A comprehensive guide on how to use the ground services provided by FlyPadOS3 in the FlyByWire A32NX.
+description: A comprehensive guide on how to use the ground services provided by flyPadOS 3 in the FlyByWire A32NX.
 ---
 
 <link rel="stylesheet" href="../../../../stylesheets/efb-interactive.css">

--- a/docs/fbw-a32nx/feature-guides/flypados3/online-atc.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/online-atc.md
@@ -1,3 +1,8 @@
+---
+title: flyPadOS 3 EFB - Online ATC
+description: Discover how to use online ATC services such as VATSIM or IVAO with FlyPadOS3 for the FlyByWire A32NX.
+---
+
 <link rel="stylesheet" href="../../../../stylesheets/efb-interactive.css">
 
 # flyPad Online ATC

--- a/docs/fbw-a32nx/feature-guides/flypados3/online-atc.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/online-atc.md
@@ -1,6 +1,6 @@
 ---
 title: flyPadOS 3 EFB - Online ATC
-description: Discover how to use online ATC services such as VATSIM or IVAO with FlyPadOS3 for the FlyByWire A32NX.
+description: Discover how to use online ATC services such as VATSIM or IVAO with flyPadOS 3 for the FlyByWire A32NX.
 ---
 
 <link rel="stylesheet" href="../../../../stylesheets/efb-interactive.css">

--- a/docs/fbw-a32nx/feature-guides/flypados3/performance.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/performance.md
@@ -1,6 +1,6 @@
 ---
 title: flyPadOS 3 EFB - Performance
-description: A comprehensive guide covering the descent and landing performance calculators provided by FlyPadOS3 in the FlyByWire A32NX.
+description: A comprehensive guide covering the descent and landing performance calculators provided by flyPadOS 3 in the FlyByWire A32NX.
 ---
 
 <link rel="stylesheet" href="../../../../stylesheets/efb-interactive.css">

--- a/docs/fbw-a32nx/feature-guides/flypados3/performance.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/performance.md
@@ -1,3 +1,8 @@
+---
+title: flyPadOS 3 EFB - Performance
+description: A comprehensive guide covering the descent and landing performance calculators provided by FlyPadOS3 in the FlyByWire A32NX.
+---
+
 <link rel="stylesheet" href="../../../../stylesheets/efb-interactive.css">
 
 # flyPad Performance

--- a/docs/fbw-a32nx/feature-guides/flypados3/presets.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/presets.md
@@ -1,3 +1,8 @@
+---
+title: flyPadOS 3 EFB - Presets
+description: Discover how to automate setup procedures in the FlyByWire A32NX with a virtual co-pilot, covering everything from lighting to aircraft systems.
+---
+
 <link rel="stylesheet" href="../../../../stylesheets/efb-interactive.css">
 
 # Interior Lighting and Aircraft Presets

--- a/docs/fbw-a32nx/feature-guides/flypados3/settings.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/settings.md
@@ -1,3 +1,8 @@
+---
+title: flyPadOS 3 EFB - Settings
+description: Learn how to configure various aspects of flyPadOS3 itself in the FlyByWire A32NX, from aircraft options to 3rd party settings.
+---
+
 <link rel="stylesheet" href="../../../../stylesheets/efb-interactive.css">
 
 # flyPad Settings

--- a/docs/fbw-a32nx/feature-guides/flypados3/throttle-calibration.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/throttle-calibration.md
@@ -1,3 +1,8 @@
+---
+title: flyPadOS 3 EFB - Throttle Calibration
+description: Important information regarding throttle calibration for use with the FlyByWire A32NX, with step-by-step guide for each controller.
+---
+
 # Throttle Calibration
 
 !!! warning "Please Note"

--- a/docs/fbw-a32nx/feature-guides/freetext.md
+++ b/docs/fbw-a32nx/feature-guides/freetext.md
@@ -1,3 +1,8 @@
+---
+title: Free Text
+description: Learn how to use the free text feature to message other sim pilots flying the FlyByWire A32NX.
+---
+
 # Free Text
 
 This page explains in detail how to use the free text feature in the AOC Menu to message other sim pilots flying the A32NX. To begin using the free text feature, you first need to enable the TELEX feature through the flyPad - [Guide Here](flypados3/settings.md#usage_3).

--- a/docs/fbw-a32nx/feature-guides/hoppie.md
+++ b/docs/fbw-a32nx/feature-guides/hoppie.md
@@ -1,3 +1,8 @@
+---
+title: Hoppie ACARS
+description: Learn how to use the Hoppie ACARS system in the FlyByWire A32NX to communicate with aircrafts, virtual airlines and virtual ATC stations.
+---
+
 # Hoppie ACARS
 
 !!! warning "Requires credentials with Hoppie service"

--- a/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
+++ b/docs/fbw-a32nx/feature-guides/loading-fuel-weight.md
@@ -1,3 +1,8 @@
+---
+title: Fuel and Weight
+description: Detailed overview of fueling, weight setup, and CG management in the A32NX, covering everything from passengers and cargo to fuel persistence.
+---
+
 # Fuel and Weight
 
 <link rel="stylesheet" href="/../../stylesheets/fuel-weight.css">

--- a/docs/fbw-a32nx/feature-guides/mcdu-keyboard.md
+++ b/docs/fbw-a32nx/feature-guides/mcdu-keyboard.md
@@ -1,3 +1,8 @@
+---
+title: MCDU Keyboard
+description: Discover how to enhance your FlyByWire A32NX experience by using your keyboard for MCDU inputs, streamlining data entry and cockpit interactions.
+---
+
 # MCDU Keyboard
 
 ---

--- a/docs/fbw-a32nx/feature-guides/nw-tiller.md
+++ b/docs/fbw-a32nx/feature-guides/nw-tiller.md
@@ -1,3 +1,8 @@
+---
+title: Nose Wheel and Tiller Operation
+description: A guide to using the FlyByWire A32NX's tiller independently of the rudder for a more realistic taxi experience.
+---
+
 # Nose Wheel and Tiller Operation
 
 We have introduced a feature for using the tiller to steer the nose wheel independently of the rudder. As Microsoft Flight Simulator does not natively support this feature yet, we had to become creative to build a solution for this.

--- a/docs/fbw-a32nx/feature-guides/simbrief.md
+++ b/docs/fbw-a32nx/feature-guides/simbrief.md
@@ -1,5 +1,6 @@
 ---
-title: SimBrief Integration
+title: SimBrief and Navigraph Integration
+description: Discover how to use SimBrief with the FlyByWire A32NX for realistic flight planning.
 ---
 
 <link rel="stylesheet" href="../../../stylesheets/toc-tables.css">

--- a/docs/fbw-a32nx/feature-guides/wheel-chocks-cones.md
+++ b/docs/fbw-a32nx/feature-guides/wheel-chocks-cones.md
@@ -1,3 +1,8 @@
+---
+title: Wheel Chocks and GSE Safety Cones
+description: Ensure safe ground operations with wheel chocks and GSE Safety Cones around the FlyByWire A32NX.
+---
+
 # Wheel Chocks and GSE Safety Cones
 
 ## Overview


### PR DESCRIPTION
Hey there!

## Summary
This PR adds `<meta>` tags to the pages listed as "Group 2" in #791 .

I kept the descriptions under 150 chars to avoid them being truncated, and I tried to keep them as descriptive, catchy and SEO friendly as possible. Feedback welcome if something can get improved !

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
- [Feature Guides](https://docs.flybywiresim.com/fbw-a32nx/feature-guides/) and all sub-pages within
- [API and Hardware](https://docs.flybywiresim.com/fbw-a32nx/a32nx-api/) and all the sub-pages within