### PR TITLE
refactor: search boost and pitch trim results

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rudder-trim.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rudder-trim.md
@@ -1,3 +1,8 @@
+---
+search:
+    boost: 0.5
+---
+
 # Rudder Trim
 
 ---

--- a/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/thrust-pitch-trim.md
+++ b/docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/thrust-pitch-trim.md
@@ -1,3 +1,8 @@
+---
+search:
+    boost: 1
+---
+
 # Thrust Lever and Pitch Trim
 
 ---

--- a/docs/pilots-corner/beginner-guide/engine-start-taxi.md
+++ b/docs/pilots-corner/beginner-guide/engine-start-taxi.md
@@ -197,13 +197,13 @@ Complete the after start flow:
 
 Perform the AFTER START checklist.
 
-!!! info "Setting Pitch Trim Advice"
-    While setting the pitch trim is standard operating procedure, a precisely set trim value on the trim wheel is not critical. As long as your center of gravity (CG) is within CG limits, any trim setting within the green band will provide for a safe takeoff in the A320neo. Appropriate trim settings can be found at the bottom of our [checklist](../assets/sop/A32NX%20Documentation/FBW%20A32NX%20Checklist.pdf).
+### Pitch Trim
 
-    There is a rotation law in the NEO that gives you a consistent rotation rate for any given stick input, regardless of other conditions. Upon liftoff, the autotrim becomes active.
+While setting the pitch trim is standard operating procedure, a precisely set trim value on the trim wheel is not critical. As long as your center of gravity (CG) is within CG limits, any trim setting within the green band will provide for a safe takeoff in the A320neo. Appropriate trim settings can be found at the bottom of our [checklist](../assets/sop/A32NX%20Documentation/FBW%20A32NX%20Checklist.pdf).
 
-    ---
+There is a rotation law in the NEO that gives you a consistent rotation rate for any given stick input, regardless of other conditions. Upon liftoff, the autotrim becomes active.
 
+!!! info "Pitch Trim Takeoff Example"
     !!! block ""
         ![Throttle quad](../assets/beginner-guide/mcdu/Thrust-lever-elev-trim.png){loading=lazy width=50% align=left}
 

--- a/docs/pilots-corner/beginner-guide/engine-start-taxi.md
+++ b/docs/pilots-corner/beginner-guide/engine-start-taxi.md
@@ -1,3 +1,8 @@
+---
+search:
+    boost: 2
+---
+
 # Engine Start and Taxi
 
 This guide will explain the correct procedures to accomplish a pushback with engine start and perform a safe taxi to the departure runway.


### PR DESCRIPTION
## Summary
Includes fixes to boost finding "Pitch Trim" in search results on the beginners guide. 

**Future Boosting Control**: After this PR we should opt to establish a boosting criteria for relevant pages if we need.

Currently it is set as the following to tweak results:

- boost: 2 (this is to bump desired result to the top)
- boost: 1 (demote other results)
- boost: 0.5 (further demote - see note below)

Header classification plays a a factor in natural boosting of results i.e. if an h1 contains `trim` it will most likely appear ahead of other searchs that are plain body or as a sub-heading.

### TO DO

- [ ] Add additional information to Pitch Trim (request from Dev's)
- [ ] Check if applicable to other pitch trim related pages that are not beginners guide


### Location
- docs/pilots-corner/beginner-guide/engine-start-taxi.md
- docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/rudder-trim.md
- docs/pilots-corner/a32nx-briefing/flight-deck/pedestal/thrust-pitch-trim.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
