### PR TITLE
fix: Include warning for Simbridge charts resources folder

### DIFF
--- a/docs/fbw-a32nx/feature-guides/flypados3/charts.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/charts.md
@@ -167,6 +167,9 @@ The local files need to be stored in the following folders (located by default i
 
 The feature does not support any subfolders (yet).
 
+!!! warning ""
+    Please make sure to keep a copy of any files you store in these locations to another folder. Updates to the Simbridge module will result in these resource folders to be deleted.
+
 ## Pinned Charts
 
 Available charts can be pinned by clicking on the pin symbol. The pinned charts are then available in this tab and also in the charts-widget on the Dashboard. 

--- a/docs/fbw-a32nx/feature-guides/flypados3/charts.md
+++ b/docs/fbw-a32nx/feature-guides/flypados3/charts.md
@@ -168,7 +168,7 @@ The local files need to be stored in the following folders (located by default i
 The feature does not support any subfolders (yet).
 
 !!! warning ""
-    Please make sure to keep a copy of any files you store in these locations to another folder. Updates to the Simbridge module will result in these resource folders to be deleted.
+    Please make sure to keep a copy of any files you store in these locations in another folder. Updates to the Simbridge module will result in these resource folders being deleted.
 
 ## Pinned Charts
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
Currently the installer will wipe the folder where Simbridge is located at, thus also removing any PDF/images that a user has stored for charts & coroutes. A warning, until a patch is merged that prevents this, should be added hence this PR. 

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
/fbw-a32nx/feature-guides/flypados3/charts

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
