### PR TITLE
feat: Adding PR Build and Deploy actions for all PRs

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,29 @@
+# build-preview.yml
+name: PR Build Preview for Cloudflare
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+    name: Build Preview Site and Upload Build Artifact
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install requirements
+        run: pip install -r requirements.txt
+      - name: Build PR
+        run: mkdocs build
+
+      # Uploads the build directory as a workflow artifact
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-build
+          path: site

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -1,0 +1,39 @@
+# deploy-preview.yml
+name: PR Upload Preview to Cloudflare
+on:
+  workflow_run:
+    workflows: ['PR Build Preview for Cloudflare']
+    types:
+      - completed
+
+permissions:
+  actions: read
+  deployments: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    name: Deploy Preview to Cloudflare Pages
+    steps:
+      # Downloads the build directory from the previous workflow
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        id: preview-build-artifact
+        with:
+          name: preview-build
+          path: build
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Deploy to Cloudflare Pages
+        uses: AdrianGonz97/refined-cf-pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_PAGES_ACCOUNT_ID }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          projectName: ${{ secrets.CLOUDFLARE_DOCS_PROJECT }}
+          deploymentName: Preview
+          directory: ${{ steps.preview-build-artifact.outputs.download-path }}


### PR DESCRIPTION
## Summary
Uses https://github.com/marketplace/actions/refined-cloudflare-pages-action#enabling-pr-previews-from-forks for building and deploying PR Previews to Cloudflare pages.

### Setup
Requires a few new secrets:
* `CLOUDFLARE_PAGES_API_TOKEN` - Specific API Token with access to editing Cloudflare Pages for the account
* `CLOUDFLARE_PAGES_ACCOUNT_ID` - API Account ID for Cloudflare Pages, this could be the same as the main account, but might be good to split up in case we ever need to have flexibility.
* `CLOUDFLARE_DOCS_PROJECT` - The Pages project in Cloudflare for the docs site specifically.

On Cloudflare Pages, it is best to **only** allow automatic building of the main branch (primary) of the main repo, and not other branches, although this is not a must. If building all branches remains enabled, if a PR is created for a branch on the main repo, two deployments will exist for the PR. One for the branch, and one for the PR itself (using this change). 

### Functionality
This is a two-stepped approach so that PRs do not need access to secrets (fork PRs have no access to secrets of the main repo):
1. PR Build & Upload - This builds and uploads an archive of the build locally for the PR itself. This is triggered by opening or syncing a PR (pushing to it)
2. PR Deploy - This runs after the PR Build, and runs inside the secure context of the main repo, with no visibility into the secrets by the PR or PR Repo. It takes the archive and creates a Preview deployment for the PR (name is `<repo-owner>-<branch>.<project>.pages.dev`. 
3. The action creates or updates (if new commits) a comment on the PR with the Preview deployment link after build

### Proof of concept
* Mirrored docs repo: https://github.com/pdellaert/test-fbw-docs
  * Deployed on https://test-fbw-docs.pages.dev/
  * 'main' repo branch PR - pdellaert/test-fbw-docs#2
* Forked Rep of mirror: https://github.com/fbw-devops/test-fbw-docs/
  * Fork repo branch PR -  pdellaert/test-fbw-docs#3
 
Both have been deployed on CF Pages as previews, with multiple commits (create PR, and adding more commits after):
![image](https://github.com/user-attachments/assets/87a457ad-698b-4ef0-877d-7c27e1f43279)
Note that in this test deployment, only Primary (production) branch is enabled for automatic build. For other branches on the main repo, the automatic builds are disabled.
