### PR TITLE
build: bump mkdocs-material -> 9.6.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.6.5
+mkdocs-material==9.6.14
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ mkdocs-embed-external-markdown
 mkdocs-video
 mkdocs-glightbox
 pillow
-cairosvg<2.8
+cairosvg
 urllib3<2.0


### PR DESCRIPTION
## Summary
Upstream fixes and updates to mkdocs-material.

### Main Important Fixes
- unpins CairoSVG since upstream fix is included
- fortnight fixes
- Bump to support jinja version 3.1
- upstream refactor with python function invocations 
- firefox visual issues 

### Location
- requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
