### PR TITLE
docs: Update FAA Quick Reference Guide link

### DIFF
--- a/docs/pilots-corner/airliner/airliner-flying-guide/airport-signage.md
+++ b/docs/pilots-corner/airliner/airliner-flying-guide/airport-signage.md
@@ -9,7 +9,7 @@ on the ground. However, this guide will explain how to read and understand them.
 The FAA has a handy guide available for download that contains images of all the pertinent signs you may encounter,
 their purpose, and location at the airport.
 
-[Download FAA Guide](https://www.faa.gov/sites/faa.gov/files/airports/runway_safety/publications/QuickReferenceGuideProof8.pdf){ .md-button }
+[Download FAA Guide](https://www.faa.gov/sites/faa.gov/files/SignsAndMarkings_one-doc.pdf){ .md-button }
 
 ---
 


### PR DESCRIPTION
## Summary
The FAA Quick Reference Guide link directs to a 404. 
The old Quick Reference Guide can be found on the Wayback Machine at http://web.archive.org/web/20230129105056/https://www.faa.gov/sites/faa.gov/files/airports/runway_safety/publications/QuickReferenceGuideProof8.pdf.

Update the link to the new Quick Reference Guide at https://www.faa.gov/sites/faa.gov/files/SignsAndMarkings_one-doc.pdf.

The new guide has been updated to also include light gun signals. This may not be wanted
