### PR TITLE
style: Cockpit lighting hover sections fix

### DIFF
--- a/docs/pilots-corner/a380x/a380x-briefing/flight-deck/overviews/pedestal.md
+++ b/docs/pilots-corner/a380x/a380x-briefing/flight-deck/overviews/pedestal.md
@@ -45,16 +45,7 @@ description: The A380 Flight Deck Pedestal page is providing an interactive grap
 
     <!-- COCKPIT LIGHTING -->
     <a href="/pilots-corner/a380x/a380x-briefing/flight-deck/pedestalcockpit-lighting">
-    <div class="imagemap" style="
-        position: absolute; 
-        top: 64%; 
-        left: 9.5%; 
-        width: 27%; 
-        height: 15%; 
-        clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 70% 100%, 70% 40%, 0% 40%);">
-        <span class="imagemapname">Cockpit Lighting</span>
-    </div>
-    </a>
+    <div class="imagemap" style="position: absolute; top: 64%; left: 9.5%; width: 27%; height: 15%; clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 70% 100%, 70% 40%, 0% 40%);"><span class="imagemapname">Cockpit Lighting</span></div></a>
 
     <!-- PARKING BRAKE -->
     <a href="/pilots-corner/a380x/a380x-briefing/flight-deck/pedestal/parking-brake"><div class="imagemap" style="position: absolute; top: 70%; height: 9%; left: 9.5%; width: 18.5%;"><span class="imagemapname">Parking Brake</span></div></a>

--- a/docs/pilots-corner/a380x/a380x-briefing/flight-deck/overviews/pedestal.md
+++ b/docs/pilots-corner/a380x/a380x-briefing/flight-deck/overviews/pedestal.md
@@ -44,7 +44,7 @@ description: The A380 Flight Deck Pedestal page is providing an interactive grap
     <a href="/pilots-corner/a380x/a380x-briefing/flight-deck/pedestal/surveillance"><div class="imagemap" style="position: absolute; top: 51%; height: 13%; left: 36.5%; width: 26.5%;"><span class="imagemapname">Surveillance Control</span></div></a>
 
     <!-- COCKPIT LIGHTING -->
-    <a href="/pilots-corner/a380x/a380x-briefing/flight-deck/pedestalcockpit-lighting">
+    <a href="/pilots-corner/a380x/a380x-briefing/flight-deck/pedestal/cockpit-lighting">
     <div class="imagemap" style="position: absolute; top: 64%; left: 9.5%; width: 27%; height: 15%; clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 70% 100%, 70% 40%, 0% 40%);"><span class="imagemapname">Cockpit Lighting</span></div></a>
 
     <!-- PARKING BRAKE -->

--- a/docs/pilots-corner/a380x/a380x-briefing/flight-deck/overviews/pedestal.md
+++ b/docs/pilots-corner/a380x/a380x-briefing/flight-deck/overviews/pedestal.md
@@ -44,8 +44,17 @@ description: The A380 Flight Deck Pedestal page is providing an interactive grap
     <a href="/pilots-corner/a380x/a380x-briefing/flight-deck/pedestal/surveillance"><div class="imagemap" style="position: absolute; top: 51%; height: 13%; left: 36.5%; width: 26.5%;"><span class="imagemapname">Surveillance Control</span></div></a>
 
     <!-- COCKPIT LIGHTING -->
-    <a href="/pilots-corner/a380x/a380x-briefing/flight-deck/pedestal/cockpit-lighting"><div class="imagemap" style="position: absolute; top: 64%; height: 6%; left: 9.5%; width: 27%;"><span class="imagemapname">Cockpit Lighting</span></div></a>
-    <a href="/pilots-corner/a380x/a380x-briefing/flight-deck/pedestal/cockpit-lighting"><div class="imagemap" style="position: absolute; top: 70%; height: 9%; left: 28%; width: 8.5%;"><span class="imagemapname">Cockpit Lighting</span></div></a>
+    <a href="/pilots-corner/a380x/a380x-briefing/flight-deck/pedestal/cockpit-lighting">
+    <div class="imagemap" style="
+        position: absolute; 
+        top: 64%; 
+        left: 9.5%; 
+        width: 27%; 
+        height: 15%; 
+        clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 70% 100%, 70% 40%, 0% 40%);">
+        <span class="imagemapname">Cockpit Lighting</span>
+    </div>
+    </a>
 
     <!-- PARKING BRAKE -->
     <a href="/pilots-corner/a380x/a380x-briefing/flight-deck/pedestal/parking-brake"><div class="imagemap" style="position: absolute; top: 70%; height: 9%; left: 9.5%; width: 18.5%;"><span class="imagemapname">Parking Brake</span></div></a>

--- a/docs/pilots-corner/a380x/a380x-briefing/flight-deck/overviews/pedestal.md
+++ b/docs/pilots-corner/a380x/a380x-briefing/flight-deck/overviews/pedestal.md
@@ -44,7 +44,7 @@ description: The A380 Flight Deck Pedestal page is providing an interactive grap
     <a href="/pilots-corner/a380x/a380x-briefing/flight-deck/pedestal/surveillance"><div class="imagemap" style="position: absolute; top: 51%; height: 13%; left: 36.5%; width: 26.5%;"><span class="imagemapname">Surveillance Control</span></div></a>
 
     <!-- COCKPIT LIGHTING -->
-    <a href="/pilots-corner/a380x/a380x-briefing/flight-deck/pedestal/cockpit-lighting">
+    <a href="/pilots-corner/a380x/a380x-briefing/flight-deck/pedestalcockpit-lighting">
     <div class="imagemap" style="
         position: absolute; 
         top: 64%; 


### PR DESCRIPTION
Fixes #1041

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
Removes the separator and merges both cockpit lighting sections together.

Current version:

![image](https://github.com/user-attachments/assets/e172df14-903f-4959-bead-f38c4bf1a07e)
![image](https://github.com/user-attachments/assets/4d3c6b3a-03a1-4ce9-b677-ccb2f81de473)

Fixed version:

![image](https://github.com/user-attachments/assets/2f4236e0-8d48-4b89-8282-a5b3411f339d)

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
https://docs.flybywiresim.com/pilots-corner/a380x/a380x-briefing/flight-deck/overviews/pedestal/

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): LunakisLeaks
