### PR TITLE
fix: update announcement bar URL + NOTAM title

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -2,5 +2,5 @@
 
 <!-- Announcement Bar Implementation -->
 {% block announce %}
-    Read our latest NOTAM - <a href="https://flybywiresim.com/notams/all-the-downloads/">All the Downloads! A Story of a Large Release</a>
+    Read our latest NOTAM - <a href="https://flybywiresim.com/notams/fsweekend-2024/">FlyByWire Simulations at FSWeekend 2024</a>
 {% endblock %}


### PR DESCRIPTION
## Summary
Quick update to the announcement bar.

### Location
- overrides/main.html

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
