### PR TITLE
fix: remove outdated tip about clicking on LSK for V-Speed calculation

### DIFF
--- a/docs/pilots-corner/a32nx/a32nx-briefing/mcdu/perf.md
+++ b/docs/pilots-corner/a32nx/a32nx-briefing/mcdu/perf.md
@@ -43,8 +43,6 @@ Prompts on each PERF page:
         In the FlyByWire A32NX, pilots can calculate takeoff performance data via the flyPad. Visit our flyPad Performance Page guide for more information.
 
         [flyPad Performance Page](../../../../aircraft/common/flypados3/performance.md){target=new .md-button}
-
-        !!! warning "Not Available in the Stable Version; you can instead click on the LSK next to V1, VR and V2 to let the aircraft calculate the V-Speeds for you."
         
 
 - TRANS ALT (4L)


### PR DESCRIPTION
<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here -->

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->

Remove outdated tip to use LSK for V-Speed calculation. This is no longer possible in the A32NX.

<img width="819" height="120" alt="image" src="https://github.com/user-attachments/assets/047fba3a-b273-4030-92fe-1973634155f8" />

### Location
<!-- Please provide the original URL of the page modified or directory location here -->

https://docs.flybywiresim.com/pilots-corner/a32nx/a32nx-briefing/mcdu/perf/#take-off

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub): Heclak
