### PR TITLE
fix: outdated docs for realism settings flyPadOS 3

### DIFF
--- a/docs/aircraft/common/flypados3/settings.md
+++ b/docs/aircraft/common/flypados3/settings.md
@@ -161,6 +161,11 @@ Settings for simulation aspects of the A32NX aircraft.
 ## Realism
 Settings for realism aspects of the A32NX aircraft.
 
+!!! warning "Outdated Image"
+    Please note that the setting "Sync EFIS controls between Captin and FO (Unrealistic)" now reads:
+
+    Sync EFIS and **Audio Controls** Between Captain and FO
+
 <div style="position: relative;">
     <img src="/aircraft/common/assets/flypados3/flypad-settings-realism.png" style="width: 100%; height: auto;" loading="lazy">
     <a href="../dashboard/">   <div class="imagemap" style="position: absolute; left: 1.7%; top:  6.9%; width: 5.8%; height: 7.0%;"><span class="imagemapname">Dashboard</span></div></a>
@@ -201,10 +206,9 @@ Settings for realism aspects of the A32NX aircraft.
     - The timeout feature will automatically deactivate the focus of the MCDU screen after the given amount of seconds.
     - Valid range is 5 - 120 seconds.
     - Setting is only available if MCDU Keyboard Input is enabled.
-- Sync EFIS controls between Captain and FO (unrealistic)
+- Sync EFIS and Audio Controls between Captain and FO (unrealistic)
     - When enabled, the EFIS controls will be synchronized between the Captain and FO.
     - This includes the Flight Director (FD), Landing System (LS) and Baro (STD, QNH and inHg/hPa) controls.
-    - Note: Baro is currently not separated between the Captain and FO and is always synchronized independent of this setting. 
 - Show Pilot Avatar
     - When enabled, the pilot avatar will be visible in the cockpit. 
     - The avatar style can be chosen in the MSFS settings `General Options -> Misc`.

--- a/docs/aircraft/common/flypados3/settings.md
+++ b/docs/aircraft/common/flypados3/settings.md
@@ -162,7 +162,7 @@ Settings for simulation aspects of the A32NX aircraft.
 Settings for realism aspects of the A32NX aircraft.
 
 !!! warning "Outdated Image"
-    Please note that the setting "Sync EFIS controls between Captin and FO (Unrealistic)" now reads:
+    Please note that the setting "Sync EFIS controls between Captain and FO (Unrealistic)" now reads:
 
     Sync EFIS and **Audio Controls** Between Captain and FO
 


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
Noticed discussion linked from #docs channel about outdated docs being inconsistent with A32NX behaviour in virtual cockpit. 

Updated to match functionality and removed outdated notice. 

Included notice that the image is outdated and I don't have one unless we add one before merging. 

### Location
- docs/aircraft/common/flypados3/settings.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri
