### PR TITLE
fix: broken text formatting with mathjax/latex enabled

### DIFF
--- a/docs/pilots-corner/airliner-flying-guide/approaches.md
+++ b/docs/pilots-corner/airliner-flying-guide/approaches.md
@@ -8,15 +8,15 @@ To land any aircraft, the first step is to start an approach that will bring you
 
 Depending on what equipment the airfield has, what the aircraft is capable of, what the pilot is certified to do and the weather that is on the airfield will determine which of these approaches you will do. Here are some of the more common ones you may see in an airliner.
 
-### ^^Precision Approaches \(PA\)^^
+### ^^Precision Approaches *PA*^^
 
 A precision approach will give you full guidance, both vertically and laterally, to guide you down to a point where you can see the runway. This information can come from a set of radio beacons on the ground, satellite information or from a controller.
 
-|           Approach Type           |                Equipment Used                 |                             Used For                             |
-|:---------------------------------:|:---------------------------------------------:|:----------------------------------------------------------------:|
-| Instrument Landing System \(ILS\) |    A localizer and glideslope radio beacon    | Most precise available, the most common for airliner operations. |
-|    GBAS Landing System \(GLS\)    | GPS Satellite systems and ground transmitters |        A new alternative to ILS, for difficult approaches        |
-| Precision Approach Radar \(PAR\)  |         A radar dish and a controller         |          Commonly as a backup, or at military airfields          |
+|          Approach Type          |                Equipment Used                 |                             Used For                             |
+|:-------------------------------:|:---------------------------------------------:|:----------------------------------------------------------------:|
+| Instrument Landing System *ILS* |    A localizer and glideslope radio beacon    | Most precise available, the most common for airliner operations. |
+|    GBAS Landing System *GLS*    | GPS Satellite systems and ground transmitters |        A new alternative to ILS, for difficult approaches        |
+| Precision Approach Radar *PAR*  |         A radar dish and a controller         |          Commonly as a backup, or at military airfields          |
 
 ![runway](https://upload.wikimedia.org/wikipedia/commons/a/ad/Brussels_Airport_Runway_25_R.jpg)
 <sub> Lucash, <a href="https://creativecommons.org/licenses/by-sa/3.0">CC BY-SA 3.0</a>, via Wikimedia Commons
@@ -44,24 +44,24 @@ When all other systems fail, this system can be used as a backup to provide thes
 
 ***
 
-### ^^Non-Precision Approaches \(NPA\)^^
+### ^^Non-Precision Approaches *NPA*^^
 
 A non-precision approach officially can only give you lateral guidance to the point where you can see the runway. This is fed either to the pilots either using a single radio beacon or by satellite navigation, but these cannot tell you if you are too high or low. The only way is to use a table off an aviation chart that shows you at what altitude you need to be at certain distances.
 
-|            Approach Type            |                            Equipment Used                             |                                   Used For                                   |
-|:-----------------------------------:|:---------------------------------------------------------------------:|:----------------------------------------------------------------------------:|
-|       Localizer Only \(LOC\)        |       A localizer that would be part of an ILS system normally        | Some airports only have localizer but also when ILS glideslopes have failed. |
-|         VOR-DME or VOR Only         |            A VOR beacon with/without a distance from a DME            |               Old style approaches, where ILS cannot be used.                |
-|         NDB-DME or NDB Only         |            A NDB beacon with/without a distance from a DME            |              Old style approaches, where an ILS cannot be used               |
-|              LNAV Only              | GPS or the aircraft's position inside the flight management computers |           Approaches where there are no radio beacons in the area            |
-| Approach Surveillance Radar \(ASR\) |   A radar dish and a controller <br> (No altitude compared to PAR)    |               Commonly as a backup, or at military airfields.                |
-|               Visual                |                           Pilot's eyeball!                            | Where there is no issue with the weather and the runway is already in sight  |
+|           Approach Type           |                            Equipment Used                             |                                   Used For                                   |
+|:---------------------------------:|:---------------------------------------------------------------------:|:----------------------------------------------------------------------------:|
+|       Localizer Only *LOC*        |       A localizer that would be part of an ILS system normally        | Some airports only have localizer but also when ILS glideslopes have failed. |
+|        VOR-DME or VOR Only        |            A VOR beacon with/without a distance from a DME            |               Old style approaches, where ILS cannot be used.                |
+|        NDB-DME or NDB Only        |            A NDB beacon with/without a distance from a DME            |              Old style approaches, where an ILS cannot be used               |
+|             LNAV Only             | GPS or the aircraft's position inside the flight management computers |           Approaches where there are no radio beacons in the area            |
+| Approach Surveillance Radar *ASR* |   A radar dish and a controller <br> (No altitude compared to PAR)    |               Commonly as a backup, or at military airfields.                |
+|              Visual               |                           Pilot's eyeball!                            | Where there is no issue with the weather and the runway is already in sight  |
 
 These approaches are all flown traditionally with just a beacon pointer, a localizer giving left/right corrections, or a controller giving rough headings. With a helpful co-pilot, who will be using the altitude table to check if you are high or low, you keep correcting down towards the runway. As the term non-precision hints, these approaches are nowhere near as accurate as a precision approach and as such can require quite good weather to be able to attempt them. VOR and NDB beacons are slowly disappearing due to maintenance costs and the more useful APV approaches being made available.
 
 ***
 
-### ^^Approaches with Vertical Guidance \(APV\)^^
+### ^^Approaches with Vertical Guidance *APV*^^
 
 A newer kind of approach, that uses both lateral and vertical guidance from sources such as GPS satellites, and does not require the use of radio beacons at all. At the time of writing, these approaches were not yet classed as precision, as they do not quite have the accuracy required, but are constantly getting better with each new design. They are now flown very similarly to an ILS and do not require much input from the pilots.
 
@@ -83,14 +83,14 @@ A newer kind of approach, that uses both lateral and vertical guidance from sour
 
 With the ILS system, there are several categories that have different requirements from the pilots, the aircraft, the weather, and the airport equipment. They are known as CAT, short for category, and are listed as both Roman numerals and Latin numbers:
 
-|             ILS Category              |      Autoland Required <br>\(in the Airbus\)      |               Weather <br>\(Normally\)                |    MDA/DA or DH     |
-|:-------------------------------------:|:-------------------------------------------------:|:-----------------------------------------------------:|:-------------------:|
-|                 CAT I                 | No <br>\(May also be unsafe due to interference\) |     Cloud base above 200 ft <br>Visibility 550 m      |       MDA/DA        |
-| CAT I LTS <br>\(Lower Than Standard\) |                        Yes                        | Cloud base above 200 ft <br>Visibility 400 m or 450 m |       MDA/DA        |
-|                CAT II                 |                        Yes                        |     Cloud base above 100 ft <br>Visibility 300 m      |         DH          |
-|               CAT IIIA                |                        Yes                        |     Cloud base above 100 ft <br>Visibility 200 m      |         DH          |
-|               CAT IIIB                |               Yes \(2 Autopilots\)                |      Cloud base above 50 ft <br>Visibility 75 m       | DH <br>\(can be 0\) |
-|               CAT IIIC                |               Yes \(2 Autopilots\)                |       Cloud base above 0 ft <br>Visibility 0 m        | DH <br>\(can be 0\) |
+|            ILS Category             |      Autoland Required <br>*in the Airbus*      |                Weather <br>*Normally*                 |   MDA/DA or DH    |
+|:-----------------------------------:|:-----------------------------------------------:|:-----------------------------------------------------:|:-----------------:|
+|                CAT I                | No <br>*May also be unsafe due to interference* |     Cloud base above 200 ft <br>Visibility 550 m      |      MDA/DA       |
+| CAT I LTS <br>*Lower Than Standard* |                       Yes                       | Cloud base above 200 ft <br>Visibility 400 m or 450 m |      MDA/DA       |
+|               CAT II                |                       Yes                       |     Cloud base above 100 ft <br>Visibility 300 m      |        DH         |
+|              CAT IIIA               |                       Yes                       |     Cloud base above 100 ft <br>Visibility 200 m      |        DH         |
+|              CAT IIIB               |               Yes *2 Autopilots*                |      Cloud base above 50 ft <br>Visibility 75 m       | DH <br>*can be 0* |
+|              CAT IIIC               |               Yes *2 Autopilots*                |       Cloud base above 0 ft <br>Visibility 0 m        | DH <br>*can be 0* |
 
 
 As the weather gets progressively worse, the higher the category you need to use, which in turn requires more advanced equipment both on the airfield and in the cockpit. To be able to do this, pilots are required to retrain on low visibility operations every year.
@@ -107,13 +107,13 @@ The CAT IIIC can be performed without ever seeing anything at all, but this is 
 
 So, you have picked your approach and are flying towards the runway, but how close can you get before you decide it is a bad idea and to try again somewhere else? This is where the minimums come into effect. These are fixed values that decide how low you can go on the approach, and when you get to this altitude, you cannot go any lower until you can see the runway.
 
-|                Minimum Type                 |                Defined As                |               Approaches Used In               |
-|:-------------------------------------------:|:----------------------------------------:|:----------------------------------------------:|
-|    MDA <br>\(Minimum Descent Altitude\)     |      Altitude Above Mean Sea Level       | LOC, LDA, SDF, VOR <br> NDB, LNAV, ASR, Visual |
-|         DA <br>(Decision Altitude)          | Barometric Altitude Above Mean Sea Level | CAT I ILS <br> LNAV / VNAV, LPV, RNP, PAR, GLS |
-| DH/RA <br>\(Decision Height/Radio Altitude) |    Radio Altitude Above Ground Level     |       CAT II ILS <br> CAT III A/B/C ILS        |
+|                Minimum Type                |                Defined As                |               Approaches Used In               |
+|:------------------------------------------:|:----------------------------------------:|:----------------------------------------------:|
+|     MDA <br>*Minimum Descent Altitude*     |      Altitude Above Mean Sea Level       | LOC, LDA, SDF, VOR <br> NDB, LNAV, ASR, Visual |
+|         DA <br>(Decision Altitude)         | Barometric Altitude Above Mean Sea Level | CAT I ILS <br> LNAV / VNAV, LPV, RNP, PAR, GLS |
+| DH/RA <br>*Decision Height/Radio Altitude) |    Radio Altitude Above Ground Level     |       CAT II ILS <br> CAT III A/B/C ILS        |
 
