### PR TITLE
docs: add clarification for A32NX.FCU_EFIS_L/R_BARO_SET event unit

### DIFF
--- a/docs/aircraft/a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/aircraft/a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -442,8 +442,8 @@ Flight Deck: [EFIS Control Panel](../../../pilots-corner/a32nx/a32nx-briefing/fl
 |              | A32NX.FCU_EFIS_R_BARO_INC                | -                 | -          | Custom EVENT     |                                                               |
 |              | A32NX.FCU_EFIS_L_BARO_DEC                | -                 | -          | Custom EVENT     |                                                               |
 |              | A32NX.FCU_EFIS_R_BARO_DEC                | -                 | -          | Custom EVENT     |                                                               |
-|              | A32NX.FCU_EFIS_L_BARO_SET                | -                 | -          | Custom EVENT     |                                                               |
-|              | A32NX.FCU_EFIS_R_BARO_SET                | -                 | -          | Custom EVENT     |                                                               |
+|              | A32NX.FCU_EFIS_L_BARO_SET                | -                 | -          | Custom EVENT     | Parameter is hPa * 16 (same as KOHLSMAN_SET)                  |
+|              | A32NX.FCU_EFIS_R_BARO_SET                | -                 | -          | Custom EVENT     | Parameter is hPa * 16 (same as KOHLSMAN_SET)                  |
 |              | A32NX.FCU_EFIS_L_BARO_PUSH               | -                 | -          | Custom EVENT     |                                                               |
 |              | A32NX.FCU_EFIS_R_BARO_PUSH               | -                 | -          | Custom EVENT     |                                                               |
 |              | A32NX.FCU_EFIS_L_BARO_PULL               | -                 | -          | Custom EVENT     |                                                               |

--- a/docs/aircraft/a32nx/a32nx-api/a32nx-flightdeck-api.md
+++ b/docs/aircraft/a32nx/a32nx-api/a32nx-flightdeck-api.md
@@ -442,8 +442,8 @@ Flight Deck: [EFIS Control Panel](../../../pilots-corner/a32nx/a32nx-briefing/fl
 |              | A32NX.FCU_EFIS_R_BARO_INC                | -                 | -          | Custom EVENT     |                                                               |
 |              | A32NX.FCU_EFIS_L_BARO_DEC                | -                 | -          | Custom EVENT     |                                                               |
 |              | A32NX.FCU_EFIS_R_BARO_DEC                | -                 | -          | Custom EVENT     |                                                               |
-|              | A32NX.FCU_EFIS_L_BARO_SET                | -                 | -          | Custom EVENT     | Parameter is hPa * 16 (same as KOHLSMAN_SET)                  |
-|              | A32NX.FCU_EFIS_R_BARO_SET                | -                 | -          | Custom EVENT     | Parameter is hPa * 16 (same as KOHLSMAN_SET)                  |
+|              | A32NX.FCU_EFIS_L_BARO_SET                | -                 | -          | Custom EVENT     | in hPa * 16                                                   |
+|              | A32NX.FCU_EFIS_R_BARO_SET                | -                 | -          | Custom EVENT     | in hPa * 16                                                   |
 |              | A32NX.FCU_EFIS_L_BARO_PUSH               | -                 | -          | Custom EVENT     |                                                               |
 |              | A32NX.FCU_EFIS_R_BARO_PUSH               | -                 | -          | Custom EVENT     |                                                               |
 |              | A32NX.FCU_EFIS_L_BARO_PULL               | -                 | -          | Custom EVENT     |                                                               |


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->
Add a description for the FCU EFIS CP event `A32NX.FCU_EFIS_L/R_BARO_SET`, as this will be changed in https://github.com/flybywiresim/aircraft/pull/9617 to facilitate setting inHg with four significant digits.

### Location
<!-- Please provide the original URL of the page modified or directory location here -->

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
