### PR TITLE
fix: mathjax formula rendering

### DIFF
--- a/docs/pilots-corner/advanced-guides/flight-planning/takeoff-perf-calc.md
+++ b/docs/pilots-corner/advanced-guides/flight-planning/takeoff-perf-calc.md
@@ -80,5 +80,3 @@ magnetic North. If the winds are 240/10 true from the METAR, adjust it to 236/10
 
 Since the magnetic variation is only 4 degrees and winds are normally rounded to the nearest ten degrees, you can also just skip converting the wind reference from true North 
 to magnetic North for LOWI.
-
-*[TORA]: Take-Off Run Available

--- a/docs/pilots-corner/advanced-guides/flight-planning/takeoff-perf-calc.md
+++ b/docs/pilots-corner/advanced-guides/flight-planning/takeoff-perf-calc.md
@@ -62,9 +62,13 @@ intersections (where a 90-degree entry angle would apply) are listed in the Addi
 The runway elevation for each runway is different, so each runway will have a slope value. Use the following equation to calculate the slope value:
 
 !!! info "Slope Equation"
-    $$\frac{Elevation\,at\,end\,of\,TORA - Elevation\,at\,beginning\,of\,TORA}{TORA} * 100$$ 
+    $$
+    \frac{\text{Elevation at end of TORA} - \text{Elevation at beginning of TORA}}{\text{TORA}} \times 100
+    $$
 
-    \[ with\,all\,units\,being\,the\,same.\]
+    $$
+    {\text{with all units being the same.}}
+    $$
 
 !!! info "Runway 08 Example"
     To calculate the runway slope for Runway 08 the equation with units included would look like the following:


### PR DESCRIPTION
## Summary
Fix rendered formula on takeoff page. Seems to be the way I had written it earlier was a little bit off. Renders fine locally but let's see if this new way works.

We should probably also figure out if there are any more "formulas" on site before merging so it's all in one go. 

### Location
- docs/pilots-corner/advanced-guides/flight-planning/takeoff-perf-calc.md
- 
<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
