### PR TITLE
build: bump mkdocs-material -> 9.6.23

### DIFF
--- a/docs/pilots-corner/index.md
+++ b/docs/pilots-corner/index.md
@@ -3,7 +3,7 @@ title: Pilot's Corner - Overview
 description: The Pilot’s Corner contains guides for both novice and advanced users of the Airbus A320.
 ---
 
-<link rel="stylesheet" href="../../stylesheets/toc-tables.css">
+<link rel="stylesheet" href="../stylesheets/toc-tables.css">
 
 # Pilot's Corner Overview
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.6.14
+mkdocs-material==9.6.23
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
# Summary
This is in preperation for the move to Zensical as part of Stage 1. This is also before moving to 9.7.0

As mentioned on Migration Plan on Discord:
*Reference on Stage 1 – Update Existing Docs
Upgrade to Material for MkDocs 9.7.0, the final feature-complete release. Minimal feature changes expected.*

**Notable Upstream Updates**

- Large font size setting throws of breakpoints in JavaScript
- Improved semantic markup of "edit this page" button
- Improved info plugin virtual environment resolution
- Info plugin doesn't correctly detect virtualenv in some cases
- Videos do not autoplay when inside a content tab
- Stroke width not effective in Mermaid.js diagrams
- Fixed last compat issues with minijinja, now 100% compatible
- Added support for Python 3.14
- FontAwesome icons color not set in social cards (regression)
- Deprecation warning as of Python 3.14 in Emoji extension
- `&` character not escaped in search highlighting
- Temporary pin of click dependency

### Location
requirements.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
