### PR TITLE
docs: added note to use SURV page instead of SURV panel

### DIFF
--- a/docs/pilots-corner/a380x/a380x-beginner-guide/02_cockpit-preparation.md
+++ b/docs/pilots-corner/a380x/a380x-beginner-guide/02_cockpit-preparation.md
@@ -322,6 +322,8 @@ In the simulator, we are usually alone, so we will do the flow on our own.
 `NAVIGATION CHARTS ............................................... PREPARE`<br/>
 `MFD SURVEILLANCE DEFAULT SETTINGS................................. SELECT`<br/>
 ??? note "MFD Surveillance Default Settings"
+    ### MFD Surveillance Default Settings
+    
     Verify on the Multi-Function Display (MFD) Surveillance page that the transponder is set to AUTO, the squawk code
     is as per ATC, the TCAS is set to TA/RA and Norm, all TAWS modes are ON, and the weather radar is set to AUTO, the
     elevation/tilt to AUTO, Mode set to WX, TURB set to AUTO, GAIN set to AUTO, WX ON VD set to ON and PRED W/S to AUTO)

--- a/docs/pilots-corner/a380x/a380x-briefing/flight-deck/pedestal/surveillance.md
+++ b/docs/pilots-corner/a380x/a380x-briefing/flight-deck/pedestal/surveillance.md
@@ -27,7 +27,9 @@ functions:
 !!! warning ""
     The Surveillance Panel is not yet fully implemented in the A380X.
 
-    You can use the [MFD's SURV](../../../a380x-beginner-guide/02_cockpit-preparation.md#mfd-surveillance-default-settings) page to setup surveillance systems.
+    You can use the 
+    [MFD's SURV](../../../a380x-beginner-guide/02_cockpit-preparation.md#mfd-surveillance-default-settings) page to 
+    setup surveillance systems.
 
 ## Usage
 

--- a/docs/pilots-corner/a380x/a380x-briefing/flight-deck/pedestal/surveillance.md
+++ b/docs/pilots-corner/a380x/a380x-briefing/flight-deck/pedestal/surveillance.md
@@ -27,6 +27,8 @@ functions:
 !!! warning ""
     The Surveillance Panel is not yet fully implemented in the A380X.
 
+    You can use the [MFD's SURV](../../../a380x-beginner-guide/02_cockpit-preparation.md#mfd-surveillance-default-settings) page to setup surveillance systems.
+
 ## Usage
 
 ### WXR Controls (INOP)


### PR DESCRIPTION
Closes #1052 

## Summary
Added a note and link to use SURV page instead of SURV panel

### Location
/pilots-corner/a380x/a380x-briefing/flight-deck/pedestal/surveillance/

Discord username (if different from GitHub): cdr-maverick