-These are defined in feet, \(or meters if that airspace uses meter altitudes\) and can be found at the bottom of the aeronautical chart that is published for that approach. Each approach to each airport will have a separate value, changing due to obstacles, terrain, and other things that may get in the way while descending towards the runway.
+These are defined in feet, *or meters if that airspace uses meter altitudes* and can be found at the bottom of the aeronautical chart that is published for that approach. Each approach to each airport will have a separate value, changing due to obstacles, terrain, and other things that may get in the way while descending towards the runway.
 
 !!! info "Expanded Information from FAA Instrument Procedure Handbook"
     Chapter 4: Approaches in the FAA IPH provides more context on the definition of the different types of minimums.
@@ -157,10 +157,10 @@ Now, depending on the aircraft you are flying, depends on the minimums you are a
 In the above example, which is for the ILS or LOC/DME for Runway 23 at Buffalo Airport, NY in the USA, this chart uses a format designed by the Federal Aviation Administration (FAA) of the USA. Each chart designer unfortunately has slight differences compared to each other, but the basics are usually the same. So, for the above approach:
 
 |                             | MDA <br>(ft) | Visibility <br> (in 100s of ft (USA)) | Visibility <br>(m) | Height above the ground <br>(ft) |
-|----------------------------:|:------------:|:--------------------------------------:|:------------------:|:--------------------------------:|
-|              ILS CAT I RW23 |     928      |                  1800                  |        550         |               200                |
-| LOC RW23 <br>(Category ABC) |     1060     |                  2400                  |        730         |               332                |
-|   LOC RW23 <br>(Category D) |     1060     |                  4000                  |        1220        |               332                |
+|----------------------------:|:------------:|:-------------------------------------:|:------------------:|:--------------------------------:|
+|              ILS CAT I RW23 |     928      |                 1800                  |        550         |               200                |
+| LOC RW23 <br>(Category ABC) |     1060     |                 2400                  |        730         |               332                |
+|   LOC RW23 <br>(Category D) |     1060     |                 4000                  |        1220        |               332                |
 
 <sub> N.b. The brackets in the above image are used by the FAA for military operations, nothing to worry about in an airliner!
 
