### PR TITLE
fix: a32nx sop online preview links

### DIFF
--- a/docs/pilots-corner/a32nx/a32nx-sop.md
+++ b/docs/pilots-corner/a32nx/a32nx-sop.md
@@ -12,12 +12,12 @@ They are available for download or preview online via the links below.
 
 An in-flight checklist for flight crew operations. Items critical regarding flight safety are on this list.
 
-[Download](assets/sop/A32NX Documentation/FBW A32NX Checklist.pdf){ .md-button } [:fontawesome-brands-github:{: .github } Online Preview](https://github.com/flybywiresim/docs/blob/primary/docs/pilots-corner/assets/sop/A32NX%20Documentation/FBW%20A32NX%20Checklist.pdf){ target=new .md-button }
+[Download](assets/sop/A32NX Documentation/FBW A32NX Checklist.pdf){ .md-button } [:fontawesome-brands-github:{: .github } Online Preview](https://github.com/flybywiresim/docs/blob/primary/docs/pilots-corner/a32nx/assets/sop/A32NX%20Documentation/FBW%20A32NX%20Checklist.pdf){ target=new .md-button }
 
 ## Normal Procedures
 
 This document can be considered as an overview of what to do during each phase of flight, with remarks about each location and item.
 
-[Download](assets/sop/A32NX Documentation/FBW A32NX SOP.pdf){ .md-button } [:fontawesome-brands-github:{: .github } Online Preview](https://github.com/flybywiresim/docs/blob/primary/docs/pilots-corner/assets/sop/A32NX%20Documentation/FBW%20A32NX%20SOP.pdf){ target=new .md-button }
+[Download](assets/sop/A32NX Documentation/FBW A32NX SOP.pdf){ .md-button } [:fontawesome-brands-github:{: .github } Online Preview](https://github.com/flybywiresim/docs/blob/primary/docs/pilots-corner/a32nx/assets/sop/A32NX%20Documentation/FBW%20A32NX%20SOP.pdf){ target=new .md-button }
 
 


### PR DESCRIPTION
## Summary

Updates the a32nx SOP Online Preview links to include the /a32nx/ path prefix.

### Location

https://docs.flybywiresim.com/pilots-corner/a32nx/a32nx-sop/

