### PR TITLE
build: bump mkdocs-material -> 9.5.17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.5.15
+mkdocs-material==9.5.17
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.5.12
+mkdocs-material==9.5.15
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary
Provides patch fix for social plugin issues with new Google Fonts API changes crashing the build.

Updates to latest upstream mkdocs-material.

Notable Changes
- Reverted fix for transparent iframes (9.5.14)
- Fixed edge cases in exclusion logic of info plugin
- Fixed inability to reset pipeline in search plugin

### Location
- requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
