### PR TITLE
docs: update A380X release notes to remove incorrect mention of ATC COM

### DIFF
--- a/docs/release-notes/a380x/v0130.md
+++ b/docs/release-notes/a380x/v0130.md
@@ -58,7 +58,7 @@ Cabin lighting controls have migrated into the EFB Quick Settings for intuitive 
 
 - [x] **Flight Management System (FMS) & AFCS**
 
-Layout fixes on PERF and T.O. pages improve readability, and differentiation of compatible approach vias streamlines planning. The autopilot has been tuned to better support 4x simulation rate, and improvements have been made to the TCAS simulation..
+Layout fixes on PERF and T.O. pages improve readability, and differentiation of compatible approach vias streamlines planning. The newly added ATCCOM connect page and improved simulation-rate support ensure more robust autopilot and TCAS interactions.
 
 - [x] **Visual & Structural Enhancements**
 

--- a/docs/release-notes/a380x/v0130.md
+++ b/docs/release-notes/a380x/v0130.md
@@ -58,7 +58,7 @@ Cabin lighting controls have migrated into the EFB Quick Settings for intuitive 
 
 - [x] **Flight Management System (FMS) & AFCS**
 
-Layout fixes on PERF and T.O. pages improve readability, and differentiation of compatible approach vias streamlines planning. The newly added ATCCOM connect page and improved simulation-rate support ensure more robust autopilot and TCAS interactions.
+Layout fixes on PERF and T.O. pages improve readability, and differentiation of compatible approach vias streamlines planning. The autopilot has been tuned to better support 4x simulation rate, and improvements have been made to the TCAS simulation.
 
 - [x] **Visual & Structural Enhancements**
 

--- a/docs/release-notes/a380x/v0130.md
+++ b/docs/release-notes/a380x/v0130.md
@@ -58,7 +58,7 @@ Cabin lighting controls have migrated into the EFB Quick Settings for intuitive 
 
 - [x] **Flight Management System (FMS) & AFCS**
 
-Layout fixes on PERF and T.O. pages improve readability, and differentiation of compatible approach vias streamlines planning. The newly added ATCCOM connect page and improved simulation-rate support ensure more robust autopilot and TCAS interactions.
+Layout fixes on PERF and T.O. pages improve readability, and differentiation of compatible approach vias streamlines planning. The autopilot has been tuned to better support 4x simulation rate, and improvements have been made to the TCAS simulation..
 
 - [x] **Visual & Structural Enhancements**
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->

Removed mention of the ATC COM as the single page is currently kept INOP as the entire ATC COM section needs to be functional together. Tweaked phrasing of the remainder of the sentence.

### Location
<!-- Please provide the original URL of the page modified or directory location here -->

https://docs.flybywiresim.com/release-notes/a380x/v0130/#release-feature-highlights

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
