### PR TITLE
fix: Fix table headings on VNAV overview page

### DIFF
--- a/docs/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/overview.md
+++ b/docs/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/overview.md
@@ -75,14 +75,14 @@ Vertical guidance is available for TAKEOFF, CLIMB, CRUISE, DESCENT, and APPROACH
 
 The vertical modes are divided into two main modes:
 
-- Selected Vertical Modes
-- Managed Vertical Modes
+- [Selected Vertical Modes](selected-modes.md)
+- [Managed Vertical Modes](./managed-modes.md)
 
 One of the main notable differences between Selected and Managed Vertical Guidance is that the managed mode accounts for altitude and speed constraints at waypoints and computes the vertical flight path accordingly. Selected mode, on the other hand, ignores any constraints from the flight plan.
 
 Vertical guidance includes these modes:
 
-| [SELECTED](selected-modes.md)                                                | [MANAGED](./managed-modes.md)                                          |
+| Selected                                                                     | Managed                                                                |
 |:-----------------------------------------------------------------------------|:-----------------------------------------------------------------------|
 | [OP CLB](selected-modes.md#op-clb-open-climb)                                | [SRS](managed-modes.md#takeoff-srs-speed-reference-system) (TO and GA) |
 | [OP DES](selected-modes.md#op-des-open-descent)                              | [CLB](managed-modes.md#clb-climb),                                     |


### PR DESCRIPTION
## Summary

The VNAV Overview page has a table with vertical modes overview, however, text in the table heading is currently invisible:

<img width="787" alt="image" src="https://github.com/flybywiresim/docs/assets/18719127/bdb75b0f-f322-4115-a406-3e9d3fcadf23">

This is because the background color of table headings is blue, which matches the color of links. This quick fix moves links from the table heading to the VNAV modes list above. Potentially there's a better fix, but might require more fiddling with markdown and HTML.

### Location

https://docs.flybywiresim.com/pilots-corner/advanced-guides/flight-guidance/vertical-guidance/overview/?h=vnav#vertical-modes-overview