### PR TITLE
build: bump mkdocs-material -> 9.7.4

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.7.1
+mkdocs-material==9.7.4
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material==9.7.1
+mkdocs-material==9.7.4
 mkdocs-awesome-pages-plugin
 mkdocs-git-revision-date-localized-plugin
 mkdocs-redirects


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
Upstream changes with the following important ones:
- CVE mitigation with urllib
- mkdocs 2.0 incompatibility warning (build is upstream pinned to mkdocs<2.0 or 1.6.1)
- Social Cards plugin switched to sandboxed environment.

### Location
- requirements.txt
- requirements-dev.txt

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): valastiri
