### PR TITLE
Change autopilot off procedure and go-around note typo

### DIFF
--- a/docs/pilots-corner/a380x/a380x-beginner-guide/07_landing.md
+++ b/docs/pilots-corner/a380x/a380x-beginner-guide/07_landing.md
@@ -330,8 +330,8 @@ Verify these items:
 
 `AUTOPILOT ............................................................ OFF`<br/>
 ??? note "Autopilot OFF"
-    Next, we turn the **Autopilot** `OFF` at about 500ft above the ground by pressing the green lit `AP1+2` buttons on 
-    the `FCU`.
+    Next, we turn the **Autopilot** `OFF` at about 500ft above the ground by pressing the red pushbutton on one of the sidesticks.
+    It is required to press the button a second time at least 1.8 seconds after the first press. If that is not done further warnings will be triggered.
 
     We leave the **Autothrust** on, so we don't have to worry about thrust and speed at all (Leaving **Autothrust** on 
     for landing is common for the Airbus).
@@ -370,7 +370,7 @@ Verify these items:
     If you are not stable for landing at 100ft above the ground, you should do a go-around. This is a common procedure 
     and not a failure.
 
-    Thie beginner guide does not cover a go-around - see the advanced guide for this.
+    This beginner guide does not cover a go-around - see the advanced guide for this.
     <p style="color:yellow; font-size:18px;">TODO: link to advanced guide</p>
 
 `FLARE (~40ft agl) ............................................... INITIATE`<br/>

--- a/docs/pilots-corner/a380x/a380x-beginner-guide/07_landing.md
+++ b/docs/pilots-corner/a380x/a380x-beginner-guide/07_landing.md
@@ -330,9 +330,9 @@ Verify these items:
 
 `AUTOPILOT ............................................................ OFF`<br/>
 ??? note "Autopilot OFF"
-    Next, we turn the **Autopilot** `OFF` at about 500ft above the ground by pressing the red pushbutton on one of the sidesticks.
-    It is required to press the button a second time at least 1.8 seconds after the first press. If that is not done further warnings will be triggered.
-    For that to work correctly it is important that the correct binding is used. Bind the button of your choice to `AP OFF`.
+    Next, we turn the **Autopilot** `OFF` at about 500 ft (ca. 152 m) above the ground by pressing the red pushbutton on one of the sidesticks.
+    It is required to press the button a second time at least 1.8 s after the first press. If that is not done, further warnings will be triggered.
+    For that to work correctly, it is important that the correct binding is used. Bind the button of your choice to `AP OFF`.
 
     We leave the **Autothrust** on, so we don't have to worry about thrust and speed at all (Leaving **Autothrust** on 
     for landing is common for the Airbus).

--- a/docs/pilots-corner/a380x/a380x-beginner-guide/07_landing.md
+++ b/docs/pilots-corner/a380x/a380x-beginner-guide/07_landing.md
@@ -332,6 +332,7 @@ Verify these items:
 ??? note "Autopilot OFF"
     Next, we turn the **Autopilot** `OFF` at about 500ft above the ground by pressing the red pushbutton on one of the sidesticks.
     It is required to press the button a second time at least 1.8 seconds after the first press. If that is not done further warnings will be triggered.
+    For that to work correctly it is important that the correct binding is used. Bind the button of your choice to `AP OFF`.
 
     We leave the **Autothrust** on, so we don't have to worry about thrust and speed at all (Leaving **Autothrust** on 
     for landing is common for the Airbus).


### PR DESCRIPTION
Updated instructions for turning off the autopilot and fixed a typo in the GO AROUND note.

<!-- If this PR closes an existing issue please add it using "Fixes #[issue_no]" here --> Fixes #1148

## Summary
<!-- Please provide a quick summary of changes for this PR. -->
Changed the procedure for AP disengagement and fixed a small typo in the go-around note.
<!-- If required for your PR, please provide references to backup any documentation you are submitting. -->

### Location
<!-- Please provide the original URL of the page modified or directory location here -->
https://docs.flybywiresim.com/pilots-corner/a380x/a380x-beginner-guide/07_landing/#4-landing

<!-- You may optionally provide your discord username, so that we may contact you directly about the issue. -->
Discord username (if different from GitHub):