@@ -218,6 +218,6 @@ The Airbus will have several Flight Mode Annunciators (FMAs) display during an A
 
 |   FMA   |                                         Description                                         |
 |:-------:|:-------------------------------------------------------------------------------------------:|
-|  LAND   |                    Appears at 350 ft AGL and locks in the final guidance                     |
-|  FLARE  |                  At or below 40 ft AGL, and flares the aircraft for landing                  |
+|  LAND   |                    Appears at 350 ft AGL and locks in the final guidance                    |
+|  FLARE  |                 At or below 40 ft AGL, and flares the aircraft for landing                  |
 | ROLLOUT | On touchdown, keeps the aircraft straight on the runway until the autopilot is disconnected |

--- a/docs/pilots-corner/airliner-flying-guide/approaches.md
+++ b/docs/pilots-corner/airliner-flying-guide/approaches.md
@@ -111,7 +111,7 @@ So, you have picked your approach and are flying towards the runway, but how clo
 |:------------------------------------------:|:----------------------------------------:|:----------------------------------------------:|
 |     MDA <br>*Minimum Descent Altitude*     |      Altitude Above Mean Sea Level       | LOC, LDA, SDF, VOR <br> NDB, LNAV, ASR, Visual |
 |         DA <br>(Decision Altitude)         | Barometric Altitude Above Mean Sea Level | CAT I ILS <br> LNAV / VNAV, LPV, RNP, PAR, GLS |
