### PR TITLE
docs: Typo fix "KCCU to KBD"

### DIFF
--- a/docs/pilots-corner/a380x/a380x-briefing/flight-deck/pedestal/kccu.md
+++ b/docs/pilots-corner/a380x/a380x-briefing/flight-deck/pedestal/kccu.md
@@ -99,7 +99,7 @@ Moves the cursor to the display unit that is to the right, or to the left, of th
 - OFF:
     - The KCCU cursor control device is inactive.
 
-### KCCU sw
+### KBD sw
 
 - ON:
     - The KCCU keyboard is active.


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
Fixed a typo in the KCCU page: "KCCU sw" is meant to be "KBD sw" .

KCCU Panel:

![image](https://github.com/user-attachments/assets/a9f46580-1629-43d2-8ab4-bec3ad668ee7)

Current KCCU Page:

![image](https://github.com/user-attachments/assets/f708779f-9fa6-4394-a70a-f91852d3a874)

### Location
https://docs.flybywiresim.com/pilots-corner/a380x/a380x-briefing/flight-deck/pedestal/kccu/#kccu-sw

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): LunakisLeaks
