### PR TITLE
refactor: readme links and sim version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 
 Repository for the FlyByWire Simulations Documentation Project website.
 
-[Learn How to Contribute](https://docs.flybywiresim.com/dev-corner/dev-guide/contribute/)
+[Learn How to Contribute](https://docs.flybywiresim.com/dev-corner/development-projects/documentation-project/documentation/)
+
+[Writing Guide](https://docs.flybywiresim.com/dev-corner/development-projects/documentation-project/writing-documentation/)
 
 [https://docs.flybywiresim.com/](https://docs.flybywiresim.com/)
 

--- a/docs/fbw-a32nx/support/reported-issues.md
+++ b/docs/fbw-a32nx/support/reported-issues.md
@@ -18,7 +18,7 @@ description: Explore reported issues and known bugs for the FlyByWire A32NX add-
 
     <img src="https://img.shields.io/github/v/release/flybywiresim/aircraft.svg?color=2F4E5B&style=flat" /> <img src="https://img.shields.io/badge/dynamic/json?color=00848A&label=Development&query=shortSha&url=https%3A%2F%2Fapi.flybywiresim.com%2Fapi%2Fv1%2Fgit-versions%2Fflybywiresim%2Faircraft%2Fbranches%2Fmaster&style=flat" alt="Development Version" />
 
-    FBW Installer - [Download Here](https://api.flybywiresim.com/installer){target=new} / *Latest Sim Version: 1.36.2.0*
+    FBW Installer - [Download Here](https://api.flybywiresim.com/installer){target=new} / *Latest Sim Version: 1.37.18.0*
 
 !!! warning "Read our Support Guides"
 


### PR DESCRIPTION
## Summary
Fixes the contributing links on the README.md and adds a new one for our split writing guide.

Update to SU15 version number on reported-issues.md

### Location
- README.md
- docs/fbw-a32nx/support/reported-issues.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
