### PR TITLE
fix: Update a32nx-breifing/MCDU/PERF to direct to takeoff calc page

### DIFF
--- a/docs/pilots-corner/a32nx-briefing/mcdu/perf.md
+++ b/docs/pilots-corner/a32nx-briefing/mcdu/perf.md
@@ -44,7 +44,7 @@ Prompts on each PERF page:
 
         [flyPad Performance Page](../../../fbw-a32nx/feature-guides/flypados3/performance.md){target=new .md-button}
 
-        !!! warning "Not Available in Stable Version, you can instead click on the LSK next to V1, VR and V2, to let the aircraft calculate the V-Speed for you."
+        !!! warning "Not Available in the Stable Version; you can instead click on the LSK next to V1, VR and V2 to let the aircraft calculate the V-Speeds for you."
         
 
 - TRANS ALT (4L)

--- a/docs/pilots-corner/a32nx-briefing/mcdu/perf.md
+++ b/docs/pilots-corner/a32nx-briefing/mcdu/perf.md
@@ -40,7 +40,9 @@ Prompts on each PERF page:
             If the takeoff shift (see below) or the runway is changed after V1, V2 or VR insertion, but the origin airport remains the same, the MCDU message “CHECK TAKEOFF DATA” is displayed, but all takeoff parameters are retained.
     
     !!! tip
-        In the FlyByWire A32NX you can click on the LSK next to V1, VR and V2, to let the aircraft calculate the V-Speed for you. This calculated value is placed in the Scratchpad and can be moved to the V-Speed field with a second click. In real life, this value is usually calculated by a specific airline application on the EFB.
+        In the FlyByWire A32NX, pilots can calculate takeoff performance data via the flyPad. Visit our flyPad Performance Page guide for more information.
+
+        [flyPad Performance Page](../../../fbw-a32nx/feature-guides/flypados3/performance.md){target=new .md-button}
 
 - TRANS ALT (4L)
     - This field displays the navigation database default transition altitude (if defined) once the origin airport is entered. The pilot can modify it.

--- a/docs/pilots-corner/a32nx-briefing/mcdu/perf.md
+++ b/docs/pilots-corner/a32nx-briefing/mcdu/perf.md
@@ -44,6 +44,9 @@ Prompts on each PERF page:
 
         [flyPad Performance Page](../../../fbw-a32nx/feature-guides/flypados3/performance.md){target=new .md-button}
 
+        !!! warning "Not Available in Stable Version, you can instead click on the LSK next to V1, VR and V2, to let the aircraft calculate the V-Speed for you."
+        
+
 - TRANS ALT (4L)
     - This field displays the navigation database default transition altitude (if defined) once the origin airport is entered. The pilot can modify it.
 


### PR DESCRIPTION
Fixes #990 

## Summary
Changes the tip on the MCDU PERF page to direct to the flyPad takeoff calculator page.

### Location
https://docs.flybywiresim.com/pilots-corner/beginner-guide/preparing-mcdu/#init-fuel-pred

Discord username (if different from GitHub): mrsprouse (Fender)
