### PR TITLE
fix: A32NX release notes and build warning

### DIFF
--- a/docs/release-notes/a32nx/v0121.md
+++ b/docs/release-notes/a32nx/v0121.md
@@ -9,7 +9,7 @@ search:
 
 # A32NX Stable Release v0.12.1
 
-This update primarily addresses some issues that were present in our v0.12 release for the A380X with some minor updates
+This update primarily addresses some issues that were present in our v0.12.1 release for the A380X with some minor updates
 for the A32NX.
 
 Happy Flying!
@@ -24,4 +24,5 @@ For a full release changelog - [see below](#changelog)
 
 1. [GENERAL] Fixed issue in C++ WASM Framework that caused performance degradation in some WASM modules - @frankkopp (Frank Kopp)
 1. [A32NX/FCU] Fixed auto-initialisation of baro unit - @tracernz (Mike)
-1. [A32NX/CAMERA] Improved default camera position for Virtual Reality (VR) - @aguther (Andreas Guther)dded popup for telex consent @saschl (saschl) @Maximilian-Reuter (\_chaoz)
+1. [A32NX/CAMERA] Improved default camera position for Virtual Reality (VR) - @aguther (Andreas Guther)
+1. [A380X/TELEX] Added popup for telex consent @saschl (saschl) @Maximilian-Reuter (\_chaoz)


### PR DESCRIPTION
## Summary
As requested in Discord docs channel

### Location
- release-notes\a32nx

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
