### PR TITLE
fix: outdated text in installation guide

### DIFF
--- a/docs/aircraft/install/settings.md
+++ b/docs/aircraft/install/settings.md
@@ -103,7 +103,7 @@ Please see the screenshot below for an example:
 
 For the rudder, which by default also controls the nosewheel in MSFS, we recommend a bit of sensitivity, although linear should also work fine.
 
-On the Development version, if you have an extra axis on your controllers (e.g., twisting joystick while rudder is on pedals) you can separate the nosewheel steering via tiller from the rudder inputs. See [Nosewheel Tiller Separation](../a32nx/feature-guides/nw-tiller.md).
+If you have an extra axis on your controllers (e.g., twisting joystick while rudder is on pedals) you can separate the nosewheel steering via tiller from the rudder inputs. See [Nosewheel Tiller Separation](../a32nx/feature-guides/nw-tiller.md).
 
 ??? tip "Racing Pedals Compatibility"
     The following configuration can be used with the A32NX if you use racing pedals. *Please note* that this may not work for all variations of racing pedals, but can serve as a starting point for your settings.


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
Quick fix for outdated text notified via Discord -> docs.

### Location
- docs/aircraft/install/settings.md

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
