### PR TITLE
fix: broken internal links

### DIFF
--- a/docs/aircraft/common/flypados3/charts.md
+++ b/docs/aircraft/common/flypados3/charts.md
@@ -165,10 +165,9 @@ The local files need to be stored in the following folders (located by default i
 | Images | `C:\Users\<Username>\Documents\FlyByWireSim\Simbridge\resources\images` |
 | PDFs   | `C:\Users\<Username>\Documents\FlyByWireSim\Simbridge\resources\pdfs`   |
 
-Note: the documents directory might be accessible on a different path on your machine. Please check [Resources](https://docs.flybywiresim.com/simbridge/install-configure/installation/#resources-folder) if you cannot find it.
+Note: the documents directory might be accessible on a different path on your machine. Please check [Resources](../../../tools/simbridge/install-configure/installation.md#resources-folder) if you cannot find it.
 
 The feature does not support any subfolders (yet).
-
 
 ## Pinned Charts
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
As noted in Discord there was a hard coded URL in the flypados3 documentation pointing to simbridge documentation.

This is now changed to a proper relative URL

### Location
- docs/aircraft/common/flypados3/charts.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
