### PR TITLE
build: bump mkdocs-material -> 9.5.21

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.5.17
+mkdocs-material==9.5.21
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary
Updates mkdocs-material. Notable changes:

### mkdocs
- Mkdocs updated to 1.6
- New serve flag `--open` which opens browser and site after server started.
- Python 3.12 now fully supported
- Full changelog available [here](https://www.mkdocs.org/about/release-notes/)

### mkdocs material
- Various social plugin fixes
- Various styling fixes across elements from mkdocs-material

### Location
- requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
