### PR TITLE
build: bump mkdocs-material -> 9.6.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.5.49
+mkdocs-material==9.6.5
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
## Summary
Updates Material for MkDocs to from 9.5 -> 9.6 with minor bug fixes to x.x.4

### Relevant New Features
- Meta Plugin
- Rewrite of tags plugin
- Various added support for tags + blogs plugin.

### Location
- requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
