### PR TITLE
feat: add redirect to outdated fbw-a32nx link

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,8 @@ plugins:
     mark: "video-embed"
   redirects:
       redirect_maps:
+        # Folder: /fbw-a32nx/
+        'fbw-a32nx/index.md': 'aircraft/a32nx/index.md'
         # Folder: /beginner-guide/
         'beginner-guide/overview.md': 'pilots-corner/a32nx/a32nx-beginner-guide/overview.md'
         # Folder: /airliner-flying-guide/
@@ -60,6 +62,7 @@ plugins:
         # Folder: /a32nx-devs/
         'a32nx-dev/overview.md': 'dev-corner/dev-guide/index.md'
         'a32nx-dev/texture-changes.md': 'dev-corner/livery-creators/a32nx-texture-changes.md'
+
 
         # TEMP redirects
         # A.FLOOR


### PR DESCRIPTION
fixes #1094

## Summary
Installer has an outdated link in the about section. This redirect at least provides support to anyone who clicks that link to arrive at the appropriate page.

This is a config modification.

### Location
- mkdocs.yml

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Valastiri
