### PR TITLE
build: bump mkdocs-material 9.5.40

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.5.30
+mkdocs-material==9.5.40
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary
Relevant upstream mkdocs material fixes

- Social cards not using site name on home page
- not staying on page when using mike's canonical versioning
- Added 4th and 5th level ordered list styles
- Tags have no spacing in search
- Social cards incorrectly rendering HTML entities
- Updated Mermaid.js to version 11 (latest)
- Fixed RXSS vulnerability via deep link in search results


### Location
- requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
