### PR TITLE
fix: Fixed broken link and revert of meta tags PR 

### DIFF
--- a/docs/fbw-a32nx/feature-guides/flypados3/settings.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/settings.md
@@ -244,7 +244,7 @@ Settings for integrations with various 3rd party applications
 - Navigraph Account Link
     - Setup wizard to connect your Navigraph Account with the flypad.
 - Override SimBrief User ID
-    - Allows users to input a custom SimBrief User ID. For more information see [A32NX simBrief Integration](../simbrief/#setup-a32nx-simbrief-integration).
+    - Allows users to input a custom SimBrief User ID. For more information see [A32NX simBrief Integration](../simbrief.md/#setup-a32nx-simbrief-integration).
 - Automatically Import SimBrief Data
     - Imports latest SimBrief flight automatically when starting the flyPad.
 

--- a/docs/pilots-corner/beginner-guide/.pages
+++ b/docs/pilots-corner/beginner-guide/.pages
@@ -1,8 +1,3 @@
-# Edit this page to get:
-# - Title for the whole directory
-# - Titles for specific pages or subdirectories
-# - Order of pages (otherwise alphabetical order)
-
 title: Beginner Guide
 nav:
     - Overview: overview.md

--- a/docs/pilots-corner/beginner-guide/after-landing.md
+++ b/docs/pilots-corner/beginner-guide/after-landing.md
@@ -1,8 +1,3 @@
----
-title: A32NX Beginner Guide - After Landing and Taxi to Gate
-description: Learn the correct procedures for after landing and vacating the runway with the FlyByWire A32NX.
----
-
 # After Landing and Taxi to Gate
 
 This guide will explain the correct procedures after we have landed and vacated the runway and then taxiing to the designated gate.

--- a/docs/pilots-corner/beginner-guide/descent.md
+++ b/docs/pilots-corner/beginner-guide/descent.md
@@ -1,8 +1,3 @@
----
-title: A32NX Beginner Guide - Descent Planning and Descent
-description: Learn how to plan and fly a descent from cruise altitude through STAR and Instrument Approach up to the final approach with the FlyByWire A32NX.
----
-
 # Descent Planning and Descent
 
 This guide will explain the correct procedures to plan and fly a descent

--- a/docs/pilots-corner/beginner-guide/engine-start-taxi.md
+++ b/docs/pilots-corner/beginner-guide/engine-start-taxi.md
@@ -1,8 +1,3 @@
----
-title: A32NX Beginner Guide - Engine Start and Taxi
-description: Learn how to accomplish a pushback with engine start and perform a safe taxi to the departure runway with the FlyByWire A32NX.
----
-
 # Engine Start and Taxi
 
 This guide will explain the correct procedures to accomplish a pushback with engine start and perform a safe taxi to the departure runway.

--- a/docs/pilots-corner/beginner-guide/landing.md
+++ b/docs/pilots-corner/beginner-guide/landing.md
@@ -1,8 +1,3 @@
----
-title: A32NX Beginner Guide - Approach and ILS Landing
-description: Learn how to fly a final approach and conduct an ILS landing with the FlyByWire A32NX.
----
-
 # Approach and ILS Landing
 
 This guide will explain the correct procedures to fly a final approach and conduct an ILS landing.

--- a/docs/pilots-corner/beginner-guide/powering-down.md
+++ b/docs/pilots-corner/beginner-guide/powering-down.md
@@ -1,8 +1,3 @@
----
-title: A32NX Beginner Guide - Powering Down
-description: Learn the correct procedures to power down the FlyByWire A32NX aircraft.
----
-
 # Powering Down
 
 This guide will explain the correct procedures to power down the aircraft when at the gate after arriving at the destination and taxi to the designated gate.

--- a/docs/pilots-corner/beginner-guide/preflight.md
+++ b/docs/pilots-corner/beginner-guide/preflight.md
@@ -1,8 +1,3 @@
----
-title: A32NX Beginner Guide - Preflight
-description: Learn about the FlyByWire A32NX's features that assist in configuring and operating the aircraft.
----
-
 # Preflight
 
 Before you start your flight in earnest, we have included various features in the A32NX that assist in configuring the aircraft and in-flight support. Some of these features require the aircraft to be powered on. Additionally, these guides will be linked in the appropriate locations throughout the beginner guide. 

--- a/docs/pilots-corner/beginner-guide/preparing-mcdu.md
+++ b/docs/pilots-corner/beginner-guide/preparing-mcdu.md
@@ -1,8 +1,3 @@
----
-title: A32NX Beginner Guide - Preparing the MCDU
-description: Learn how to prepare the MCDU in the FlyByWire A32NX for your departure. 
----
-
 # Preparing the MCDU
 
 This guide will help you prepare the MCDU in the A32NX for your departure. It includes a simple route that you can use to follow along easily and replicate in the simulator.

--- a/docs/pilots-corner/beginner-guide/starting-the-aircraft.md
+++ b/docs/pilots-corner/beginner-guide/starting-the-aircraft.md
@@ -1,8 +1,3 @@
----
-title: A32NX Beginner Guide - Starting the Aircraft
-description: Learn how to start the FlyByWire A32NX aircraft from a cold and dark state.
----
-
 # Starting the Aircraft
 
 This guide will assist you with starting your aircraft. It includes images to assist you with understanding the locations of all buttons and switches.

--- a/docs/pilots-corner/beginner-guide/takeoff-climb-cruise.md
+++ b/docs/pilots-corner/beginner-guide/takeoff-climb-cruise.md
@@ -1,8 +1,3 @@
----
-title: A32NX Beginner Guide - Takeoff, Climb and Cruise
-description: Learn how to takeoff, climb and establish cruise altitude with the FlyByWire A32NX.
----
-
 # Takeoff, Climb and Cruise
 
 This guide will explain the correct procedures to accomplish takeoff, climb and establish cruise altitude.


### PR DESCRIPTION
## Summary
Fixing issue with meta tags by reverting PR:
![image](https://github.com/flybywiresim/docs/assets/16833201/1ab1d230-0cb2-4f71-b714-66df8c0dbc49)

Discord username (if different from GitHub):