-| DH/RA <br>*Decision Height/Radio Altitude) |    Radio Altitude Above Ground Level     |       CAT II ILS <br> CAT III A/B/C ILS        |
+| DH/RA <br>*Decision Height/Radio Altitude* |    Radio Altitude Above Ground Level     |       CAT II ILS <br> CAT III A/B/C ILS        |
 
 These are defined in feet, *or meters if that airspace uses meter altitudes* and can be found at the bottom of the aeronautical chart that is published for that approach. Each approach to each airport will have a separate value, changing due to obstacles, terrain, and other things that may get in the way while descending towards the runway.
 

--- a/docs/pilots-corner/airliner-flying-guide/navigation.md
+++ b/docs/pilots-corner/airliner-flying-guide/navigation.md
@@ -10,7 +10,7 @@
 
     === "1"
 
-        The category of aircraft allowed to do this approach \(A, B, C & D\).
+        The category of aircraft allowed to do this approach *A, B, C & D*.
 
         The altitude of the airfield (392 ft) and altitude of the runway touchdown (317ft)
 


### PR DESCRIPTION
## Summary
See discussion in Discord Docs channel starting [here](https://discord.com/channels/738864299392630914/791494566058000434/1280489427868586035). 

Seems to be an iissue with our original commit for italicized text on page conflicting with the mathjax/latex pymdownx implementation. 

### Location
- docs/pilots-corner/airliner-flying-guide/approaches.md
- docs/pilots-corner/airliner-flying-guide/navigation.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
