### PR TITLE
feat: print.css for printing support

### DIFF
--- a/docs/stylesheets/print.css
+++ b/docs/stylesheets/print.css
@@ -1,0 +1,39 @@
+@media print {
+  /* Force all text to black, backgrounds to white or transparent */
+  * {
+    color: #000 !important;
+    background: none !important;
+    background-color: #fff !important;
+  }
+
+  /* Make sure all headings print black */
+  h1, h2, h3, h4, h5, h6 {
+    color: #000 !important;
+    background: none !important;
+  }
+
+  /* Tables */
+  .md-typeset table:not([class]) th {
+    background-color: #eee !important;
+    color: #000 !important;
+  }
+  .md-typeset table:not([class]) td {
+    border-color: #000 !important;
+  }
+
+  /* Remove UI chrome */
+  .md-header,
+  .md-footer,
+  .md-nav,
+  .md-button,
+  .gif-placeholder {
+    display: none !important;
+  }
+
+  /* Expose real URLs for links */
+  a[href]:after {
+    content: " (" attr(href) ")";
+    font-size: 0.9em;
+  }
+}
+

--- a/docs/stylesheets/print.css
+++ b/docs/stylesheets/print.css
@@ -31,9 +31,9 @@
   }
 
   /* Expose real URLs for links */
-  a[href]:after {
+/*  a[href]:after {
     content: " (" attr(href) ")";
     font-size: 0.9em;
-  }
+  }*/
 }
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -116,6 +116,7 @@ extra_css:
   - stylesheets/extra.css
   - stylesheets/admonitions.css
   - stylesheets/navigation.css
+  - stylesheets/print.css
 
 # Javascript
 extra_javascript:


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->
fixes #1081

## Summary
As noted by user in support and forwarded to docs channel. Adds a separate css to provide printing support across multiple styles.

### Location
- stylesheets
- root

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
